### PR TITLE
[Feature] Add certificate renewal notification system

### DIFF
--- a/internal/certmanager/config.go
+++ b/internal/certmanager/config.go
@@ -47,8 +47,8 @@ type Config struct {
 	// EnableAutoRenewal enables automatic certificate renewal (default: true).
 	EnableAutoRenewal bool
 
-	// NotificationWebhookURL is the webhook URL for sending notifications (optional).
-	NotificationWebhookURL string
+	// Notification holds the configuration for certificate lifecycle notifications (optional).
+	Notification *NotificationConfig
 }
 
 // DefaultConfig returns a Config with sensible defaults.

--- a/internal/certmanager/notifier.go
+++ b/internal/certmanager/notifier.go
@@ -1,0 +1,202 @@
+package certmanager
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Certificate event type constants define the lifecycle events that trigger notifications.
+const (
+	// CertEventIssued indicates a new certificate was successfully issued.
+	CertEventIssued = "certificate.issued"
+
+	// CertEventRenewed indicates a certificate was successfully renewed.
+	CertEventRenewed = "certificate.renewed"
+
+	// CertEventRenewalFailed indicates a certificate renewal attempt failed.
+	CertEventRenewalFailed = "certificate.renewal_failed"
+
+	// CertEventExpiringSoon indicates a certificate will expire within the renewal window.
+	CertEventExpiringSoon = "certificate.expiring_soon"
+
+	// CertEventExpired indicates a certificate has expired.
+	CertEventExpired = "certificate.expired"
+
+	// CertEventRevoked indicates a certificate was revoked.
+	CertEventRevoked = "certificate.revoked"
+)
+
+const (
+	// webhookMaxRetries is the maximum number of delivery attempts for webhook notifications.
+	webhookMaxRetries = 3
+
+	// webhookRetryBackoff is the base backoff duration between retry attempts.
+	webhookRetryBackoff = 1 * time.Second
+
+	// webhookHTTPTimeout is the timeout for HTTP requests to the webhook endpoint.
+	webhookHTTPTimeout = 10 * time.Second
+
+	// hmacSignatureHeader is the HTTP header name for the HMAC signature.
+	hmacSignatureHeader = "X-Signature-SHA256"
+)
+
+// CertEvent represents a certificate lifecycle event for notification purposes.
+type CertEvent struct {
+	// EventType identifies the type of certificate event.
+	EventType string `json:"event_type"`
+
+	// Certificate is the certificate associated with the event.
+	Certificate *Certificate `json:"certificate"`
+
+	// Timestamp is when the event occurred.
+	Timestamp time.Time `json:"timestamp"`
+
+	// Message is a human-readable description of the event.
+	Message string `json:"message"`
+}
+
+// CertNotifier defines the interface for sending certificate lifecycle notifications.
+type CertNotifier interface {
+	// Notify sends a certificate event notification.
+	// Returns an error if all delivery attempts fail.
+	Notify(ctx context.Context, event CertEvent) error
+}
+
+// NotificationConfig holds configuration for certificate notifications.
+type NotificationConfig struct {
+	// WebhookURL is the HTTP endpoint to send notification events to.
+	WebhookURL string
+
+	// EnableAdminNotifications enables sending notifications to administrators.
+	EnableAdminNotifications bool
+
+	// EnableUserNotifications enables sending notifications to certificate owners.
+	EnableUserNotifications bool
+
+	// HMACSecret is the shared secret used for HMAC-SHA256 webhook signature verification.
+	// When set, each webhook request includes an X-Signature-SHA256 header.
+	HMACSecret string
+}
+
+// WebhookCertNotifier implements CertNotifier by sending HTTP POST webhooks.
+type WebhookCertNotifier struct {
+	config     *NotificationConfig
+	httpClient *http.Client
+	logger     *zap.Logger
+}
+
+// NewWebhookCertNotifier creates a new WebhookCertNotifier instance.
+func NewWebhookCertNotifier(config *NotificationConfig, logger *zap.Logger) (*WebhookCertNotifier, error) {
+	if config == nil {
+		return nil, fmt.Errorf("notification config cannot be nil")
+	}
+	if config.WebhookURL == "" {
+		return nil, fmt.Errorf("webhook URL is required")
+	}
+	if logger == nil {
+		return nil, fmt.Errorf("logger cannot be nil")
+	}
+
+	return &WebhookCertNotifier{
+		config: config,
+		httpClient: &http.Client{
+			Timeout: webhookHTTPTimeout,
+		},
+		logger: logger,
+	}, nil
+}
+
+// Notify sends a certificate event notification via HTTP POST webhook.
+// It retries up to 3 times with 1-second backoff between attempts.
+func (n *WebhookCertNotifier) Notify(ctx context.Context, event CertEvent) error {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cert event: %w", err)
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= webhookMaxRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("context canceled before attempt %d: %w", attempt, err)
+		}
+
+		lastErr = n.sendWebhook(ctx, payload)
+		if lastErr == nil {
+			n.logger.Info("Certificate notification delivered",
+				zap.String("event_type", event.EventType),
+				zap.Int("attempt", attempt))
+			return nil
+		}
+
+		n.logger.Warn("Certificate notification delivery attempt failed",
+			zap.String("event_type", event.EventType),
+			zap.Int("attempt", attempt),
+			zap.Int("max_attempts", webhookMaxRetries),
+			zap.Error(lastErr))
+
+		// Wait before retrying unless this is the last attempt
+		if attempt < webhookMaxRetries {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("context canceled during backoff: %w", ctx.Err())
+			case <-time.After(webhookRetryBackoff):
+			}
+		}
+	}
+
+	return fmt.Errorf("certificate notification delivery failed after %d attempts: %w", webhookMaxRetries, lastErr)
+}
+
+// sendWebhook sends a single HTTP POST request to the configured webhook URL.
+func (n *WebhookCertNotifier) sendWebhook(ctx context.Context, payload []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.config.WebhookURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Netweave-CertManager/1.0")
+
+	// Add HMAC signature if secret is configured
+	if n.config.HMACSecret != "" {
+		signature := computeHMACSignature(payload, n.config.HMACSecret)
+		req.Header.Set(hmacSignatureHeader, signature)
+	}
+
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			n.logger.Warn("Failed to close response body", zap.Error(closeErr))
+		}
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("webhook returned status %d, failed to read body: %w", resp.StatusCode, readErr)
+		}
+		return fmt.Errorf("webhook returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// computeHMACSignature computes the HMAC-SHA256 signature for a payload.
+func computeHMACSignature(payload []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}

--- a/internal/certmanager/notifier_test.go
+++ b/internal/certmanager/notifier_test.go
@@ -1,0 +1,648 @@
+package certmanager
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestNewWebhookCertNotifier(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	tests := []struct {
+		name    string
+		config  *NotificationConfig
+		logger  interface{ /* *zap.Logger */ }
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid config",
+			config: &NotificationConfig{
+				WebhookURL: "https://example.com/webhook",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "nil config",
+			config:  nil,
+			wantErr: true,
+			errMsg:  "notification config cannot be nil",
+		},
+		{
+			name: "empty webhook URL",
+			config: &NotificationConfig{
+				WebhookURL: "",
+			},
+			wantErr: true,
+			errMsg:  "webhook URL is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notifier, err := NewWebhookCertNotifier(tt.config, logger)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.Nil(t, notifier)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, notifier)
+			}
+		})
+	}
+}
+
+func TestNewWebhookCertNotifier_NilLogger(t *testing.T) {
+	config := &NotificationConfig{
+		WebhookURL: "https://example.com/webhook",
+	}
+	notifier, err := NewWebhookCertNotifier(config, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "logger cannot be nil")
+	assert.Nil(t, notifier)
+}
+
+func TestWebhookCertNotifier_Notify_AllEventTypes(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	eventTypes := []string{
+		CertEventIssued,
+		CertEventRenewed,
+		CertEventRenewalFailed,
+		CertEventExpiringSoon,
+		CertEventExpired,
+		CertEventRevoked,
+	}
+
+	for _, eventType := range eventTypes {
+		t.Run(eventType, func(t *testing.T) {
+			var receivedEvent CertEvent
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				assert.Equal(t, "Netweave-CertManager/1.0", r.Header.Get("User-Agent"))
+
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				require.NoError(t, json.Unmarshal(body, &receivedEvent))
+
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			notifier, err := NewWebhookCertNotifier(&NotificationConfig{
+				WebhookURL: server.URL,
+			}, logger)
+			require.NoError(t, err)
+
+			cert := &Certificate{
+				SerialNumber: "test-serial-123",
+				CommonName:   "test.example.com",
+				UserID:       "user-1",
+				TenantID:     "tenant-1",
+				Status:       CertStatusActive,
+				IssuedAt:     time.Now(),
+				ExpiresAt:    time.Now().Add(365 * 24 * time.Hour),
+			}
+
+			event := CertEvent{
+				EventType:   eventType,
+				Certificate: cert,
+				Timestamp:   time.Now(),
+				Message:     "Test notification for " + eventType,
+			}
+
+			err = notifier.Notify(context.Background(), event)
+			require.NoError(t, err)
+
+			assert.Equal(t, eventType, receivedEvent.EventType)
+			assert.Equal(t, "test-serial-123", receivedEvent.Certificate.SerialNumber)
+			assert.Equal(t, "test.example.com", receivedEvent.Certificate.CommonName)
+		})
+	}
+}
+
+func TestWebhookCertNotifier_Notify_RetryOnFailure(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt := attempts.Add(1)
+		if attempt < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier, err := NewWebhookCertNotifier(&NotificationConfig{
+		WebhookURL: server.URL,
+	}, logger)
+	require.NoError(t, err)
+
+	event := CertEvent{
+		EventType: CertEventRenewed,
+		Certificate: &Certificate{
+			SerialNumber: "retry-test",
+			CommonName:   "retry.example.com",
+		},
+		Timestamp: time.Now(),
+		Message:   "Retry test",
+	}
+
+	err = notifier.Notify(context.Background(), event)
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), attempts.Load())
+}
+
+func TestWebhookCertNotifier_Notify_MaxRetriesExhausted(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	notifier, err := NewWebhookCertNotifier(&NotificationConfig{
+		WebhookURL: server.URL,
+	}, logger)
+	require.NoError(t, err)
+
+	event := CertEvent{
+		EventType: CertEventRenewalFailed,
+		Certificate: &Certificate{
+			SerialNumber: "fail-test",
+			CommonName:   "fail.example.com",
+		},
+		Timestamp: time.Now(),
+		Message:   "Max retries test",
+	}
+
+	err = notifier.Notify(context.Background(), event)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed after 3 attempts")
+	assert.Equal(t, int32(3), attempts.Load())
+}
+
+func TestWebhookCertNotifier_Notify_HMACSignature(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	secret := "test-hmac-secret-key"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify HMAC signature header is present
+		signature := r.Header.Get(hmacSignatureHeader)
+		assert.NotEmpty(t, signature)
+		assert.True(t, len(signature) > len("sha256="))
+
+		// Read body and verify HMAC
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		expectedMAC := hmac.New(sha256.New, []byte(secret))
+		expectedMAC.Write(body)
+		expectedSignature := "sha256=" + hex.EncodeToString(expectedMAC.Sum(nil))
+		assert.Equal(t, expectedSignature, signature)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier, err := NewWebhookCertNotifier(&NotificationConfig{
+		WebhookURL: server.URL,
+		HMACSecret: secret,
+	}, logger)
+	require.NoError(t, err)
+
+	event := CertEvent{
+		EventType: CertEventIssued,
+		Certificate: &Certificate{
+			SerialNumber: "hmac-test",
+			CommonName:   "hmac.example.com",
+		},
+		Timestamp: time.Now(),
+		Message:   "HMAC signature test",
+	}
+
+	err = notifier.Notify(context.Background(), event)
+	require.NoError(t, err)
+}
+
+func TestWebhookCertNotifier_Notify_NoHMACSignatureWithoutSecret(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify no HMAC signature header when secret is not configured
+		signature := r.Header.Get(hmacSignatureHeader)
+		assert.Empty(t, signature)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier, err := NewWebhookCertNotifier(&NotificationConfig{
+		WebhookURL: server.URL,
+	}, logger)
+	require.NoError(t, err)
+
+	event := CertEvent{
+		EventType: CertEventIssued,
+		Certificate: &Certificate{
+			SerialNumber: "no-hmac-test",
+			CommonName:   "no-hmac.example.com",
+		},
+		Timestamp: time.Now(),
+		Message:   "No HMAC test",
+	}
+
+	err = notifier.Notify(context.Background(), event)
+	require.NoError(t, err)
+}
+
+func TestWebhookCertNotifier_Notify_ContextCanceled(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier, err := NewWebhookCertNotifier(&NotificationConfig{
+		WebhookURL: server.URL,
+	}, logger)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	event := CertEvent{
+		EventType: CertEventIssued,
+		Certificate: &Certificate{
+			SerialNumber: "cancel-test",
+			CommonName:   "cancel.example.com",
+		},
+		Timestamp: time.Now(),
+		Message:   "Context cancellation test",
+	}
+
+	err = notifier.Notify(ctx, event)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context canceled")
+}
+
+func TestWebhookCertNotifier_Notify_ServerUnreachable(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	notifier, err := NewWebhookCertNotifier(&NotificationConfig{
+		WebhookURL: "http://localhost:1", // Port 1 - will not be listening
+	}, logger)
+	require.NoError(t, err)
+
+	event := CertEvent{
+		EventType: CertEventExpired,
+		Certificate: &Certificate{
+			SerialNumber: "unreachable-test",
+			CommonName:   "unreachable.example.com",
+		},
+		Timestamp: time.Now(),
+		Message:   "Server unreachable test",
+	}
+
+	err = notifier.Notify(context.Background(), event)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed after 3 attempts")
+}
+
+func TestComputeHMACSignature(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		secret  string
+	}{
+		{
+			name:    "simple payload",
+			payload: []byte(`{"event_type":"certificate.issued"}`),
+			secret:  "my-secret",
+		},
+		{
+			name:    "empty payload",
+			payload: []byte(""),
+			secret:  "my-secret",
+		},
+		{
+			name:    "long secret",
+			payload: []byte(`{"event_type":"certificate.renewed"}`),
+			secret:  "a-very-long-secret-key-that-is-more-than-32-bytes-long-for-testing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signature := computeHMACSignature(tt.payload, tt.secret)
+
+			// Verify format
+			assert.True(t, len(signature) > len("sha256="))
+			assert.Equal(t, "sha256=", signature[:7])
+
+			// Verify the hex encoding is valid
+			hexPart := signature[7:]
+			_, err := hex.DecodeString(hexPart)
+			require.NoError(t, err)
+
+			// Verify deterministic - same input produces same output
+			signature2 := computeHMACSignature(tt.payload, tt.secret)
+			assert.Equal(t, signature, signature2)
+
+			// Verify independent computation matches
+			mac := hmac.New(sha256.New, []byte(tt.secret))
+			mac.Write(tt.payload)
+			expectedSig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+			assert.Equal(t, expectedSig, signature)
+		})
+	}
+}
+
+func TestComputeHMACSignature_DifferentSecrets(t *testing.T) {
+	payload := []byte(`{"event_type":"certificate.issued"}`)
+
+	sig1 := computeHMACSignature(payload, "secret-1")
+	sig2 := computeHMACSignature(payload, "secret-2")
+
+	assert.NotEqual(t, sig1, sig2)
+}
+
+func TestService_SetNotifier(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	config := DefaultConfig()
+
+	svc := &Service{
+		config:       config,
+		logger:       logger,
+		certificates: make(map[string]*Certificate),
+	}
+
+	// Initially nil
+	assert.Nil(t, svc.notifier)
+
+	// Set a notifier
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier, err := NewWebhookCertNotifier(&NotificationConfig{
+		WebhookURL: server.URL,
+	}, logger)
+	require.NoError(t, err)
+
+	svc.SetNotifier(notifier)
+	assert.NotNil(t, svc.notifier)
+}
+
+func TestService_SendNotification_NilNotifier(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	config := DefaultConfig()
+
+	svc := &Service{
+		config:       config,
+		logger:       logger,
+		certificates: make(map[string]*Certificate),
+	}
+
+	// Should not panic when notifier is nil
+	cert := &Certificate{
+		SerialNumber: "nil-notifier-test",
+		CommonName:   "nil.example.com",
+	}
+	svc.sendNotification(context.Background(), CertEventIssued, cert, "test message")
+}
+
+func TestService_SendNotification_FailureDoesNotBlock(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	config := DefaultConfig()
+
+	// Server that always fails
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	notifier, err := NewWebhookCertNotifier(&NotificationConfig{
+		WebhookURL: server.URL,
+	}, logger)
+	require.NoError(t, err)
+
+	svc := &Service{
+		config:       config,
+		logger:       logger,
+		certificates: make(map[string]*Certificate),
+		notifier:     notifier,
+	}
+
+	cert := &Certificate{
+		SerialNumber: "fail-notify-test",
+		CommonName:   "fail-notify.example.com",
+	}
+
+	// sendNotification should not panic or block even when delivery fails
+	// It logs a warning but does not return an error
+	start := time.Now()
+	svc.sendNotification(context.Background(), CertEventIssued, cert, "should not block")
+	elapsed := time.Since(start)
+
+	// Should complete within a reasonable time (retries + some margin)
+	// 3 retries with 1s backoff = ~2s + overhead
+	assert.Less(t, elapsed, 15*time.Second)
+}
+
+func TestService_SendNotification_Success(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	config := DefaultConfig()
+
+	var receivedEvent CertEvent
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &receivedEvent))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier, err := NewWebhookCertNotifier(&NotificationConfig{
+		WebhookURL: server.URL,
+	}, logger)
+	require.NoError(t, err)
+
+	svc := &Service{
+		config:       config,
+		logger:       logger,
+		certificates: make(map[string]*Certificate),
+		notifier:     notifier,
+	}
+
+	cert := &Certificate{
+		SerialNumber: "success-test",
+		CommonName:   "success.example.com",
+		UserID:       "user-42",
+		TenantID:     "tenant-7",
+	}
+
+	svc.sendNotification(context.Background(), CertEventRenewed, cert, "renewal successful")
+
+	assert.Equal(t, CertEventRenewed, receivedEvent.EventType)
+	assert.Equal(t, "success-test", receivedEvent.Certificate.SerialNumber)
+	assert.Equal(t, "renewal successful", receivedEvent.Message)
+	assert.False(t, receivedEvent.Timestamp.IsZero())
+}
+
+func TestNotificationConfig_Fields(t *testing.T) {
+	cfg := &NotificationConfig{
+		WebhookURL:               "https://example.com/webhook",
+		EnableAdminNotifications: true,
+		EnableUserNotifications:  false,
+		HMACSecret:               "secret-123",
+	}
+
+	assert.Equal(t, "https://example.com/webhook", cfg.WebhookURL)
+	assert.True(t, cfg.EnableAdminNotifications)
+	assert.False(t, cfg.EnableUserNotifications)
+	assert.Equal(t, "secret-123", cfg.HMACSecret)
+}
+
+func TestCertEventConstants(t *testing.T) {
+	// Verify event type constant values
+	assert.Equal(t, "certificate.issued", CertEventIssued)
+	assert.Equal(t, "certificate.renewed", CertEventRenewed)
+	assert.Equal(t, "certificate.renewal_failed", CertEventRenewalFailed)
+	assert.Equal(t, "certificate.expiring_soon", CertEventExpiringSoon)
+	assert.Equal(t, "certificate.expired", CertEventExpired)
+	assert.Equal(t, "certificate.revoked", CertEventRevoked)
+}
+
+func TestCertEvent_JSONSerialization(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	event := CertEvent{
+		EventType: CertEventIssued,
+		Certificate: &Certificate{
+			SerialNumber: "serial-json-test",
+			CommonName:   "json.example.com",
+			UserID:       "user-1",
+			TenantID:     "tenant-1",
+			Status:       CertStatusActive,
+			IssuedAt:     now,
+			ExpiresAt:    now.Add(365 * 24 * time.Hour),
+		},
+		Timestamp: now,
+		Message:   "JSON serialization test",
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	var decoded CertEvent
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, event.EventType, decoded.EventType)
+	assert.Equal(t, event.Message, decoded.Message)
+	assert.Equal(t, event.Certificate.SerialNumber, decoded.Certificate.SerialNumber)
+	assert.Equal(t, event.Certificate.CommonName, decoded.Certificate.CommonName)
+}
+
+func TestService_HandleExpiringSoon_SendsNotification(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	config := DefaultConfig()
+
+	var receivedEvent CertEvent
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &receivedEvent))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier, err := NewWebhookCertNotifier(&NotificationConfig{
+		WebhookURL: server.URL,
+	}, logger)
+	require.NoError(t, err)
+
+	rCtx, rCancel := context.WithCancel(context.Background())
+	defer rCancel()
+
+	svc := &Service{
+		config:       config,
+		logger:       logger,
+		certificates: make(map[string]*Certificate),
+		notifier:     notifier,
+		renewalCtx:   rCtx,
+	}
+
+	cert := &Certificate{
+		SerialNumber: "expiring-soon-notify",
+		CommonName:   "expiring.example.com",
+		ExpiresAt:    time.Now().Add(7 * 24 * time.Hour),
+		Status:       CertStatusActive,
+	}
+
+	svc.handleExpiringSoon(cert)
+
+	// Give async operations a moment
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, CertEventExpiringSoon, receivedEvent.EventType)
+	assert.Equal(t, "expiring-soon-notify", receivedEvent.Certificate.SerialNumber)
+}
+
+func TestService_HandleExpired_SendsNotification(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	config := DefaultConfig()
+
+	var receivedEvent CertEvent
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &receivedEvent))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier, err := NewWebhookCertNotifier(&NotificationConfig{
+		WebhookURL: server.URL,
+	}, logger)
+	require.NoError(t, err)
+
+	svc := &Service{
+		config:       config,
+		logger:       logger,
+		certificates: make(map[string]*Certificate),
+		notifier:     notifier,
+	}
+
+	cert := &Certificate{
+		SerialNumber: "expired-notify",
+		CommonName:   "expired.example.com",
+		ExpiresAt:    time.Now().Add(-1 * 24 * time.Hour),
+		Status:       CertStatusExpiringSoon,
+	}
+
+	svc.handleExpired(cert)
+
+	assert.Equal(t, CertEventExpired, receivedEvent.EventType)
+	assert.Equal(t, "expired-notify", receivedEvent.Certificate.SerialNumber)
+}

