### PR TITLE
[Fix] Add -short flag to integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
         env:
           REDIS_ADDR: localhost:6379
           KUBECONFIG: ${{ github.workspace }}/.kube/config
-        run: go test -v -tags=integration ./...
+        run: go test -v -short -tags=integration ./...
 
   # Build verification
   build:


### PR DESCRIPTION
## Summary
- Added `-short` flag to integration test command in CI workflow
- Aligns with unit test execution which already uses `-short`
- Prevents adapter tests from running when real infrastructure is unavailable

## Problem Fixed
Integration tests were failing in CI because GCP and VMware adapter tests were attempting to connect to real infrastructure, which isn't available in the CI environment.

## Solution
All adapter integration tests already have `testing.Short()` guards. This PR adds the `-short` flag to the CI command so these tests are properly skipped.

## Testing
- Verified all adapter tests have `testing.Short()` guards
- CI will now skip infrastructure-dependent tests
- Only tests compatible with CI environment will run

Resolves #284