### PR TITLE
[Test] Increase adapter test coverage for DTIAS, StarlingX, and GCP

### DIFF
--- a/internal/adapters/dtias/deploymentmanager_test.go
+++ b/internal/adapters/dtias/deploymentmanager_test.go
@@ -1,0 +1,207 @@
+package dtias_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/piwi3910/netweave/internal/adapters/dtias"
+)
+
+// TestGetDeploymentManager tests the GetDeploymentManager method with a mock server.
+func TestGetDeploymentManager(t *testing.T) {
+	tests := []struct {
+		name              string
+		requestID         string
+		datacenterHandler func(w http.ResponseWriter, r *http.Request)
+		expectErr         bool
+		errContains       string
+		validate          func(*testing.T, *dtias.Adapter, *interface{})
+	}{
+		{
+			name:      "valid ID returns deployment manager metadata",
+			requestID: "dm-test",
+			datacenterHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(dtias.DatacenterInfo{
+					ID:        "dc-test",
+					Name:      "Test Datacenter",
+					City:      "Dallas",
+					Country:   "US",
+					Latitude:  32.7767,
+					Longitude: -96.7970,
+				})
+			},
+			expectErr: false,
+		},
+		{
+			name:      "empty ID is accepted as alias",
+			requestID: "",
+			datacenterHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(dtias.DatacenterInfo{
+					ID:   "dc-test",
+					Name: "Test Datacenter",
+				})
+			},
+			expectErr: false,
+		},
+		{
+			name:      "default ID is accepted as alias",
+			requestID: "default",
+			datacenterHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(dtias.DatacenterInfo{
+					ID:   "dc-test",
+					Name: "Test Datacenter",
+				})
+			},
+			expectErr: false,
+		},
+		{
+			name:      "wrong ID returns error",
+			requestID: "wrong-dm-id",
+			datacenterHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+			expectErr:   true,
+			errContains: "deployment manager not found",
+		},
+		{
+			name:      "datacenter info failure uses defaults gracefully",
+			requestID: "dm-test",
+			datacenterHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error": "internal error"}`))
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				tt.datacenterHandler(w, r)
+			}))
+			defer mockServer.Close()
+
+			adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+			adp.DeploymentManagerID = "dm-test"
+			adp.OCloudID = "ocloud-test"
+			adp.Config = &dtias.Config{
+				Endpoint:   mockServer.URL,
+				Datacenter: "dc-test",
+			}
+
+			dm, err := adp.GetDeploymentManager(context.Background(), tt.requestID)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Nil(t, dm)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, dm)
+
+			// Verify common deployment manager fields
+			assert.Equal(t, "dm-test", dm.DeploymentManagerID)
+			assert.Equal(t, "ocloud-test", dm.OCloudID)
+			assert.Equal(t, mockServer.URL, dm.ServiceURI)
+			assert.Contains(t, dm.Name, "DTIAS")
+			assert.Contains(t, dm.Description, "DTIAS")
+			assert.NotEmpty(t, dm.Capabilities)
+			assert.NotNil(t, dm.Extensions)
+
+			// Verify extensions contain expected keys
+			assert.Equal(t, mockServer.URL, dm.Extensions["dtias.endpoint"])
+			assert.Equal(t, "dc-test", dm.Extensions["dtias.datacenter"])
+			assert.Equal(t, "1.0", dm.Extensions["dtias.apiVersion"])
+		})
+	}
+}
+
+// TestGetDeploymentManager_WithDatacenterLocation tests that datacenter location info is included.
+func TestGetDeploymentManager_WithDatacenterLocation(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(dtias.DatacenterInfo{
+			ID:        "dc-dallas",
+			Name:      "Dallas DC",
+			City:      "Dallas",
+			Country:   "US",
+			Latitude:  32.7767,
+			Longitude: -96.7970,
+		})
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+	adp.DeploymentManagerID = "dm-test"
+	adp.OCloudID = "ocloud-test"
+	adp.Config = &dtias.Config{
+		Endpoint:   mockServer.URL,
+		Datacenter: "dc-dallas",
+	}
+
+	dm, err := adp.GetDeploymentManager(context.Background(), "dm-test")
+	require.NoError(t, err)
+	require.NotNil(t, dm)
+
+	// Verify datacenter location info is present
+	assert.NotEmpty(t, dm.SupportedLocations)
+	assert.Contains(t, dm.SupportedLocations, "dc-dallas")
+	assert.Equal(t, "Dallas", dm.Extensions["dtias.location.city"])
+	assert.Equal(t, "US", dm.Extensions["dtias.location.country"])
+	assert.Equal(t, 32.7767, dm.Extensions["dtias.location.latitude"])
+	assert.Equal(t, -96.7970, dm.Extensions["dtias.location.longitude"])
+}
+
+// TestGetDeploymentManager_DatacenterInfoPartial tests partial datacenter info.
+func TestGetDeploymentManager_DatacenterInfoPartial(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Return datacenter info with only city (no lat/lon)
+		_ = json.NewEncoder(w).Encode(dtias.DatacenterInfo{
+			ID:   "dc-test",
+			Name: "Test DC",
+			City: "Dallas",
+		})
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+	adp.DeploymentManagerID = "dm-test"
+	adp.OCloudID = "ocloud-test"
+	adp.Config = &dtias.Config{
+		Endpoint:   mockServer.URL,
+		Datacenter: "dc-test",
+	}
+
+	dm, err := adp.GetDeploymentManager(context.Background(), "dm-test")
+	require.NoError(t, err)
+	require.NotNil(t, dm)
+
+	// City should be present
+	assert.Equal(t, "Dallas", dm.Extensions["dtias.location.city"])
+	// Country should not be present (empty string)
+	_, hasCountry := dm.Extensions["dtias.location.country"]
+	assert.False(t, hasCountry)
+	// Lat/lon should not be present (zero values)
+	_, hasLat := dm.Extensions["dtias.location.latitude"]
+	assert.False(t, hasLat)
+}

