### PR TITLE
[Fix] Add fetch-depth 0 to security scan for gitleaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full history for gitleaks to properly scan commit ranges
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary
- Added `fetch-depth: 0` to security scan checkout step
- Fixes gitleaks git revision errors in CI

## Problem Fixed
Gitleaks was failing with:
```
fatal: ambiguous argument '...' unknown revision or path not in the working tree
```

This was happening because GitHub Actions by default does a shallow checkout (fetch-depth: 1), which doesn't include the full git history needed for gitleaks to scan commit ranges.

## Solution
Added `fetch-depth: 0` to the checkout step in the security job, which fetches the full git history. This allows gitleaks to properly find and scan commit ranges.

## Testing
- Verified this is a standard solution for gitleaks-action
- Will monitor CI run to confirm gitleaks now passes
- No impact on other security tools (gosec, govulncheck)

Resolves #286