### PR TITLE
[Fix] O2-IMS Deployment Managers endpoint returns 500

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ARG BUILD_TIME=unknown
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    CGO_ENABLED=0 go build \
     -v \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildTime=${BUILD_TIME}" \
     -o netweave \
@@ -68,6 +68,9 @@ COPY --from=builder --chown=netweave:netweave /build/netweave /app/netweave
 
 # Copy example config (can be overridden via ConfigMap)
 COPY --from=builder --chown=netweave:netweave /build/config/config.yaml.example /etc/netweave/config/config.yaml.example
+
+# Copy OpenAPI specification
+COPY --from=builder --chown=netweave:netweave /build/api/openapi/o2ims.yaml /app/api/openapi/o2ims.yaml
 
 # Switch to non-root user
 USER netweave:netweave

--- a/internal/adapters/kubernetes/adapter_test.go
+++ b/internal/adapters/kubernetes/adapter_test.go
@@ -290,6 +290,20 @@ func TestKubernetesAdapter_GetDeploymentManager(t *testing.T) {
 		assert.Contains(t, dm.Capabilities, "resource-types")
 	})
 
+	t.Run("default alias returns configured DM", func(t *testing.T) {
+		dm, err := adp.GetDeploymentManager(ctx, "default")
+		require.NoError(t, err)
+		require.NotNil(t, dm)
+		assert.Equal(t, "test-dm", dm.DeploymentManagerID)
+	})
+
+	t.Run("empty string alias returns configured DM", func(t *testing.T) {
+		dm, err := adp.GetDeploymentManager(ctx, "")
+		require.NoError(t, err)
+		require.NotNil(t, dm)
+		assert.Equal(t, "test-dm", dm.DeploymentManagerID)
+	})
+
 	t.Run("invalid deployment manager ID", func(t *testing.T) {
 		dm, err := adp.GetDeploymentManager(ctx, "invalid-dm")
 		require.Error(t, err)
@@ -876,12 +890,6 @@ func TestKubernetesAdapter_GetOperations_EmptyID(t *testing.T) {
 		name     string
 		testFunc func() (interface{}, error)
 	}{
-		{
-			name: "GetDeploymentManager with empty ID",
-			testFunc: func() (interface{}, error) {
-				return adp.GetDeploymentManager(ctx, "")
-			},
-		},
 		{
 			name: "GetResourcePool with empty ID",
 			testFunc: func() (interface{}, error) {

--- a/internal/adapters/kubernetes/deploymentmanagers.go
+++ b/internal/adapters/kubernetes/deploymentmanagers.go
@@ -41,8 +41,10 @@ func (a *Adapter) GetDeploymentManager(_ context.Context, id string) (*adapter.D
 	a.logger.Debug("GetDeploymentManager called",
 		zap.String("id", id))
 
-	// Validate ID matches configured deployment manager
-	if id != a.deploymentManagerID {
+	// Validate ID matches configured deployment manager.
+	// Accept "" and "default" as aliases for the configured DM ID,
+	// since callers listing DMs don't know the configured ID.
+	if id != a.deploymentManagerID && id != "default" && id != "" {
 		return nil, fmt.Errorf("deployment manager %s not found", id)
 	}
 


### PR DESCRIPTION
## Summary
- Fix `GetDeploymentManager` in the Kubernetes adapter to accept `""` and `"default"` as aliases for the configured deployment manager ID
- This matches the pattern already used by the mock adapter
- Fix Dockerfile to include OpenAPI spec and use native GOARCH (arm64 support)

## Root Cause
`server/routes.go` passes `"default"` to `adapter.GetDeploymentManager()`, but the Kubernetes adapter only accepted its exact configured ID (`netweave-k8s-dm`), causing a 500 error.

## Test plan
- [x] Added test cases for `"default"` and `""` aliases in `TestKubernetesAdapter_GetDeploymentManager`
- [x] Updated `TestKubernetesAdapter_GetOperations_EmptyID` to reflect new behavior
- [x] Verified on local K8s cluster: `curl .../deploymentManagers` returns 200 with correct data
- [x] All existing tests pass (`go test -race ./internal/adapters/kubernetes/...`)

Resolves #325