### PR TITLE
Fix subscription storage initialization with Keycloak backend

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -240,7 +240,7 @@ func initializeComponents(cfg *config.Config, logger *zap.Logger) (*ApplicationC
 		}
 		imsAdapter = mockAdp
 	default:
-		k8sAdp, k8sErr := initializeKubernetesAdapter(cfg, logger)
+		k8sAdp, k8sErr := initializeKubernetesAdapter(cfg, logger, store)
 		if k8sErr != nil {
 			cleanupOnError(store, nil, logger)
 			return nil, fmt.Errorf("failed to initialize Kubernetes adapter: %w", k8sErr)
@@ -634,7 +634,7 @@ func verifyRedisConnectivity(store *storage.RedisStore) error {
 }
 
 // initializeKubernetesAdapter creates and initializes the Kubernetes adapter.
-func initializeKubernetesAdapter(cfg *config.Config, logger *zap.Logger) (*kubernetes.Adapter, error) {
+func initializeKubernetesAdapter(cfg *config.Config, logger *zap.Logger, store storage.Store) (*kubernetes.Adapter, error) {
 	// Build Kubernetes adapter configuration
 	k8sCfg := &kubernetes.Config{
 		Kubeconfig:          cfg.Kubernetes.ConfigPath,
@@ -642,6 +642,7 @@ func initializeKubernetesAdapter(cfg *config.Config, logger *zap.Logger) (*kuber
 		DeploymentManagerID: "netweave-k8s-dm",
 		Namespace:           cfg.Kubernetes.Namespace,
 		Logger:              logger,
+		Store:               store,
 	}
 
 	// Set default namespace if not specified


### PR DESCRIPTION
## Summary
- Fixed subscription storage not being passed to the Kubernetes adapter when using the Keycloak auth backend
- `initializeKubernetesAdapter` was missing the `Store` field in `kubernetes.Config`, causing all subscription operations to fail with "subscription storage not configured"
- One-line fix: pass the Redis store to the adapter config

## Test plan
- [x] `go test -race ./...` passes
- [x] `make lint` passes
- [x] Verified subscription endpoint no longer returns 500 when Keycloak auth is enabled

Resolves #333