### PR TITLE
Fix subscription double-store causing 500 on POST

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -444,7 +444,7 @@ func (s *Server) handleCreateSubscription(c *gin.Context) {
 		return
 	}
 
-	// Store subscription with tenant ID
+	// Update subscription with tenant ID (adapter already stored it in Redis)
 	storageSub := &storage.Subscription{
 		ID:                     created.SubscriptionID,
 		Callback:               created.Callback,
@@ -459,8 +459,8 @@ func (s *Server) handleCreateSubscription(c *gin.Context) {
 		}
 	}
 
-	if err := s.store.Create(ctx, storageSub); err != nil {
-		s.logger.Error("failed to store subscription", zap.Error(err))
+	if err := s.store.Update(ctx, storageSub); err != nil {
+		s.logger.Error("failed to update subscription with tenant ID", zap.Error(err))
 		// Attempt to clean up adapter subscription (best effort)
 		_ = s.adapter.DeleteSubscription(ctx, created.SubscriptionID)
 		// Rollback quota increment


### PR DESCRIPTION
## Summary
- Changed `s.store.Create()` to `s.store.Update()` in the subscription POST route handler
- The Kubernetes adapter already stores the subscription in Redis via its own `CreateSubscription()` method, so the route handler only needs to update the record with the tenant ID
- Without this fix, every subscription POST returns 500 "Failed to store subscription" due to "already exists" conflict

## Test plan
- [x] `go test -race -short ./internal/server/...` passes
- [x] Verified subscription POST returns 201 on deployed cluster
- [x] Full RBAC test matrix passes (33/33)

Resolves #338