--- a/internal/adapters/dtias/resources_test.go
+++ b/internal/adapters/dtias/resources_test.go
@@ -281,3 +281,862 @@ func TestUpdateResourceNotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 }
+
+// TestListResources tests the ListResources method with a mock server.
+func TestListResources(t *testing.T) {
+	now := time.Now()
+	servers := []dtias.Server{
+		{
+			ID:           "server-001",
+			Hostname:     "web-server-1.example.com",
+			ServerPoolID: "pool-compute",
+			Type:         "r640",
+			State:        "ready",
+			PowerState:   "on",
+			HealthState:  "healthy",
+			CPU:          dtias.CPUInfo{Vendor: "Intel", Model: "Xeon Gold 6248R", TotalCores: 48},
+			Memory:       dtias.MemoryInfo{TotalGB: 256, Type: "DDR4"},
+			Metadata:     map[string]string{"env": "production"},
+			CreatedAt:    now, UpdatedAt: now, LastHealthCheck: now,
+		},
+		{
+			ID:           "server-002",
+			Hostname:     "db-server-1.example.com",
+			ServerPoolID: "pool-storage",
+			Type:         "r740xd",
+			State:        "in-use",
+			PowerState:   "on",
+			HealthState:  "healthy",
+			CPU:          dtias.CPUInfo{Vendor: "Intel", Model: "Xeon Gold 6248R", TotalCores: 48},
+			Memory:       dtias.MemoryInfo{TotalGB: 512, Type: "DDR4"},
+			Metadata:     map[string]string{"env": "production", "o2ims.io/tenant-id": "tenant-a"},
+			CreatedAt:    now, UpdatedAt: now, LastHealthCheck: now,
+		},
+	}
+
+	tests := []struct {
+		name          string
+		filter        *adapter.Filter
+		expectedCount int
+	}{
+		{
+			name:          "list all resources without filter",
+			filter:        nil,
+			expectedCount: 2,
+		},
+		{
+			name: "filter by resource pool ID",
+			filter: &adapter.Filter{
+				ResourcePoolID: "pool-compute",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "filter by resource type ID",
+			filter: &adapter.Filter{
+				ResourceTypeID: "dtias-server-type-r740xd",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "filter by tenant ID",
+			filter: &adapter.Filter{
+				TenantID: "tenant-a",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "filter by non-matching tenant ID",
+			filter: &adapter.Filter{
+				TenantID: "tenant-nonexistent",
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "filter by labels",
+			filter: &adapter.Filter{
+				Labels: map[string]string{"env": "production"},
+			},
+			expectedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/v2/inventory/servers")
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(dtias.ServersInventoryResponse{
+					Full: servers,
+				})
+			}))
+			defer mockServer.Close()
+
+			adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+			result, err := adp.ListResources(context.Background(), tt.filter)
+			require.NoError(t, err)
+			assert.Len(t, result, tt.expectedCount)
+
+			for _, res := range result {
+				assert.NotEmpty(t, res.ResourceID)
+				assert.NotEmpty(t, res.ResourceTypeID)
+				assert.NotEmpty(t, res.Description)
+				assert.NotNil(t, res.Extensions)
+				assert.Contains(t, res.GlobalAssetID, "urn:dtias:server:")
+			}
+		})
+	}
+}
+
+// TestListResources_APIError tests ListResources error handling.
+func TestListResources_APIError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "internal server error"}`))
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+	result, err := adp.ListResources(context.Background(), nil)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "failed to")
+}
+
+// TestListResources_APIResponseError tests ListResources with API error in response body.
+func TestListResources_APIResponseError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(dtias.ServersInventoryResponse{
+			Error: &dtias.APIError{
+				Message: "access denied",
+			},
+		})
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+	result, err := adp.ListResources(context.Background(), nil)
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+// TestGetResource tests the GetResource method with a mock server.
+func TestGetResource(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name        string
+		resourceID  string
+		servers     []dtias.Server
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:       "get existing resource",
+			resourceID: "server-001",
+			servers: []dtias.Server{
+				{
+					ID:           "server-001",
+					Hostname:     "web-server-1.example.com",
+					ServerPoolID: "pool-compute",
+					Type:         "r640",
+					State:        "ready",
+					PowerState:   "on",
+					HealthState:  "healthy",
+					CPU:          dtias.CPUInfo{Vendor: "Intel", Model: "Xeon", TotalCores: 16},
+					Memory:       dtias.MemoryInfo{TotalGB: 64, Type: "DDR4"},
+					Metadata:     map[string]string{},
+					CreatedAt:    now, UpdatedAt: now, LastHealthCheck: now,
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name:        "resource not found (empty response)",
+			resourceID:  "nonexistent",
+			servers:     []dtias.Server{},
+			expectErr:   true,
+			errContains: "server not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(dtias.ServersInventoryResponse{
+					Full: tt.servers,
+				})
+			}))
+			defer mockServer.Close()
+
+			adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+			result, err := adp.GetResource(context.Background(), tt.resourceID)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Nil(t, result)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.resourceID, result.ResourceID)
+			assert.NotEmpty(t, result.Description)
+			assert.NotNil(t, result.Extensions)
+		})
+	}
+}
+
+// TestCreateResource tests the CreateResource method with a mock server.
+func TestCreateResource(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name         string
+		resource     *adapter.Resource
+		mockResponse dtias.Server
+		expectErr    bool
+	}{
+		{
+			name: "create basic resource",
+			resource: &adapter.Resource{
+				ResourcePoolID: "pool-compute",
+				ResourceTypeID: "r640",
+			},
+			mockResponse: dtias.Server{
+				ID:           "new-server-001",
+				Hostname:     "new-server.example.com",
+				ServerPoolID: "pool-compute",
+				Type:         "r640",
+				State:        "provisioning",
+				PowerState:   "off",
+				HealthState:  "unknown",
+				CPU:          dtias.CPUInfo{Vendor: "Intel", Model: "Xeon", TotalCores: 16},
+				Memory:       dtias.MemoryInfo{TotalGB: 64, Type: "DDR4"},
+				Metadata:     map[string]string{},
+				CreatedAt:    now, UpdatedAt: now, LastHealthCheck: now,
+			},
+			expectErr: false,
+		},
+		{
+			name: "create resource with tenant ID and extensions",
+			resource: &adapter.Resource{
+				ResourcePoolID: "pool-compute",
+				ResourceTypeID: "r640",
+				TenantID:       "tenant-a",
+				Extensions: map[string]interface{}{
+					"dtias.hostname":        "custom-host.example.com",
+					"dtias.operatingSystem": "ubuntu-22.04",
+					"dtias.metadata": map[string]string{
+						"team": "platform",
+					},
+				},
+			},
+			mockResponse: dtias.Server{
+				ID:           "new-server-002",
+				Hostname:     "custom-host.example.com",
+				ServerPoolID: "pool-compute",
+				Type:         "r640",
+				State:        "provisioning",
+				PowerState:   "off",
+				HealthState:  "unknown",
+				CPU:          dtias.CPUInfo{Vendor: "Intel", Model: "Xeon", TotalCores: 16},
+				Memory:       dtias.MemoryInfo{TotalGB: 64, Type: "DDR4"},
+				Metadata: map[string]string{
+					"o2ims.io/tenant-id": "tenant-a",
+					"team":               "platform",
+				},
+				CreatedAt: now, UpdatedAt: now, LastHealthCheck: now,
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/v2/resources/allocate", r.URL.Path)
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(tt.mockResponse)
+			}))
+			defer mockServer.Close()
+
+			adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+			result, err := adp.CreateResource(context.Background(), tt.resource)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.mockResponse.ID, result.ResourceID)
+			assert.NotEmpty(t, result.Description)
+			assert.NotNil(t, result.Extensions)
+		})
+	}
+}
+
+// TestCreateResource_APIError tests CreateResource error handling.
+func TestCreateResource_APIError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "internal server error"}`))
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+	result, err := adp.CreateResource(context.Background(), &adapter.Resource{
+		ResourcePoolID: "pool-1",
+		ResourceTypeID: "r640",
+	})
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "failed to provision server")
+}
+
+// TestDeleteResource tests the DeleteResource method with a mock server.
+func TestDeleteResource(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverID   string
+		statusCode int
+		expectErr  bool
+	}{
+		{
+			name:       "delete existing resource",
+			serverID:   "server-001",
+			statusCode: http.StatusOK,
+			expectErr:  false,
+		},
+		{
+			name:       "delete with accepted status",
+			serverID:   "server-002",
+			statusCode: http.StatusAccepted,
+			expectErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/v2/resources/release", r.URL.Path)
+
+				// Verify request body contains the server ID
+				var reqBody map[string]interface{}
+				err := json.NewDecoder(r.Body).Decode(&reqBody)
+				require.NoError(t, err)
+				assert.Equal(t, tt.serverID, reqBody["id"])
+
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer mockServer.Close()
+
+			adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+			err := adp.DeleteResource(context.Background(), tt.serverID)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestDeleteResource_APIError tests DeleteResource error handling.
+func TestDeleteResource_APIError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "internal server error"}`))
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+	err := adp.DeleteResource(context.Background(), "server-error")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decommission server")
+}
+
+// TestPowerControl tests the PowerControl method with a mock server.
+func TestPowerControl(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverID   string
+		operation  dtias.ServerPowerOperation
+		statusCode int
+		expectErr  bool
+	}{
+		{
+			name:       "power on",
+			serverID:   "server-001",
+			operation:  dtias.PowerOn,
+			statusCode: http.StatusOK,
+			expectErr:  false,
+		},
+		{
+			name:       "power off",
+			serverID:   "server-001",
+			operation:  dtias.PowerOff,
+			statusCode: http.StatusOK,
+			expectErr:  false,
+		},
+		{
+			name:       "power reset",
+			serverID:   "server-001",
+			operation:  dtias.PowerReset,
+			statusCode: http.StatusOK,
+			expectErr:  false,
+		},
+		{
+			name:       "power cycle",
+			serverID:   "server-001",
+			operation:  dtias.PowerCycle,
+			statusCode: http.StatusOK,
+			expectErr:  false,
+		},
+		{
+			name:       "force power off",
+			serverID:   "server-001",
+			operation:  dtias.PowerForceOff,
+			statusCode: http.StatusOK,
+			expectErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/v2/resources/action", r.URL.Path)
+
+				var reqBody map[string]interface{}
+				err := json.NewDecoder(r.Body).Decode(&reqBody)
+				require.NoError(t, err)
+				assert.Equal(t, tt.serverID, reqBody["id"])
+				assert.Equal(t, string(tt.operation), reqBody["action"])
+
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer mockServer.Close()
+
+			adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+			err := adp.PowerControl(context.Background(), tt.serverID, tt.operation)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestPowerControl_APIError tests PowerControl error handling.
+func TestPowerControl_APIError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "internal server error"}`))
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+	err := adp.PowerControl(context.Background(), "server-error", dtias.PowerOn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to perform power operation")
+}
+
+// TestGetHealthMetrics tests the GetHealthMetrics method with a mock server.
+func TestGetHealthMetrics(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/v2/inventory/servers/server-001")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(dtias.HealthMetrics{
+			ServerID:              "server-001",
+			CPUUtilization:        45.5,
+			MemoryUtilization:     62.3,
+			CPUTemperature:        55.0,
+			PowerConsumptionWatts: 350,
+			FanSpeeds: []dtias.FanSpeed{
+				{Name: "Fan1", SpeedRPM: 3500, SpeedPercent: 50, Status: "ok"},
+			},
+			Temperatures: []dtias.TemperatureSensor{
+				{Name: "CPU0", TemperatureCelsius: 55.0, Status: "ok"},
+			},
+		})
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+	metrics, err := adp.GetHealthMetrics(context.Background(), "server-001")
+	require.NoError(t, err)
+	require.NotNil(t, metrics)
+	assert.Equal(t, 45.5, metrics.CPUUtilization)
+	assert.Equal(t, 62.3, metrics.MemoryUtilization)
+	assert.Equal(t, 55.0, metrics.CPUTemperature)
+	assert.Equal(t, 350, metrics.PowerConsumptionWatts)
+	assert.Len(t, metrics.FanSpeeds, 1)
+	assert.Len(t, metrics.Temperatures, 1)
+}
+
+// TestGetHealthMetrics_APIError tests GetHealthMetrics error handling.
+func TestGetHealthMetrics_APIError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "internal server error"}`))
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+	metrics, err := adp.GetHealthMetrics(context.Background(), "server-error")
+	require.Error(t, err)
+	assert.Nil(t, metrics)
+	assert.Contains(t, err.Error(), "failed to get health metrics")
+}
+
+// TestBuildServersPath tests the buildServersPath function indirectly through ListResources.
+func TestBuildServersPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		filter      *adapter.Filter
+		expectPath  string
+		expectQuery map[string]string
+	}{
+		{
+			name:       "nil filter produces base path",
+			filter:     nil,
+			expectPath: "/v2/inventory/servers",
+		},
+		{
+			name: "filter with resource pool ID",
+			filter: &adapter.Filter{
+				ResourcePoolID: "pool-1",
+			},
+			expectQuery: map[string]string{"resourcePool": "pool-1"},
+		},
+		{
+			name: "filter with resource type ID",
+			filter: &adapter.Filter{
+				ResourceTypeID: "type-1",
+			},
+			expectQuery: map[string]string{"resourceProfileId": "type-1"},
+		},
+		{
+			name: "filter with location",
+			filter: &adapter.Filter{
+				Location: "dc-dallas",
+			},
+			expectQuery: map[string]string{"location": "dc-dallas"},
+		},
+		{
+			name: "filter with pagination",
+			filter: &adapter.Filter{
+				Limit:  10,
+				Offset: 20,
+			},
+			expectQuery: map[string]string{
+				"pageSize":   "10",
+				"pageNumber": "3", // (20/10) + 1 = 3
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.expectPath != "" {
+					assert.Equal(t, tt.expectPath, r.URL.Path)
+				}
+				for key, value := range tt.expectQuery {
+					assert.Equal(t, value, r.URL.Query().Get(key),
+						"expected query param %s=%s", key, value)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(dtias.ServersInventoryResponse{
+					Full: []dtias.Server{},
+				})
+			}))
+			defer mockServer.Close()
+
+			adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+			_, err := adp.ListResources(context.Background(), tt.filter)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestTransformServerToResource tests the server-to-resource transformation indirectly.
+func TestTransformServerToResource(t *testing.T) {
+	now := time.Now()
+	server := dtias.Server{
+		ID:           "server-001",
+		Hostname:     "web-server-1.example.com",
+		ServerPoolID: "pool-compute",
+		Type:         "r640",
+		State:        "ready",
+		PowerState:   "on",
+		HealthState:  "healthy",
+		CPU: dtias.CPUInfo{
+			Vendor:         "Intel",
+			Model:          "Xeon Gold 6248R",
+			Architecture:   "x86_64",
+			Sockets:        2,
+			CoresPerSocket: 24,
+			TotalCores:     48,
+			TotalThreads:   96,
+			FrequencyMHz:   2400,
+		},
+		Memory: dtias.MemoryInfo{
+			TotalGB:        256,
+			AvailableGB:    200,
+			Type:           "DDR4",
+			SpeedMHz:       3200,
+			DIMMs:          16,
+			SlotsUsed:      16,
+			SlotsAvailable: 0,
+		},
+		BIOS: dtias.BIOSInfo{
+			Vendor:      "Dell",
+			Version:     "2.14.0",
+			ReleaseDate: "2023-06-15",
+		},
+		Management: dtias.ManagementInfo{
+			Type:       "idrac",
+			Version:    "6.00.30.00",
+			IPAddress:  "10.0.0.100",
+			MACAddress: "AA:BB:CC:DD:EE:FF",
+			Hostname:   "idrac-001.example.com",
+		},
+		Location: dtias.Location{
+			Datacenter: "dc-dallas-1",
+			Rack:       "rack-a01",
+			RackUnit:   15,
+			City:       "Dallas",
+			Country:    "US",
+		},
+		Metadata: map[string]string{
+			"env":                "production",
+			"o2ims.io/tenant-id": "tenant-a",
+		},
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastHealthCheck: now,
+	}
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(dtias.ServersInventoryResponse{
+			Full: []dtias.Server{server},
+		})
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+	resources, err := adp.ListResources(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+
+	res := resources[0]
+	assert.Equal(t, "server-001", res.ResourceID)
+	assert.Equal(t, "tenant-a", res.TenantID)
+	assert.Equal(t, "dtias-server-type-r640", res.ResourceTypeID)
+	assert.Equal(t, "pool-compute", res.ResourcePoolID)
+	assert.Equal(t, "urn:dtias:server:server-001", res.GlobalAssetID)
+	assert.Contains(t, res.Description, "web-server-1.example.com")
+	assert.Contains(t, res.Description, "r640")
+
+	// Verify extensions
+	ext := res.Extensions
+	assert.Equal(t, "server-001", ext["dtias.serverId"])
+	assert.Equal(t, "web-server-1.example.com", ext["dtias.hostname"])
+	assert.Equal(t, "r640", ext["dtias.serverType"])
+	assert.Equal(t, "ready", ext["dtias.state"])
+	assert.Equal(t, "on", ext["dtias.powerState"])
+	assert.Equal(t, "healthy", ext["dtias.healthState"])
+
+	// CPU info
+	assert.Equal(t, "Intel", ext["dtias.cpu.vendor"])
+	assert.Equal(t, "Xeon Gold 6248R", ext["dtias.cpu.model"])
+	assert.Equal(t, "x86_64", ext["dtias.cpu.architecture"])
+	assert.Equal(t, 48, ext["dtias.cpu.totalCores"])
+
+	// Memory info
+	assert.Equal(t, 256, ext["dtias.memory.totalGb"])
+	assert.Equal(t, "DDR4", ext["dtias.memory.type"])
+
+	// Location info
+	assert.Equal(t, "dc-dallas-1", ext["dtias.location.datacenter"])
+	assert.Equal(t, "rack-a01", ext["dtias.location.rack"])
+
+	// Metadata
+	metadata, ok := ext["dtias.metadata"].(map[string]string)
+	require.True(t, ok)
+	assert.Equal(t, "production", metadata["env"])
+}
+
+// TestTransformServerToResource_UnhealthyServer tests description for unhealthy servers.
+func TestTransformServerToResource_UnhealthyServer(t *testing.T) {
+	now := time.Now()
+	server := dtias.Server{
+		ID:           "server-sick",
+		Hostname:     "sick-server.example.com",
+		ServerPoolID: "pool-1",
+		Type:         "r640",
+		State:        "error",
+		PowerState:   "on",
+		HealthState:  "critical",
+		CPU:          dtias.CPUInfo{Vendor: "Intel", Model: "Xeon", TotalCores: 16},
+		Memory:       dtias.MemoryInfo{TotalGB: 64, Type: "DDR4"},
+		Metadata:     map[string]string{},
+		CreatedAt:    now, UpdatedAt: now, LastHealthCheck: now,
+	}
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(dtias.ServersInventoryResponse{
+			Full: []dtias.Server{server},
+		})
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+	resources, err := adp.ListResources(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+
+	// Unhealthy server should include health info in description
+	assert.Contains(t, resources[0].Description, "critical")
+}
+
+// TestMatchesResourceFilter tests the resource filter matching logic indirectly.
+func TestMatchesResourceFilter(t *testing.T) {
+	now := time.Now()
+	servers := []dtias.Server{
+		{
+			ID: "server-pool1-type1", Hostname: "s1.example.com",
+			ServerPoolID: "pool-1", Type: "r640",
+			State: "ready", PowerState: "on", HealthState: "healthy",
+			CPU: dtias.CPUInfo{TotalCores: 16}, Memory: dtias.MemoryInfo{TotalGB: 64, Type: "DDR4"},
+			Metadata:  map[string]string{"env": "prod", "tier": "gold"},
+			CreatedAt: now, UpdatedAt: now, LastHealthCheck: now,
+		},
+		{
+			ID: "server-pool2-type2", Hostname: "s2.example.com",
+			ServerPoolID: "pool-2", Type: "r740xd",
+			State: "ready", PowerState: "on", HealthState: "healthy",
+			CPU: dtias.CPUInfo{TotalCores: 48}, Memory: dtias.MemoryInfo{TotalGB: 512, Type: "DDR4"},
+			Metadata:  map[string]string{"env": "staging"},
+			CreatedAt: now, UpdatedAt: now, LastHealthCheck: now,
+		},
+	}
+
+	tests := []struct {
+		name          string
+		filter        *adapter.Filter
+		expectedCount int
+	}{
+		{
+			name:          "no filter returns all",
+			filter:        nil,
+			expectedCount: 2,
+		},
+		{
+			name:          "filter by pool matches one",
+			filter:        &adapter.Filter{ResourcePoolID: "pool-1"},
+			expectedCount: 1,
+		},
+		{
+			name:          "filter by type matches one",
+			filter:        &adapter.Filter{ResourceTypeID: "dtias-server-type-r640"},
+			expectedCount: 1,
+		},
+		{
+			name: "filter by matching label",
+			filter: &adapter.Filter{
+				Labels: map[string]string{"env": "prod"},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "filter by non-matching label",
+			filter: &adapter.Filter{
+				Labels: map[string]string{"env": "dev"},
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "filter by multiple labels (all must match)",
+			filter: &adapter.Filter{
+				Labels: map[string]string{"env": "prod", "tier": "gold"},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "filter by multiple labels (partial match fails)",
+			filter: &adapter.Filter{
+				Labels: map[string]string{"env": "prod", "tier": "silver"},
+			},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(dtias.ServersInventoryResponse{
+					Full: servers,
+				})
+			}))
+			defer mockServer.Close()
+
+			adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+			result, err := adp.ListResources(context.Background(), tt.filter)
+			require.NoError(t, err)
+			assert.Len(t, result, tt.expectedCount)
+		})
+	}
+}

--- a/internal/adapters/dtias/resourcetypes_test.go
+++ b/internal/adapters/dtias/resourcetypes_test.go
@@ -1,0 +1,377 @@
+package dtias_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/piwi3910/netweave/internal/adapters/dtias"
+)
+
+// TestListResourceTypes tests the ListResourceTypes method with a mock server.
+func TestListResourceTypes(t *testing.T) {
+	tests := []struct {
+		name          string
+		serverTypes   []dtias.ServerType
+		expectedCount int
+		expectErr     bool
+	}{
+		{
+			name: "list multiple resource types",
+			serverTypes: []dtias.ServerType{
+				{
+					ID:                "r640",
+					Name:              "Dell PowerEdge R640",
+					Vendor:            "Dell",
+					Model:             "PowerEdge R640",
+					Generation:        "14G",
+					FormFactor:        "rack",
+					CPUModel:          "Xeon Gold 6248R",
+					CPUCores:          48,
+					MemoryGB:          256,
+					StorageType:       "nvme",
+					StorageCapacityGB: 2000,
+					NetworkPorts:      4,
+					NetworkSpeed:      "25Gbps",
+					PowerWatts:        750,
+					RackUnits:         1,
+				},
+				{
+					ID:                "r740xd",
+					Name:              "Dell PowerEdge R740xd",
+					Vendor:            "Dell",
+					Model:             "PowerEdge R740xd",
+					Generation:        "14G",
+					FormFactor:        "rack",
+					CPUModel:          "Xeon Gold 6248R",
+					CPUCores:          48,
+					MemoryGB:          512,
+					StorageType:       "ssd",
+					StorageCapacityGB: 100000,
+					NetworkPorts:      4,
+					NetworkSpeed:      "25Gbps",
+					PowerWatts:        1100,
+					RackUnits:         2,
+				},
+			},
+			expectedCount: 2,
+			expectErr:     false,
+		},
+		{
+			name:          "list empty resource types",
+			serverTypes:   []dtias.ServerType{},
+			expectedCount: 0,
+			expectErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/v2/resourcetypes")
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(dtias.ResourceTypesResponse{
+					ResourceTypes: tt.serverTypes,
+				})
+			}))
+			defer mockServer.Close()
+
+			adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+			result, err := adp.ListResourceTypes(context.Background(), nil)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, result, tt.expectedCount)
+
+			for i, rt := range result {
+				assert.NotEmpty(t, rt.ResourceTypeID)
+				assert.Equal(t, tt.serverTypes[i].Name, rt.Name)
+				assert.Equal(t, tt.serverTypes[i].Vendor, rt.Vendor)
+				assert.Equal(t, tt.serverTypes[i].Model, rt.Model)
+				assert.Equal(t, "physical", rt.ResourceKind)
+				assert.NotEmpty(t, rt.Description)
+				assert.NotNil(t, rt.Extensions)
+			}
+		})
+	}
+}
+
+// TestListResourceTypes_APIError tests ListResourceTypes error handling.
+func TestListResourceTypes_APIError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "internal server error"}`))
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+	result, err := adp.ListResourceTypes(context.Background(), nil)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "failed to")
+}
+
+// TestGetResourceType tests the GetResourceType method with a mock server.
+func TestGetResourceType(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceID   string
+		serverTypes  []dtias.ServerType
+		expectErr    bool
+		errContains  string
+		validateName string
+	}{
+		{
+			name:       "get existing resource type",
+			resourceID: "r640",
+			serverTypes: []dtias.ServerType{
+				{
+					ID:                "r640",
+					Name:              "Dell PowerEdge R640",
+					Vendor:            "Dell",
+					Model:             "PowerEdge R640",
+					Generation:        "14G",
+					FormFactor:        "rack",
+					CPUModel:          "Xeon Gold 6248R",
+					CPUCores:          48,
+					MemoryGB:          256,
+					StorageType:       "nvme",
+					StorageCapacityGB: 2000,
+					NetworkPorts:      4,
+					NetworkSpeed:      "25Gbps",
+					PowerWatts:        750,
+					RackUnits:         1,
+				},
+			},
+			expectErr:    false,
+			validateName: "Dell PowerEdge R640",
+		},
+		{
+			name:        "resource type not found (empty response)",
+			resourceID:  "nonexistent",
+			serverTypes: []dtias.ServerType{},
+			expectErr:   true,
+			errContains: "server type not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/v2/search/resourcetypes/")
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(dtias.ResourceTypesResponse{
+					ResourceTypes: tt.serverTypes,
+				})
+			}))
+			defer mockServer.Close()
+
+			adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+			result, err := adp.GetResourceType(context.Background(), tt.resourceID)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Nil(t, result)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.validateName, result.Name)
+			assert.NotEmpty(t, result.ResourceTypeID)
+			assert.Equal(t, "physical", result.ResourceKind)
+		})
+	}
+}
+
+// TestGetResourceType_APIError tests GetResourceType error handling.
+func TestGetResourceType_APIError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "internal server error"}`))
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+	result, err := adp.GetResourceType(context.Background(), "r640")
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+// TestTransformServerTypeToResourceType_ResourceClassDetection tests the resource class detection logic.
+func TestTransformServerTypeToResourceType_ResourceClassDetection(t *testing.T) {
+	tests := []struct {
+		name          string
+		serverType    dtias.ServerType
+		expectedClass string
+	}{
+		{
+			name: "compute class (default)",
+			serverType: dtias.ServerType{
+				ID:                "compute-1",
+				Name:              "Compute Node",
+				Vendor:            "Dell",
+				CPUCores:          48,
+				MemoryGB:          256,
+				StorageCapacityGB: 2000,
+				NetworkPorts:      4,
+				NetworkSpeed:      "25Gbps",
+			},
+			expectedClass: "compute",
+		},
+		{
+			name: "storage class (storage capacity >> memory * 100)",
+			serverType: dtias.ServerType{
+				ID:                "storage-1",
+				Name:              "Storage Node",
+				Vendor:            "Dell",
+				CPUCores:          16,
+				MemoryGB:          64,
+				StorageCapacityGB: 100000, // 100000 > 64*100=6400
+				NetworkPorts:      4,
+				NetworkSpeed:      "25Gbps",
+			},
+			expectedClass: "storage",
+		},
+		{
+			name: "network class (many network ports > 4)",
+			serverType: dtias.ServerType{
+				ID:                "network-1",
+				Name:              "Network Node",
+				Vendor:            "Dell",
+				CPUCores:          16,
+				MemoryGB:          64,
+				StorageCapacityGB: 500, // 500 < 64*100=6400
+				NetworkPorts:      8,   // > 4
+				NetworkSpeed:      "100Gbps",
+			},
+			expectedClass: "network",
+		},
+		{
+			name: "storage takes priority over network",
+			serverType: dtias.ServerType{
+				ID:                "storage-net-1",
+				Name:              "Storage+Network Node",
+				Vendor:            "Dell",
+				CPUCores:          16,
+				MemoryGB:          32,
+				StorageCapacityGB: 50000, // 50000 > 32*100=3200
+				NetworkPorts:      8,     // > 4
+				NetworkSpeed:      "100Gbps",
+			},
+			expectedClass: "storage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// We need to use the mock server pattern to create an adapter
+			// and then call ListResourceTypes to get the transformed types
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(dtias.ResourceTypesResponse{
+					ResourceTypes: []dtias.ServerType{tt.serverType},
+				})
+			}))
+			defer mockServer.Close()
+
+			adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+			result, err := adp.ListResourceTypes(context.Background(), nil)
+			require.NoError(t, err)
+			require.Len(t, result, 1)
+			assert.Equal(t, tt.expectedClass, result[0].ResourceClass)
+		})
+	}
+}
+
+// TestTransformServerTypeToResourceType_Extensions tests that all extensions are populated.
+func TestTransformServerTypeToResourceType_Extensions(t *testing.T) {
+	serverType := dtias.ServerType{
+		ID:                "r640",
+		Name:              "Dell PowerEdge R640",
+		Vendor:            "Dell",
+		Model:             "PowerEdge R640",
+		Generation:        "14G",
+		FormFactor:        "rack",
+		CPUModel:          "Xeon Gold 6248R",
+		CPUCores:          48,
+		MemoryGB:          256,
+		StorageType:       "nvme",
+		StorageCapacityGB: 2000,
+		NetworkPorts:      4,
+		NetworkSpeed:      "25Gbps",
+		PowerWatts:        750,
+		RackUnits:         1,
+	}
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(dtias.ResourceTypesResponse{
+			ResourceTypes: []dtias.ServerType{serverType},
+		})
+	}))
+	defer mockServer.Close()
+
+	adp := dtias.NewTestAdapter(mockServer.URL, mockServer.Client(), zap.NewNop())
+
+	result, err := adp.ListResourceTypes(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	rt := result[0]
+	assert.Equal(t, "dtias-server-type-r640", rt.ResourceTypeID)
+	assert.Equal(t, "Dell PowerEdge R640", rt.Name)
+	assert.Equal(t, "Dell", rt.Vendor)
+	assert.Equal(t, "PowerEdge R640", rt.Model)
+	assert.Equal(t, "14G", rt.Version)
+	assert.Equal(t, "physical", rt.ResourceKind)
+
+	// Verify all extension keys
+	ext := rt.Extensions
+	assert.Equal(t, "r640", ext["dtias.serverTypeId"])
+	assert.Equal(t, "Dell", ext["dtias.vendor"])
+	assert.Equal(t, "PowerEdge R640", ext["dtias.model"])
+	assert.Equal(t, "14G", ext["dtias.generation"])
+	assert.Equal(t, "rack", ext["dtias.formFactor"])
+	assert.Equal(t, "Xeon Gold 6248R", ext["dtias.cpu.model"])
+	assert.Equal(t, 48, ext["dtias.cpu.cores"])
+	assert.Equal(t, 256, ext["dtias.memory.sizeGb"])
+	assert.Equal(t, "nvme", ext["dtias.storage.type"])
+	assert.Equal(t, 2000, ext["dtias.storage.capacityGb"])
+	assert.Equal(t, 4, ext["dtias.network.ports"])
+	assert.Equal(t, "25Gbps", ext["dtias.network.speed"])
+	assert.Equal(t, 750, ext["dtias.power.watts"])
+	assert.Equal(t, 1, ext["dtias.rack.units"])
+
+	// Verify description contains hardware summary
+	assert.Contains(t, rt.Description, "48 cores")
+	assert.Contains(t, rt.Description, "256GB RAM")
+	assert.Contains(t, rt.Description, "2000GB storage")
+	assert.Contains(t, rt.Description, "25Gbps")
+}

--- a/internal/adapters/gcp/adapter_test.go
+++ b/internal/adapters/gcp/adapter_test.go
@@ -13,12 +13,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// TestNew tests the creation of a new GCPAdapter.
-func TestNew(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
+// TestNew_Validation tests config validation without requiring GCP credentials.
+func TestNew_Validation(t *testing.T) {
 	tests := []struct {
 		name    string
 		config  *gcp.Config
@@ -92,10 +88,6 @@ func TestNew(t *testing.T) {
 
 // TestMetadata tests metadata methods.
 func TestMetadata(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
 	adp := &gcp.Adapter{
 		Logger: zap.NewNop(),
 	}
@@ -129,10 +121,6 @@ func TestMetadata(t *testing.T) {
 
 // TestGenerateIDs tests ID generation functions.
 func TestGenerateIDs(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
 	t.Run("gcp.GenerateMachineTypeID", func(t *testing.T) {
 		tests := []struct {
 			machineType string
@@ -199,10 +187,6 @@ func TestGenerateIDs(t *testing.T) {
 
 // TestExtractMachineFamily tests machine family extraction.
 func TestExtractMachineFamily(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
 	tests := []struct {
 		machineType string
 		want        string
@@ -224,10 +208,6 @@ func TestExtractMachineFamily(t *testing.T) {
 
 // TestExtractMachineTypeName tests machine type name extraction from URL.
 func TestExtractMachineTypeName(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
 	tests := []struct {
 		url  string
 		want string
@@ -257,10 +237,6 @@ func TestExtractMachineTypeName(t *testing.T) {
 
 // TestExtractZoneName tests zone name extraction from URL.
 func TestExtractZoneName(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
 	tests := []struct {
 		url  string
 		want string
@@ -289,10 +265,6 @@ func TestExtractZoneName(t *testing.T) {
 
 // TestSubscriptions tests subscription CRUD operations.
 func TestSubscriptions(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
 	adp := &gcp.Adapter{
 		Logger:        zap.NewNop(),
 		Subscriptions: make(map[string]*adapter.Subscription),
@@ -368,10 +340,6 @@ func TestSubscriptions(t *testing.T) {
 
 // TestPtrHelpers tests pointer helper functions.
 func TestPtrHelpers(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
 	t.Run("ptrToString", func(t *testing.T) {
 		s := "hello"
 		assert.Equal(t, "hello", gcp.PtrToString(&s))
@@ -536,12 +504,8 @@ func TestGCPAdapter_GetDeploymentManager(t *testing.T) {
 	})
 }
 
-// TestExtractZoneAndName tests zone and name extraction from resource extensions.
+// TestBuildInstanceLabels tests label building logic for GCP instances.
 func TestBuildInstanceLabels(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
 	adp := &gcp.Adapter{Logger: zap.NewNop()}
 
 	tests := []struct {
@@ -636,10 +600,6 @@ func TestBuildInstanceLabels(t *testing.T) {
 
 // TestDetermineResourcePoolID tests resource pool ID determination.
 func TestDetermineResourcePoolID(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
 	tests := []struct {
 		name     string
 		poolMode string
@@ -678,10 +638,6 @@ func TestDetermineResourcePoolID(t *testing.T) {
 
 // TestBuildInstanceExtensions tests GCP instance extensions building.
 func TestBuildInstanceExtensions(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
 	adp := &gcp.Adapter{Logger: zap.NewNop()}
 
 	instName := "test-vm"
@@ -819,6 +775,400 @@ func TestBuildInstanceExtensions(t *testing.T) {
 			got := adp.TestBuildInstanceExtensions(tt.instance, tt.instanceName, tt.zone, tt.machineType)
 			require.NotNil(t, got)
 			tt.checkFunc(t, got)
+		})
+	}
+}
+
+// TestSubscriptions_UpdateAndEdgeCases tests subscription update and additional edge cases.
+func TestSubscriptions_UpdateAndEdgeCases(t *testing.T) {
+	adp := &gcp.Adapter{
+		Logger:        zap.NewNop(),
+		Subscriptions: make(map[string]*adapter.Subscription),
+	}
+	ctx := context.Background()
+
+	// Create a subscription first
+	created, err := adp.CreateSubscription(ctx, &adapter.Subscription{
+		SubscriptionID:         "sub-update-test",
+		Callback:               "https://example.com/original",
+		ConsumerSubscriptionID: "consumer-1",
+		Filter: &adapter.SubscriptionFilter{
+			ResourceTypeID: "compute",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	t.Run("UpdateSubscription success", func(t *testing.T) {
+		updated, updateErr := adp.UpdateSubscription(ctx, "sub-update-test", &adapter.Subscription{
+			Callback:               "https://example.com/updated",
+			ConsumerSubscriptionID: "consumer-2",
+			Filter: &adapter.SubscriptionFilter{
+				ResourceTypeID: "storage",
+			},
+		})
+		require.NoError(t, updateErr)
+		require.NotNil(t, updated)
+		assert.Equal(t, "sub-update-test", updated.SubscriptionID)
+		assert.Equal(t, "https://example.com/updated", updated.Callback)
+		assert.Equal(t, "consumer-2", updated.ConsumerSubscriptionID)
+		require.NotNil(t, updated.Filter)
+		assert.Equal(t, "storage", updated.Filter.ResourceTypeID)
+	})
+
+	t.Run("UpdateSubscription persists changes", func(t *testing.T) {
+		fetched, fetchErr := adp.GetSubscription(ctx, "sub-update-test")
+		require.NoError(t, fetchErr)
+		assert.Equal(t, "https://example.com/updated", fetched.Callback)
+		assert.Equal(t, "consumer-2", fetched.ConsumerSubscriptionID)
+	})
+
+	t.Run("UpdateSubscription not found", func(t *testing.T) {
+		_, updateErr := adp.UpdateSubscription(ctx, "nonexistent", &adapter.Subscription{
+			Callback: "https://example.com/updated",
+		})
+		require.Error(t, updateErr)
+		assert.Contains(t, updateErr.Error(), "subscription not found")
+	})
+
+	t.Run("UpdateSubscription empty callback", func(t *testing.T) {
+		_, updateErr := adp.UpdateSubscription(ctx, "sub-update-test", &adapter.Subscription{
+			Callback: "",
+		})
+		require.Error(t, updateErr)
+		assert.Contains(t, updateErr.Error(), "callback URL is required")
+	})
+
+	t.Run("CreateSubscription with filter preserved", func(t *testing.T) {
+		sub, createErr := adp.CreateSubscription(ctx, &adapter.Subscription{
+			SubscriptionID: "sub-with-filter",
+			Callback:       "https://example.com/filtered",
+			Filter: &adapter.SubscriptionFilter{
+				ResourceTypeID: "compute",
+			},
+		})
+		require.NoError(t, createErr)
+		require.NotNil(t, sub)
+		require.NotNil(t, sub.Filter)
+		assert.Equal(t, "compute", sub.Filter.ResourceTypeID)
+	})
+}
+
+// TestResourcePoolOperations_ZoneMode tests resource pool operations in zone mode (all return errors).
+func TestResourcePoolOperations_ZoneMode(t *testing.T) {
+	adp := &gcp.Adapter{
+		Logger: zap.NewNop(),
+	}
+	adp.TestSetPoolMode("zone")
+
+	ctx := context.Background()
+
+	t.Run("CreateResourcePool in zone mode returns error", func(t *testing.T) {
+		pool, err := adp.CreateResourcePool(ctx, &adapter.ResourcePool{
+			Name:        "test-pool",
+			Description: "test description",
+		})
+		require.Error(t, err)
+		assert.Nil(t, pool)
+		assert.Contains(t, err.Error(), "zone")
+		assert.Contains(t, err.Error(), "GCP-managed")
+	})
+
+	t.Run("UpdateResourcePool in zone mode returns error", func(t *testing.T) {
+		pool, err := adp.UpdateResourcePool(ctx, "some-id", &adapter.ResourcePool{
+			Description: "updated description",
+		})
+		require.Error(t, err)
+		assert.Nil(t, pool)
+		assert.Contains(t, err.Error(), "zone")
+		assert.Contains(t, err.Error(), "GCP-managed")
+	})
+
+	t.Run("DeleteResourcePool in zone mode returns error", func(t *testing.T) {
+		err := adp.DeleteResourcePool(ctx, "some-id")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "zone")
+		assert.Contains(t, err.Error(), "GCP-managed")
+	})
+}
+
+// TestResourcePoolOperations_IGMode tests resource pool operations in IG mode.
+func TestResourcePoolOperations_IGMode(t *testing.T) {
+	adp := &gcp.Adapter{
+		Logger: zap.NewNop(),
+	}
+	adp.TestSetPoolMode("ig")
+
+	ctx := context.Background()
+
+	t.Run("CreateResourcePool in IG mode returns not implemented", func(t *testing.T) {
+		pool, err := adp.CreateResourcePool(ctx, &adapter.ResourcePool{
+			Name:        "test-ig",
+			Description: "test instance group",
+		})
+		require.Error(t, err)
+		assert.Nil(t, pool)
+		assert.Contains(t, err.Error(), "not yet implemented")
+	})
+
+	t.Run("UpdateResourcePool in IG mode returns not implemented", func(t *testing.T) {
+		pool, err := adp.UpdateResourcePool(ctx, "some-id", &adapter.ResourcePool{
+			Description: "updated",
+		})
+		require.Error(t, err)
+		assert.Nil(t, pool)
+		assert.Contains(t, err.Error(), "not yet implemented")
+	})
+
+	t.Run("DeleteResourcePool in IG mode returns not implemented", func(t *testing.T) {
+		err := adp.DeleteResourcePool(ctx, "some-id")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not yet implemented")
+	})
+}
+
+// TestCreateResource_ReturnsError tests that CreateResource always returns error.
+func TestCreateResource_ReturnsError(t *testing.T) {
+	adp := &gcp.Adapter{
+		Logger: zap.NewNop(),
+	}
+
+	ctx := context.Background()
+	result, err := adp.CreateResource(ctx, &adapter.Resource{
+		ResourceTypeID: "gcp-machine-type-n1-standard-1",
+		Description:    "Test instance",
+	})
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "additional configuration")
+}
+
+// TestGetResource_InvalidFormat tests GetResource with invalid ID formats.
+func TestGetResource_InvalidFormat(t *testing.T) {
+	adp := &gcp.Adapter{
+		Logger: zap.NewNop(),
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		resourceID  string
+		errContains string
+	}{
+		{
+			name:        "missing prefix",
+			resourceID:  "invalid-format",
+			errContains: "invalid resource ID format",
+		},
+		{
+			name:        "prefix only no remainder",
+			resourceID:  "gcp-instance-",
+			errContains: "invalid resource ID format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, err := adp.GetResource(ctx, tt.resourceID)
+			require.Error(t, err)
+			assert.Nil(t, resource)
+			assert.Contains(t, err.Error(), tt.errContains)
+		})
+	}
+}
+
+// TestExtractZoneAndName_Exported tests the extractZoneAndName function via test helper.
+func TestExtractZoneAndName_Exported(t *testing.T) {
+	adp := &gcp.Adapter{Logger: zap.NewNop()}
+
+	tests := []struct {
+		name         string
+		resource     *adapter.Resource
+		wantZone     string
+		wantInstance string
+		expectErr    bool
+	}{
+		{
+			name: "valid resource with zone and name",
+			resource: &adapter.Resource{
+				ResourceID: "gcp-instance-us-central1-a-my-vm",
+				Extensions: map[string]interface{}{
+					"gcp.zone": "us-central1-a",
+					"gcp.name": "my-vm",
+				},
+			},
+			wantZone:     "us-central1-a",
+			wantInstance: "my-vm",
+			expectErr:    false,
+		},
+		{
+			name: "missing gcp.zone",
+			resource: &adapter.Resource{
+				ResourceID: "gcp-instance-us-central1-a-my-vm",
+				Extensions: map[string]interface{}{
+					"gcp.name": "my-vm",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing gcp.name",
+			resource: &adapter.Resource{
+				ResourceID: "gcp-instance-us-central1-a-my-vm",
+				Extensions: map[string]interface{}{
+					"gcp.zone": "us-central1-a",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "nil extensions",
+			resource: &adapter.Resource{
+				ResourceID: "gcp-instance-us-central1-a-my-vm",
+			},
+			expectErr: true,
+		},
+		{
+			name: "wrong type for zone",
+			resource: &adapter.Resource{
+				ResourceID: "gcp-instance-us-central1-a-my-vm",
+				Extensions: map[string]interface{}{
+					"gcp.zone": 123,
+					"gcp.name": "my-vm",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "wrong type for name",
+			resource: &adapter.Resource{
+				ResourceID: "gcp-instance-us-central1-a-my-vm",
+				Extensions: map[string]interface{}{
+					"gcp.zone": "us-central1-a",
+					"gcp.name": 456,
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			zone, instanceName, err := adp.TestExtractZoneAndName(tt.resource)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantZone, zone)
+				assert.Equal(t, tt.wantInstance, instanceName)
+			}
+		})
+	}
+}
+
+// TestExtractMachineFamily_EdgeCases tests edge cases for machine family extraction.
+func TestExtractMachineFamily_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		machineType string
+		want        string
+	}{
+		{
+			name:        "empty string",
+			machineType: "",
+			want:        "",
+		},
+		{
+			name:        "no dash",
+			machineType: "custom",
+			want:        "custom",
+		},
+		{
+			name:        "single dash",
+			machineType: "n1-micro",
+			want:        "n1",
+		},
+		{
+			name:        "multiple dashes",
+			machineType: "a2-highgpu-1g",
+			want:        "a2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gcp.ExtractMachineFamily(tt.machineType)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestExtractZoneName_EdgeCases tests edge cases for zone name extraction.
+func TestExtractZoneName_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "no slash at all",
+			url:  "us-central1-a",
+			want: "us-central1-a",
+		},
+		{
+			name: "empty string",
+			url:  "",
+			want: "",
+		},
+		{
+			name: "trailing slash",
+			url:  "https://example.com/zones/",
+			want: "",
+		},
+		{
+			name: "single slash prefix",
+			url:  "/us-central1-a",
+			want: "us-central1-a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gcp.ExtractZoneName(tt.url)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestExtractMachineTypeName_EdgeCases tests edge cases for machine type name extraction.
+func TestExtractMachineTypeName_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "plain name no slashes",
+			url:  "n1-standard-1",
+			want: "n1-standard-1",
+		},
+		{
+			name: "empty string",
+			url:  "",
+			want: "",
+		},
+		{
+			name: "full URL",
+			url:  "https://compute.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/machineTypes/e2-medium",
+			want: "e2-medium",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gcp.ExtractMachineTypeName(tt.url)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/adapters/starlingx/resources_test.go
+++ b/internal/adapters/starlingx/resources_test.go
@@ -138,3 +138,213 @@ func TestGetResource(t *testing.T) {
 		require.ErrorIs(t, err, adapter.ErrResourceNotFound)
 	})
 }
+
+func TestListResources_EmptyHosts(t *testing.T) {
+	adp, cleanup := starlingx.CreateTestAdapter(t, &starlingx.MockServerConfig{
+		Hosts: []starlingx.IHost{},
+	})
+	defer cleanup()
+
+	ctx := context.Background()
+	resources, err := adp.ListResources(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, resources)
+}
+
+func TestListResources_FilterByResourceType(t *testing.T) {
+	hosts := []starlingx.IHost{
+		{UUID: "host-1", Hostname: "compute-0", Personality: "compute"},
+		{UUID: "host-2", Hostname: "controller-0", Personality: "controller"},
+		{UUID: "host-3", Hostname: "storage-0", Personality: "storage"},
+	}
+
+	adp, cleanup := starlingx.CreateTestAdapter(t, &starlingx.MockServerConfig{
+		Hosts: hosts,
+	})
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("filter by compute type", func(t *testing.T) {
+		resources, err := adp.ListResources(ctx, &adapter.Filter{
+			ResourceTypeID: "starlingx-compute",
+		})
+		require.NoError(t, err)
+		assert.Len(t, resources, 1)
+		assert.Equal(t, "host-1", resources[0].ResourceID)
+	})
+
+	t.Run("filter by controller type", func(t *testing.T) {
+		resources, err := adp.ListResources(ctx, &adapter.Filter{
+			ResourceTypeID: "starlingx-controller",
+		})
+		require.NoError(t, err)
+		assert.Len(t, resources, 1)
+		assert.Equal(t, "host-2", resources[0].ResourceID)
+	})
+
+	t.Run("filter by storage type", func(t *testing.T) {
+		resources, err := adp.ListResources(ctx, &adapter.Filter{
+			ResourceTypeID: "starlingx-storage",
+		})
+		require.NoError(t, err)
+		assert.Len(t, resources, 1)
+		assert.Equal(t, "host-3", resources[0].ResourceID)
+	})
+
+	t.Run("filter by non-existing type", func(t *testing.T) {
+		resources, err := adp.ListResources(ctx, &adapter.Filter{
+			ResourceTypeID: "starlingx-nonexistent",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, resources)
+	})
+}
+
+func TestListResources_FilterByPool(t *testing.T) {
+	hosts := []starlingx.IHost{
+		{UUID: "host-1", Hostname: "compute-0", Personality: "compute"},
+		{UUID: "host-2", Hostname: "compute-1", Personality: "compute"},
+	}
+
+	labels := []starlingx.Label{
+		{UUID: "label-1", HostUUID: "host-1", LabelKey: "pool", LabelValue: "pool-a"},
+		{UUID: "label-2", HostUUID: "host-2", LabelKey: "pool", LabelValue: "pool-b"},
+	}
+
+	adp, cleanup := starlingx.CreateTestAdapter(t, &starlingx.MockServerConfig{
+		Hosts:  hosts,
+		Labels: labels,
+	})
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("filter by matching pool", func(t *testing.T) {
+		resources, err := adp.ListResources(ctx, &adapter.Filter{
+			ResourcePoolID: "starlingx-pool-pool-a",
+		})
+		require.NoError(t, err)
+		assert.Len(t, resources, 1)
+		assert.Equal(t, "host-1", resources[0].ResourceID)
+		assert.Equal(t, "starlingx-pool-pool-a", resources[0].ResourcePoolID)
+	})
+
+	t.Run("filter by different pool", func(t *testing.T) {
+		resources, err := adp.ListResources(ctx, &adapter.Filter{
+			ResourcePoolID: "starlingx-pool-pool-b",
+		})
+		require.NoError(t, err)
+		assert.Len(t, resources, 1)
+		assert.Equal(t, "host-2", resources[0].ResourceID)
+	})
+
+	t.Run("filter by non-existing pool returns default matches", func(t *testing.T) {
+		resources, err := adp.ListResources(ctx, &adapter.Filter{
+			ResourcePoolID: "starlingx-pool-nonexistent",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, resources)
+	})
+}
+
+func TestListResources_WithHardwareDetails(t *testing.T) {
+	hosts := []starlingx.IHost{
+		{UUID: "host-1", Hostname: "compute-0", Personality: "compute"},
+	}
+
+	cpus := map[string][]starlingx.ICPU{
+		"host-1": {
+			{UUID: "cpu-1", CPU: 0, HostUUID: "host-1"},
+			{UUID: "cpu-2", CPU: 1, HostUUID: "host-1"},
+			{UUID: "cpu-3", CPU: 2, HostUUID: "host-1"},
+			{UUID: "cpu-4", CPU: 3, HostUUID: "host-1"},
+		},
+	}
+
+	memory := map[string][]starlingx.IMemory{
+		"host-1": {
+			{UUID: "mem-1", MemTotalMiB: 65536, HostUUID: "host-1"},
+			{UUID: "mem-2", MemTotalMiB: 65536, HostUUID: "host-1"},
+		},
+	}
+
+	disks := map[string][]starlingx.IDisk{
+		"host-1": {
+			{UUID: "disk-1", SizeMiB: 476940, HostUUID: "host-1"},
+			{UUID: "disk-2", SizeMiB: 953870, HostUUID: "host-1"},
+		},
+	}
+
+	adp, cleanup := starlingx.CreateTestAdapter(t, &starlingx.MockServerConfig{
+		Hosts:  hosts,
+		CPUs:   cpus,
+		Memory: memory,
+		Disks:  disks,
+	})
+	defer cleanup()
+
+	ctx := context.Background()
+
+	resources, err := adp.ListResources(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+
+	res := resources[0]
+	assert.Equal(t, "host-1", res.ResourceID)
+	assert.Equal(t, "compute-0", res.Extensions["hostname"])
+	assert.NotNil(t, res.Extensions)
+
+	// Verify hardware details are present (key names from mapping.go)
+	assert.NotNil(t, res.Extensions["cpus"])
+	assert.Equal(t, 4, res.Extensions["cpu_count"])
+	assert.NotNil(t, res.Extensions["memory_total_mib"])
+	assert.Equal(t, 131072, res.Extensions["memory_total_mib"])
+	assert.NotNil(t, res.Extensions["disks"])
+	assert.Equal(t, 1430810, res.Extensions["storage_total_mib"])
+}
+
+func TestGetResource_WithHardwareDetails(t *testing.T) {
+	hosts := []starlingx.IHost{
+		{UUID: "host-1", Hostname: "compute-0", Personality: "compute"},
+	}
+
+	cpus := map[string][]starlingx.ICPU{
+		"host-1": {
+			{UUID: "cpu-1", CPU: 0, HostUUID: "host-1"},
+		},
+	}
+
+	memory := map[string][]starlingx.IMemory{
+		"host-1": {
+			{UUID: "mem-1", MemTotalMiB: 131072, HostUUID: "host-1"},
+		},
+	}
+
+	disks := map[string][]starlingx.IDisk{
+		"host-1": {
+			{UUID: "disk-1", SizeMiB: 476940, HostUUID: "host-1"},
+		},
+	}
+
+	adp, cleanup := starlingx.CreateTestAdapter(t, &starlingx.MockServerConfig{
+		Hosts:  hosts,
+		CPUs:   cpus,
+		Memory: memory,
+		Disks:  disks,
+	})
+	defer cleanup()
+
+	ctx := context.Background()
+
+	resource, err := adp.GetResource(ctx, "host-1")
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	assert.Equal(t, "host-1", resource.ResourceID)
+	assert.NotNil(t, resource.Extensions["cpus"])
+	assert.Equal(t, 1, resource.Extensions["cpu_count"])
+	assert.NotNil(t, resource.Extensions["memory_total_mib"])
+	assert.Equal(t, 131072, resource.Extensions["memory_total_mib"])
+	assert.NotNil(t, resource.Extensions["disks"])
+	assert.Equal(t, 476940, resource.Extensions["storage_total_mib"])
+}


### PR DESCRIPTION
## Summary
- Adds comprehensive test coverage for DTIAS, StarlingX, and GCP adapters
- 2050 lines of new test code across 5 files
- Covers deployment managers, resource types, resources, subscriptions, and edge cases

## Files Changed
- `internal/adapters/dtias/deploymentmanager_test.go` (new) - DM retrieval, ID validation, datacenter info
- `internal/adapters/dtias/resourcetypes_test.go` (new) - Resource type listing, retrieval, class detection
- `internal/adapters/dtias/resources_test.go` (expanded) - Resources CRUD, filters, power control, health metrics
- `internal/adapters/gcp/adapter_test.go` (expanded) - Subscriptions, resource pools, helper edge cases
- `internal/adapters/starlingx/resources_test.go` (expanded) - Empty hosts, filter by type/pool, hardware details

## Test plan
- [x] All DTIAS adapter tests pass (`go test -race ./internal/adapters/dtias/...`)
- [x] All GCP adapter tests pass (`go test -race ./internal/adapters/gcp/...`)
- [x] All StarlingX adapter tests pass (`go test -race ./internal/adapters/starlingx/...`)
- [x] No test regressions in other packages

Resolves #246