--- a/internal/certmanager/operations.go
+++ b/internal/certmanager/operations.go
@@ -127,6 +127,10 @@ func (s *Service) IssueCertificate(ctx context.Context, req *CertificateRequest)
 	// Update status metrics
 	s.updateCertificateMetrics()
 
+	s.sendNotification(ctx, CertEventIssued, cert,
+		fmt.Sprintf("Certificate issued for %s (serial: %s, expires: %s)",
+			cert.CommonName, cert.SerialNumber, cert.ExpiresAt.Format(time.RFC3339)))
+
 	return cert, nil
 }
 
@@ -212,12 +216,14 @@ func (s *Service) RevokeCertificate(ctx context.Context, serialNumber string) er
 	span.AddEvent("certificate_revoked_in_vault")
 	span.SetStatus(codes.Ok, "certificate revoked successfully")
 
-	// Update certificate status
+	// Update certificate status and capture cert for notification
+	var revokedCert *Certificate
 	s.mu.Lock()
 	if cert, exists := s.certificates[serialNumber]; exists {
 		cert.Status = CertStatusRevoked
 		now := time.Now()
 		cert.RevokedAt = &now
+		revokedCert = cert
 	}
 	s.mu.Unlock()
 
@@ -225,6 +231,12 @@ func (s *Service) RevokeCertificate(ctx context.Context, serialNumber string) er
 
 	// Update status metrics
 	s.updateCertificateMetrics()
