### PR TITLE
[Fix] Fix TLS config reference and resource rate limiter path extraction

### DIFF
--- a/internal/middleware/resource_ratelimit.go
+++ b/internal/middleware/resource_ratelimit.go
@@ -344,8 +344,15 @@ func (rl *ResourceRateLimiter) Middleware() gin.HandlerFunc {
 
 		ctx := c.Request.Context()
 		tenantID := getResourceTenantID(c)
-		resourceType := extractResourceType(c.FullPath())
-		operation := extractOperation(c.Request.Method, c.FullPath())
+
+		// Use FullPath() for matched routes, fallback to Request.URL.Path for unmatched
+		path := c.FullPath()
+		if path == "" {
+			path = c.Request.URL.Path
+		}
+
+		resourceType := extractResourceType(path)
+		operation := extractOperation(c.Request.Method, path)
 
 		// Check page size for list operations
 		if operation == OperationList {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -329,7 +329,7 @@ func (s *Server) securityHeadersMiddleware() gin.HandlerFunc {
 		ContentSecurityPolicy: s.config.Security.SecurityHeaders.ContentSecurityPolicy,
 		FrameOptions:          s.config.Security.SecurityHeaders.FrameOptions,
 		ReferrerPolicy:        s.config.Security.SecurityHeaders.ReferrerPolicy,
-		TLSEnabled:            s.config.Server.TLSEnabled,
+		TLSEnabled:            s.config.TLS.Enabled,
 	}
 
 	// Apply defaults if not configured


### PR DESCRIPTION
## Summary
Fixes two critical bugs causing CI pipeline failures in unit and integration tests.

## Changes

### 1. Fixed Server TLS Configuration Reference
**File:** `internal/server/server.go:332`

**Problem:**
- Code referenced `s.config.Server.TLSEnabled` which doesn't exist
- `ServerConfig` struct has no `TLSEnabled` field
- This caused build failure: `s.config.Server.TLSEnabled undefined`

**Solution:**
- Changed to `s.config.TLS.Enabled` which is the correct field in `TLSConfig` struct
- TLS configuration is in a separate `TLSConfig` struct, not in `ServerConfig`

### 2. Fixed Resource Rate Limiter Path Extraction
**File:** `internal/middleware/resource_ratelimit.go:347-355`

**Problem:**
- Middleware used `c.FullPath()` which returns empty string for unmatched routes and in tests
- When `FullPath()` is empty, `extractResourceType()` returns `ResourceTypeUnknown`
- Rate limiting logic couldn't determine resource type and failed to enforce limits
- Tests were failing because resource type extraction wasn't working

**Solution:**
- Added fallback logic: use `c.FullPath()` if available, otherwise use `c.Request.URL.Path`
- This ensures resource type can always be extracted, both in production and tests
- Pattern matching now works correctly in all scenarios

## Test Results

### Before Fix
```
FAIL: TestResourceRateLimiter_SlidingWindow
  Expected: 429 (rate limited)
  Actual: 200 (not limited)
  
FAIL: TestResourceRateLimiter_RateLimitHeaders
  Expected: "resources"
  Actual: "unknown"

FAIL: internal/server [build failed]
  Error: s.config.Server.TLSEnabled undefined
```

### After Fix
```
✅ All tests pass
✅ TestResourceRateLimiter_SlidingWindow: PASS
✅ TestResourceRateLimiter_RateLimitHeaders: PASS
✅ internal/server: PASS (builds successfully)
✅ internal/middleware: PASS
```

## Verification
- [x] All unit tests pass: `go test ./... -short`
- [x] No new linting errors introduced
- [x] Resource rate limiting works correctly in tests
- [x] Server builds without errors

## Issues Resolved
Resolves #199 (Resource rate limiter tests failing)
Resolves #200 (ArgoCD adapter build failure - was actually server build issue)

## Impact
- **High**: These bugs were blocking CI pipeline
- **Scope**: Testing and configuration infrastructure
- **Risk**: Low - fixes are targeted and all tests pass