### PR TITLE
[Fix] Add Google Patent License to allowed licenses

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -168,7 +168,9 @@ jobs:
           fail-on-severity: high
           # Use allow-licenses instead of deprecated deny-licenses
           # Allow permissive licenses commonly used in Go ecosystem
-          allow-licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, CC0-1.0, Unlicense
+          # Note: LicenseRef-scancode-google-patent-license-golang is Google's Additional IP Rights Grant
+          # which provides additional patent protection (not a restriction) for golang.org/x/* packages
+          allow-licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, CC0-1.0, Unlicense, LicenseRef-scancode-google-patent-license-golang
           comment-summary-in-pr: true
 
   # Trivy vulnerability scanner for dependencies


### PR DESCRIPTION
## Summary

This PR fixes the dependency review failures for Dependabot PRs (like #83) by adding Google's Additional IP Rights Grant license to the allowed licenses list.

## Problem

The Dependency Review action in PR #83 fails because it detects `LicenseRef-scancode-google-patent-license-golang` which is not in the allowed licenses list. This license appears in standard Google Go packages like:

- `golang.org/x/crypto`
- `golang.org/x/net`
- `golang.org/x/text`
- `golang.org/x/time`
- `google.golang.org/protobuf`

## What is LicenseRef-scancode-google-patent-license-golang?

This is **Google's Additional IP Rights Grant** for Go packages. It's a permissive patent license that:

✅ **Supplements** the BSD-3-Clause license (doesn't replace it)
✅ **Grants additional patent rights** to users
✅ **Is NOT a restriction** but an additional protection
✅ **Standard** for Google's Go packages (golang.org/x/*)

### The Grant

> "Google hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, transfer and otherwise run, modify and propagate the contents of this implementation of Go..."

This is similar to Apache 2.0's patent grant but specifically for Go implementations.

## Changes

**Updated `.github/workflows/dependency-scan.yml`:**
- Added `LicenseRef-scancode-google-patent-license-golang` to `allow-licenses` list
- Added explanatory comment about what this license is and why it's allowed

**Before:**
```yaml
allow-licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, CC0-1.0, Unlicense
```

**After:**
```yaml
# Note: LicenseRef-scancode-google-patent-license-golang is Google's Additional IP Rights Grant
# which provides additional patent protection (not a restriction) for golang.org/x/* packages
allow-licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, CC0-1.0, Unlicense, LicenseRef-scancode-google-patent-license-golang
```

## Impact

✅ Unblocks Dependabot PRs for Google Go packages (like #83)
✅ No security or licensing concerns - this is a permissive grant
✅ Standard practice for Go projects using Google packages
✅ Aligns with common Go ecosystem practices

## Testing

After merging this PR:
1. PR #83 dependency review should pass
2. Future Dependabot updates to Google packages will not be blocked
3. License compliance workflow continues to work correctly

## References

- Google Additional IP Rights Grant: https://github.com/golang/go/blob/master/PATENTS
- Commonly used in: golang.org/x/* and google.golang.org/* packages
- Similar to Apache 2.0's patent grant

Resolves #95