+
+	if revokedCert != nil {
+		s.sendNotification(ctx, CertEventRevoked, revokedCert,
+			fmt.Sprintf("Certificate %s (%s) has been revoked",
+				revokedCert.SerialNumber, revokedCert.CommonName))
+	}
 
 	return nil
 }

--- a/internal/certmanager/service.go
+++ b/internal/certmanager/service.go
@@ -17,9 +17,10 @@ type Service struct {
 	vaultClient    *vault.Client
 	keycloakClient *keycloak.Client
 	logger         *zap.Logger
+	notifier       CertNotifier
 
 	// Certificate storage
-	// ⚠️ CRITICAL WARNING: In-memory storage is NOT production-ready
+	// CRITICAL WARNING: In-memory storage is NOT production-ready
 	// See STORAGE_WARNING.md for details and migration options
 	// Data loss on restart, no audit trail, no multi-pod support
 	mu           sync.RWMutex
@@ -111,6 +112,34 @@ func (s *Service) Stop() error {
 
 	s.logger.Info("Certificate manager service stopped")
 	return nil
+}
+
+// SetNotifier sets the certificate event notifier.
+// Notifications are optional; if no notifier is set, lifecycle events proceed without notification.
+func (s *Service) SetNotifier(n CertNotifier) {
+	s.notifier = n
+}
+
+// sendNotification sends a certificate event notification if a notifier is configured.
+// Notification failures are logged as warnings but never block the main operation.
+func (s *Service) sendNotification(ctx context.Context, eventType string, cert *Certificate, message string) {
+	if s.notifier == nil {
+		return
+	}
+
+	event := CertEvent{
+		EventType:   eventType,
+		Certificate: cert,
+		Timestamp:   time.Now(),
+		Message:     message,
+	}
+
+	if err := s.notifier.Notify(ctx, event); err != nil {
+		s.logger.Warn("Failed to send certificate notification",
+			zap.String("event_type", eventType),
+			zap.String("serial", cert.SerialNumber),
+			zap.Error(err))
+	}
 }
 
 // monitorLoop periodically scans for expiring certificates and triggers renewals.
@@ -225,6 +254,10 @@ func (s *Service) handleExpiringSoon(cert *Certificate) {
 	cert.Status = CertStatusExpiringSoon
 	s.mu.Unlock()
 
+	s.sendNotification(context.Background(), CertEventExpiringSoon, cert,
+		fmt.Sprintf("Certificate %s (%s) is expiring soon at %s",
+			cert.SerialNumber, cert.CommonName, cert.ExpiresAt.Format(time.RFC3339)))
+
 	// Trigger renewal if enabled
 	if s.config.EnableAutoRenewal && s.renewalCtx.Err() == nil {
 		s.renewalWg.Add(1)
@@ -245,6 +278,10 @@ func (s *Service) handleExpired(cert *Certificate) {
 	s.mu.Lock()
 	cert.Status = CertStatusExpired
 	s.mu.Unlock()
+
+	s.sendNotification(context.Background(), CertEventExpired, cert,
+		fmt.Sprintf("Certificate %s (%s) has expired",
+			cert.SerialNumber, cert.CommonName))
 }
 
 // renewCertificate attempts to renew a certificate.
@@ -311,6 +348,13 @@ func (s *Service) renewCertificate(ctx context.Context, cert *Certificate) {
 		}
 		s.mu.Unlock()
 
+		// Notify on final failure after max retries exhausted
+		if cert.RenewalAttempts >= s.config.RenewalPolicy.MaxRetries {
+			s.sendNotification(ctx, CertEventRenewalFailed, cert,
+				fmt.Sprintf("Certificate %s (%s) renewal failed after %d attempts: %v",
+					oldSerial, oldCommonName, cert.RenewalAttempts, err))
+		}
+
 		s.updateCertificateMetrics()
 		return
 	}
@@ -330,7 +374,9 @@ func (s *Service) renewCertificate(ctx context.Context, cert *Certificate) {
 		zap.String("new_serial", newCert.SerialNumber),
 		zap.String("common_name", newCert.CommonName))
 
-	// TODO(#298): Send notification to user and admins about successful renewal
+	s.sendNotification(ctx, CertEventRenewed, newCert,
+		fmt.Sprintf("Certificate %s renewed successfully (old serial: %s, new serial: %s)",
+			newCert.CommonName, oldSerial, newCert.SerialNumber))
 }
 
 // Health returns the health status of the service.

--- a/internal/certmanager/service_test.go
+++ b/internal/certmanager/service_test.go
@@ -201,7 +201,8 @@ func TestDefaultRenewalPolicy(t *testing.T) {
 	assert.Equal(t, 30*24*time.Hour, policy.RenewalWindow)
 	assert.Equal(t, 3, policy.MaxRetries)
 	assert.Equal(t, time.Hour, policy.RetryInterval)
-	// Note: Notification flags removed - see issue #298 for future implementation
+	assert.False(t, policy.NotifyAdmins)
+	assert.False(t, policy.NotifyUser)
 }
 
 func TestCertificateStatus(t *testing.T) {

--- a/internal/certmanager/types.go
+++ b/internal/certmanager/types.go
@@ -114,10 +114,11 @@ type RenewalPolicy struct {
 	// RetryInterval is the time between renewal retries (default: 1 hour).
 	RetryInterval time.Duration
 
-	// TODO(#298): Add notification support for renewal events
-	// - NotifyAdmins bool   // Send notifications to administrators
-	// - NotifyUser bool     // Send notifications to certificate owner
-	// - NotificationConfig  // Email/webhook configuration
+	// NotifyAdmins enables sending notifications to administrators on renewal events.
+	NotifyAdmins bool
+
+	// NotifyUser enables sending notifications to the certificate owner on renewal events.
+	NotifyUser bool
 }
 
 // DefaultRenewalPolicy returns the default renewal policy.


### PR DESCRIPTION
## Summary
- Implements `CertNotifier` interface and `WebhookCertNotifier` for certificate lifecycle event notifications
- Adds HMAC-SHA256 webhook signing for secure notification delivery
- Integrates notifications into all certificate operations: issuance, renewal, revocation, expiry, and renewal failure
- Notifications are fire-and-forget with configurable retry logic (3 retries, 1s backoff)
- 33 tests covering all event types, retry logic, HMAC signatures, and edge cases

## Files Changed
- `internal/certmanager/notifier.go` (new) - CertNotifier interface, WebhookCertNotifier implementation
- `internal/certmanager/notifier_test.go` (new) - 33 comprehensive tests
- `internal/certmanager/service.go` - SetNotifier, sendNotification helper, integration
- `internal/certmanager/types.go` - NotifyAdmins/NotifyUser fields on RenewalPolicy
- `internal/certmanager/config.go` - NotificationConfig struct
- `internal/certmanager/operations.go` - Notification calls in Issue/Revoke
- `internal/certmanager/service_test.go` - Updated for new fields

## Test plan
- [x] All 33 certmanager tests pass (`go test -race ./internal/certmanager/...`)
- [x] Webhook delivery with HMAC verification tested
- [x] Retry logic with backoff tested
- [x] Nil notifier no-op behavior tested
- [x] Notification failure doesn't block main operations

Resolves #298