### PR TITLE
Add Node.js patterns to root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,12 @@ Thumbs.db
 /netweave
 !/helm/netweave/
 netweave-gateway
+
+# Node.js / Frontend (admin portal)
+node_modules/
+.next/
+out/
+.turbo/
+*.tsbuildinfo
+next-env.d.ts
+.vercel/


### PR DESCRIPTION
## Summary
- Add `node_modules/`, `.next/`, `out/`, `.turbo/`, `*.tsbuildinfo`, `next-env.d.ts`, and `.vercel/` to the root `.gitignore`
- Provides defense-in-depth alongside the admin portal's own `.gitignore`
- Cleaned up local build artifacts (504MB `node_modules/`, `.next/` build output)

## Test plan
- [ ] Verify `git status` no longer shows Node.js build artifacts as untracked
- [ ] Verify admin portal source files are still tracked on their feature branch

Resolves #321