### PR TITLE
Add PostgreSQL store implementations for storage, auth, and events

### DIFF
--- a/internal/auth/postgres.go
+++ b/internal/auth/postgres.go
@@ -1,0 +1,892 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/piwi3910/netweave/internal/database"
+	"github.com/piwi3910/netweave/internal/database/dbsqlc"
+)
+
+// pgUniqueViolation is the PostgreSQL error code for unique constraint violations.
+const pgUniqueViolation = "23505"
+
+// PostgresStore implements the auth.Store interface using PostgreSQL as the backend.
+// It uses sqlc-generated queries for type-safe database access.
+//
+// Example:
+//
+//	db, _ := database.New(ctx, cfg, password)
+//	store := NewPostgresStore(db)
+//	defer store.Close()
+type PostgresStore struct {
+	db      *database.DB
+	queries *dbsqlc.Queries
+}
+
+// NewPostgresStore creates a new PostgresStore backed by the given database connection.
+func NewPostgresStore(db *database.DB) *PostgresStore {
+	return &PostgresStore{
+		db:      db,
+		queries: dbsqlc.New(db.Pool),
+	}
+}
+
+// Close closes the PostgreSQL connection pool and releases resources.
+func (s *PostgresStore) Close() error {
+	s.db.Close()
+	return nil
+}
+
+// Ping checks if PostgreSQL is available.
+func (s *PostgresStore) Ping(ctx context.Context) error {
+	if err := s.db.Ping(ctx); err != nil {
+		return fmt.Errorf("%w: %s", ErrStorageUnavailable, err.Error())
+	}
+	return nil
+}
+
+// --- TenantStore ---
+
+// CreateTenant creates a new tenant.
+// Returns ErrTenantExists if a tenant with the same ID already exists.
+func (s *PostgresStore) CreateTenant(ctx context.Context, tenant *Tenant) error {
+	if tenant.ID == "" {
+		return ErrInvalidTenantID
+	}
+
+	now := time.Now().UTC()
+	tenant.CreatedAt = now
+	tenant.UpdatedAt = now
+
+	quotaJSON, err := json.Marshal(tenant.Quota)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tenant quota: %w", err)
+	}
+
+	usageJSON, err := json.Marshal(tenant.Usage)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tenant usage: %w", err)
+	}
+
+	metadataJSON, err := marshalStringMap(tenant.Metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tenant metadata: %w", err)
+	}
+
+	err = s.queries.CreateTenant(ctx, dbsqlc.CreateTenantParams{
+		ID:           tenant.ID,
+		Name:         tenant.Name,
+		Description:  tenant.Description,
+		Status:       string(tenant.Status),
+		Quota:        quotaJSON,
+		Usage:        usageJSON,
+		ContactEmail: tenant.ContactEmail,
+		Metadata:     metadataJSON,
+		CreatedAt:    tenant.CreatedAt,
+		UpdatedAt:    tenant.UpdatedAt,
+	})
+	if err != nil {
+		if isPgUniqueViolation(err) {
+			return ErrTenantExists
+		}
+		return fmt.Errorf("failed to create tenant: %w", err)
+	}
+
+	return nil
+}
+
+// GetTenant retrieves a tenant by ID.
+// Returns ErrTenantNotFound if the tenant does not exist.
+func (s *PostgresStore) GetTenant(ctx context.Context, id string) (*Tenant, error) {
+	if id == "" {
+		return nil, ErrInvalidTenantID
+	}
+
+	row, err := s.queries.GetTenant(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrTenantNotFound
+		}
+		return nil, fmt.Errorf("failed to get tenant: %w", err)
+	}
+
+	return dbsqlcTenantToModel(&row)
+}
+
+// UpdateTenant updates an existing tenant.
+// Returns ErrTenantNotFound if the tenant does not exist.
+func (s *PostgresStore) UpdateTenant(ctx context.Context, tenant *Tenant) error {
+	if tenant.ID == "" {
+		return ErrInvalidTenantID
+	}
+
+	exists, err := s.queries.TenantExists(ctx, tenant.ID)
+	if err != nil {
+		return fmt.Errorf("failed to check tenant existence: %w", err)
+	}
+	if !exists {
+		return ErrTenantNotFound
+	}
+
+	tenant.UpdatedAt = time.Now().UTC()
+
+	quotaJSON, err := json.Marshal(tenant.Quota)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tenant quota: %w", err)
+	}
+
+	usageJSON, err := json.Marshal(tenant.Usage)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tenant usage: %w", err)
+	}
+
+	metadataJSON, err := marshalStringMap(tenant.Metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tenant metadata: %w", err)
+	}
+
+	err = s.queries.UpdateTenant(ctx, dbsqlc.UpdateTenantParams{
+		ID:           tenant.ID,
+		Name:         tenant.Name,
+		Description:  tenant.Description,
+		Status:       string(tenant.Status),
+		Quota:        quotaJSON,
+		Usage:        usageJSON,
+		ContactEmail: tenant.ContactEmail,
+		Metadata:     metadataJSON,
+		UpdatedAt:    tenant.UpdatedAt,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update tenant: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteTenant deletes a tenant by ID.
+// Returns ErrTenantNotFound if the tenant does not exist.
+func (s *PostgresStore) DeleteTenant(ctx context.Context, id string) error {
+	if id == "" {
+		return ErrInvalidTenantID
+	}
+
+	rowsAffected, err := s.queries.DeleteTenant(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete tenant: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrTenantNotFound
+	}
+
+	return nil
+}
+
+// ListTenants retrieves all tenants.
+// Returns an empty slice if no tenants exist.
+func (s *PostgresStore) ListTenants(ctx context.Context) ([]*Tenant, error) {
+	rows, err := s.queries.ListTenants(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tenants: %w", err)
+	}
+
+	return dbsqlcTenantsToModels(rows)
+}
+
+// IncrementUsage atomically increments a usage counter for a tenant.
+func (s *PostgresStore) IncrementUsage(ctx context.Context, tenantID, usageType string) error {
+	if tenantID == "" {
+		return ErrInvalidTenantID
+	}
+
+	exists, err := s.queries.TenantExists(ctx, tenantID)
+	if err != nil {
+		return fmt.Errorf("failed to check tenant existence: %w", err)
+	}
+	if !exists {
+		return ErrTenantNotFound
+	}
+
+	err = s.queries.IncrementTenantUsage(ctx, dbsqlc.IncrementTenantUsageParams{
+		ID:      tenantID,
+		Column2: usageType,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to increment tenant usage: %w", err)
+	}
+
+	return nil
+}
+
+// DecrementUsage atomically decrements a usage counter for a tenant.
+func (s *PostgresStore) DecrementUsage(ctx context.Context, tenantID, usageType string) error {
+	if tenantID == "" {
+		return ErrInvalidTenantID
+	}
+
+	exists, err := s.queries.TenantExists(ctx, tenantID)
+	if err != nil {
+		return fmt.Errorf("failed to check tenant existence: %w", err)
+	}
+	if !exists {
+		return ErrTenantNotFound
+	}
+
+	err = s.queries.DecrementTenantUsage(ctx, dbsqlc.DecrementTenantUsageParams{
+		ID:      tenantID,
+		Column2: usageType,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to decrement tenant usage: %w", err)
+	}
+
+	return nil
+}
+
+// --- UserStore ---
+
+// CreateUser creates a new user.
+// Returns ErrUserExists if a user with the same ID already exists.
+func (s *PostgresStore) CreateUser(ctx context.Context, user *TenantUser) error {
+	if user.ID == "" {
+		return ErrInvalidUserID
+	}
+
+	now := time.Now().UTC()
+	user.CreatedAt = now
+	user.UpdatedAt = now
+
+	err := s.queries.CreateUser(ctx, dbsqlc.CreateUserParams{
+		ID:            user.ID,
+		TenantID:      user.TenantID,
+		Subject:       user.Subject,
+		CommonName:    user.CommonName,
+		Email:         user.Email,
+		OauthSubject:  user.OAuthSubject,
+		OauthProvider: user.OAuthProvider,
+		RoleID:        user.RoleID,
+		IsActive:      user.IsActive,
+		LastLoginAt:   timeToTimestamptz(user.LastLoginAt),
+		CreatedAt:     user.CreatedAt,
+		UpdatedAt:     user.UpdatedAt,
+	})
+	if err != nil {
+		if isPgUniqueViolation(err) {
+			return ErrUserExists
+		}
+		return fmt.Errorf("failed to create user: %w", err)
+	}
+
+	return nil
+}
+
+// GetUser retrieves a user by ID.
+// Returns ErrUserNotFound if the user does not exist.
+func (s *PostgresStore) GetUser(ctx context.Context, id string) (*TenantUser, error) {
+	if id == "" {
+		return nil, ErrInvalidUserID
+	}
+
+	row, err := s.queries.GetUser(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrUserNotFound
+		}
+		return nil, fmt.Errorf("failed to get user: %w", err)
+	}
+
+	return dbsqlcUserToModel(&row), nil
+}
+
+// GetUserBySubject retrieves a user by certificate subject (mTLS).
+// Returns ErrUserNotFound if no matching user exists.
+func (s *PostgresStore) GetUserBySubject(ctx context.Context, subject string) (*TenantUser, error) {
+	row, err := s.queries.GetUserBySubject(ctx, subject)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrUserNotFound
+		}
+		return nil, fmt.Errorf("failed to get user by subject: %w", err)
+	}
+
+	return dbsqlcUserToModel(&row), nil
+}
+
+// GetUserByOAuthSubject retrieves a user by OAuth2 subject identifier.
+// Returns ErrUserNotFound if no matching user exists.
+func (s *PostgresStore) GetUserByOAuthSubject(ctx context.Context, oauthSubject string) (*TenantUser, error) {
+	row, err := s.queries.GetUserByOAuthSubject(ctx, oauthSubject)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrUserNotFound
+		}
+		return nil, fmt.Errorf("failed to get user by OAuth subject: %w", err)
+	}
+
+	return dbsqlcUserToModel(&row), nil
+}
+
+// GetUserByEmail retrieves a user by email address.
+// Returns ErrUserNotFound if no matching user exists.
+func (s *PostgresStore) GetUserByEmail(ctx context.Context, email string) (*TenantUser, error) {
+	row, err := s.queries.GetUserByEmail(ctx, email)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrUserNotFound
+		}
+		return nil, fmt.Errorf("failed to get user by email: %w", err)
+	}
+
+	return dbsqlcUserToModel(&row), nil
+}
+
+// UpdateUser updates an existing user.
+// Returns ErrUserNotFound if the user does not exist.
+func (s *PostgresStore) UpdateUser(ctx context.Context, user *TenantUser) error {
+	if user.ID == "" {
+		return ErrInvalidUserID
+	}
+
+	exists, err := s.queries.UserExists(ctx, user.ID)
+	if err != nil {
+		return fmt.Errorf("failed to check user existence: %w", err)
+	}
+	if !exists {
+		return ErrUserNotFound
+	}
+
+	user.UpdatedAt = time.Now().UTC()
+
+	err = s.queries.UpdateUser(ctx, dbsqlc.UpdateUserParams{
+		ID:            user.ID,
+		TenantID:      user.TenantID,
+		Subject:       user.Subject,
+		CommonName:    user.CommonName,
+		Email:         user.Email,
+		OauthSubject:  user.OAuthSubject,
+		OauthProvider: user.OAuthProvider,
+		RoleID:        user.RoleID,
+		IsActive:      user.IsActive,
+		UpdatedAt:     user.UpdatedAt,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update user: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteUser deletes a user by ID.
+// Returns ErrUserNotFound if the user does not exist.
+func (s *PostgresStore) DeleteUser(ctx context.Context, id string) error {
+	if id == "" {
+		return ErrInvalidUserID
+	}
+
+	rowsAffected, err := s.queries.DeleteUser(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete user: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrUserNotFound
+	}
+
+	return nil
+}
+
+// ListUsersByTenant retrieves all users for a tenant.
+// Returns an empty slice if no users exist.
+func (s *PostgresStore) ListUsersByTenant(ctx context.Context, tenantID string) ([]*TenantUser, error) {
+	rows, err := s.queries.ListUsersByTenant(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list users by tenant: %w", err)
+	}
+
+	return dbsqlcUsersToModels(rows), nil
+}
+
+// UpdateLastLogin updates the last login timestamp for a user.
+func (s *PostgresStore) UpdateLastLogin(ctx context.Context, userID string) error {
+	if userID == "" {
+		return ErrInvalidUserID
+	}
+
+	err := s.queries.UpdateLastLogin(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("failed to update last login: %w", err)
+	}
+
+	return nil
+}
+
+// --- RoleStore ---
+
+// CreateRole creates a new role.
+// Returns ErrRoleExists if a role with the same ID already exists.
+func (s *PostgresStore) CreateRole(ctx context.Context, role *Role) error {
+	if role.ID == "" {
+		return ErrInvalidRoleID
+	}
+
+	now := time.Now().UTC()
+	role.CreatedAt = now
+	role.UpdatedAt = now
+
+	permsJSON, err := marshalPermissions(role.Permissions)
+	if err != nil {
+		return fmt.Errorf("failed to marshal role permissions: %w", err)
+	}
+
+	err = s.queries.CreateRole(ctx, dbsqlc.CreateRoleParams{
+		ID:          role.ID,
+		Name:        string(role.Name),
+		Type:        string(role.Type),
+		Description: role.Description,
+		Permissions: permsJSON,
+		TenantID:    role.TenantID,
+		CreatedAt:   role.CreatedAt,
+		UpdatedAt:   role.UpdatedAt,
+	})
+	if err != nil {
+		if isPgUniqueViolation(err) {
+			return ErrRoleExists
+		}
+		return fmt.Errorf("failed to create role: %w", err)
+	}
+
+	return nil
+}
+
+// GetRole retrieves a role by ID.
+// Returns ErrRoleNotFound if the role does not exist.
+func (s *PostgresStore) GetRole(ctx context.Context, id string) (*Role, error) {
+	if id == "" {
+		return nil, ErrInvalidRoleID
+	}
+
+	row, err := s.queries.GetRole(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrRoleNotFound
+		}
+		return nil, fmt.Errorf("failed to get role: %w", err)
+	}
+
+	return dbsqlcRoleToModel(&row)
+}
+
+// GetRoleByName retrieves a role by name.
+// Returns ErrRoleNotFound if no matching role exists.
+func (s *PostgresStore) GetRoleByName(ctx context.Context, name RoleName) (*Role, error) {
+	row, err := s.queries.GetRoleByName(ctx, string(name))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrRoleNotFound
+		}
+		return nil, fmt.Errorf("failed to get role by name: %w", err)
+	}
+
+	return dbsqlcRoleToModel(&row)
+}
+
+// UpdateRole updates an existing role.
+// Returns ErrRoleNotFound if the role does not exist.
+func (s *PostgresStore) UpdateRole(ctx context.Context, role *Role) error {
+	if role.ID == "" {
+		return ErrInvalidRoleID
+	}
+
+	exists, err := s.queries.RoleExists(ctx, role.ID)
+	if err != nil {
+		return fmt.Errorf("failed to check role existence: %w", err)
+	}
+	if !exists {
+		return ErrRoleNotFound
+	}
+
+	role.UpdatedAt = time.Now().UTC()
+
+	permsJSON, err := marshalPermissions(role.Permissions)
+	if err != nil {
+		return fmt.Errorf("failed to marshal role permissions: %w", err)
+	}
+
+	err = s.queries.UpdateRole(ctx, dbsqlc.UpdateRoleParams{
+		ID:          role.ID,
+		Name:        string(role.Name),
+		Type:        string(role.Type),
+		Description: role.Description,
+		Permissions: permsJSON,
+		TenantID:    role.TenantID,
+		UpdatedAt:   role.UpdatedAt,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update role: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteRole deletes a role by ID.
+// Returns ErrRoleNotFound if the role does not exist.
+func (s *PostgresStore) DeleteRole(ctx context.Context, id string) error {
+	if id == "" {
+		return ErrInvalidRoleID
+	}
+
+	rowsAffected, err := s.queries.DeleteRole(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete role: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrRoleNotFound
+	}
+
+	return nil
+}
+
+// ListRoles retrieves all roles.
+// Returns an empty slice if no roles exist.
+func (s *PostgresStore) ListRoles(ctx context.Context) ([]*Role, error) {
+	rows, err := s.queries.ListRoles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list roles: %w", err)
+	}
+
+	return dbsqlcRolesToModels(rows)
+}
+
+// ListRolesByTenant retrieves roles for a specific tenant.
+// Includes both global roles and tenant-specific custom roles.
+func (s *PostgresStore) ListRolesByTenant(ctx context.Context, tenantID string) ([]*Role, error) {
+	rows, err := s.queries.ListRolesByTenant(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list roles by tenant: %w", err)
+	}
+
+	return dbsqlcRolesToModels(rows)
+}
+
+// InitializeDefaultRoles creates the default system roles if they don't exist.
+func (s *PostgresStore) InitializeDefaultRoles(ctx context.Context) error {
+	defaults := GetDefaultRoles()
+
+	for _, role := range defaults {
+		exists, err := s.queries.RoleExists(ctx, role.ID)
+		if err != nil {
+			return fmt.Errorf("failed to check default role existence %s: %w", role.ID, err)
+		}
+		if exists {
+			continue
+		}
+
+		if err := s.CreateRole(ctx, role); err != nil {
+			if errors.Is(err, ErrRoleExists) {
+				continue
+			}
+			return fmt.Errorf("failed to create default role %s: %w", role.ID, err)
+		}
+	}
+
+	return nil
+}
+
+// --- AuditStore ---
+
+// LogEvent creates a new audit event.
+func (s *PostgresStore) LogEvent(ctx context.Context, event *AuditEvent) error {
+	detailsJSON, err := marshalStringMap(event.Details)
+	if err != nil {
+		return fmt.Errorf("failed to marshal audit event details: %w", err)
+	}
+
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+
+	err = s.queries.InsertAuditEvent(ctx, dbsqlc.InsertAuditEventParams{
+		ID:           event.ID,
+		Type:         string(event.Type),
+		TenantID:     event.TenantID,
+		UserID:       event.UserID,
+		Subject:      event.Subject,
+		ResourceType: event.ResourceType,
+		ResourceID:   event.ResourceID,
+		Action:       event.Action,
+		Details:      detailsJSON,
+		ClientIp:     event.ClientIP,
+		UserAgent:    event.UserAgent,
+		Timestamp:    event.Timestamp,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to log audit event: %w", err)
+	}
+
+	return nil
+}
+
+// ListEvents retrieves audit events with optional filtering.
+// If tenantID is empty, returns events for all tenants.
+func (s *PostgresStore) ListEvents(ctx context.Context, tenantID string, limit, offset int) ([]*AuditEvent, error) {
+	rows, err := s.queries.ListAuditEvents(ctx, dbsqlc.ListAuditEventsParams{
+		Limit:        safeIntToInt32(limit),
+		Offset:       safeIntToInt32(offset),
+		TenantFilter: tenantID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list audit events: %w", err)
+	}
+
+	return dbsqlcAuditEventsToModels(rows)
+}
+
+// ListEventsByType retrieves audit events of a specific type.
+func (s *PostgresStore) ListEventsByType(ctx context.Context, eventType AuditEventType, limit int) ([]*AuditEvent, error) {
+	rows, err := s.queries.ListAuditEventsByType(ctx, dbsqlc.ListAuditEventsByTypeParams{
+		Type:  string(eventType),
+		Limit: safeIntToInt32(limit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list audit events by type: %w", err)
+	}
+
+	return dbsqlcAuditEventsToModels(rows)
+}
+
+// ListEventsByUser retrieves audit events for a specific user.
+func (s *PostgresStore) ListEventsByUser(ctx context.Context, userID string, limit int) ([]*AuditEvent, error) {
+	rows, err := s.queries.ListAuditEventsByUser(ctx, dbsqlc.ListAuditEventsByUserParams{
+		UserID: userID,
+		Limit:  safeIntToInt32(limit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list audit events by user: %w", err)
+	}
+
+	return dbsqlcAuditEventsToModels(rows)
+}
+
+// --- Conversion helpers ---
+
+// dbsqlcTenantToModel converts a sqlc Tenant to an auth Tenant.
+func dbsqlcTenantToModel(row *dbsqlc.Tenant) (*Tenant, error) {
+	var quota TenantQuota
+	if err := json.Unmarshal(row.Quota, &quota); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal tenant quota: %w", err)
+	}
+
+	var usage TenantUsage
+	if err := json.Unmarshal(row.Usage, &usage); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal tenant usage: %w", err)
+	}
+
+	var metadata map[string]string
+	if len(row.Metadata) > 0 && string(row.Metadata) != "{}" {
+		if err := json.Unmarshal(row.Metadata, &metadata); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal tenant metadata: %w", err)
+		}
+	}
+
+	return &Tenant{
+		ID:           row.ID,
+		Name:         row.Name,
+		Description:  row.Description,
+		Status:       TenantStatus(row.Status),
+		Quota:        quota,
+		Usage:        usage,
+		ContactEmail: row.ContactEmail,
+		Metadata:     metadata,
+		CreatedAt:    row.CreatedAt,
+		UpdatedAt:    row.UpdatedAt,
+	}, nil
+}
+
+// dbsqlcTenantsToModels converts a slice of sqlc Tenants to auth Tenants.
+func dbsqlcTenantsToModels(rows []dbsqlc.Tenant) ([]*Tenant, error) {
+	tenants := make([]*Tenant, 0, len(rows))
+	for i := range rows {
+		tenant, err := dbsqlcTenantToModel(&rows[i])
+		if err != nil {
+			return nil, err
+		}
+		tenants = append(tenants, tenant)
+	}
+	return tenants, nil
+}
+
+// dbsqlcUserToModel converts a sqlc User to an auth TenantUser.
+func dbsqlcUserToModel(row *dbsqlc.User) *TenantUser {
+	user := &TenantUser{
+		ID:            row.ID,
+		TenantID:      row.TenantID,
+		Subject:       row.Subject,
+		CommonName:    row.CommonName,
+		Email:         row.Email,
+		OAuthSubject:  row.OauthSubject,
+		OAuthProvider: row.OauthProvider,
+		RoleID:        row.RoleID,
+		IsActive:      row.IsActive,
+		CreatedAt:     row.CreatedAt,
+		UpdatedAt:     row.UpdatedAt,
+	}
+	if row.LastLoginAt.Valid {
+		user.LastLoginAt = row.LastLoginAt.Time
+	}
+	return user
+}
+
+// dbsqlcUsersToModels converts a slice of sqlc Users to auth TenantUsers.
+func dbsqlcUsersToModels(rows []dbsqlc.User) []*TenantUser {
+	users := make([]*TenantUser, 0, len(rows))
+	for i := range rows {
+		users = append(users, dbsqlcUserToModel(&rows[i]))
+	}
+	return users
+}
+
+// dbsqlcRoleToModel converts a sqlc Role to an auth Role.
+func dbsqlcRoleToModel(row *dbsqlc.Role) (*Role, error) {
+	perms, err := unmarshalPermissions(row.Permissions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal role permissions: %w", err)
+	}
+
+	return &Role{
+		ID:          row.ID,
+		Name:        RoleName(row.Name),
+		Type:        RoleType(row.Type),
+		Description: row.Description,
+		Permissions: perms,
+		TenantID:    row.TenantID,
+		CreatedAt:   row.CreatedAt,
+		UpdatedAt:   row.UpdatedAt,
+	}, nil
+}
+
+// dbsqlcRolesToModels converts a slice of sqlc Roles to auth Roles.
+func dbsqlcRolesToModels(rows []dbsqlc.Role) ([]*Role, error) {
+	roles := make([]*Role, 0, len(rows))
+	for i := range rows {
+		role, err := dbsqlcRoleToModel(&rows[i])
+		if err != nil {
+			return nil, err
+		}
+		roles = append(roles, role)
+	}
+	return roles, nil
+}
+
+// dbsqlcAuditEventToModel converts a sqlc AuditEvent to an auth AuditEvent.
+func dbsqlcAuditEventToModel(row *dbsqlc.AuditEvent) (*AuditEvent, error) {
+	var details map[string]string
+	if len(row.Details) > 0 && string(row.Details) != "{}" && string(row.Details) != "null" {
+		if err := json.Unmarshal(row.Details, &details); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal audit event details: %w", err)
+		}
+	}
+
+	return &AuditEvent{
+		ID:           row.ID,
+		Type:         AuditEventType(row.Type),
+		TenantID:     row.TenantID,
+		UserID:       row.UserID,
+		Subject:      row.Subject,
+		ResourceType: row.ResourceType,
+		ResourceID:   row.ResourceID,
+		Action:       row.Action,
+		Details:      details,
+		ClientIP:     row.ClientIp,
+		UserAgent:    row.UserAgent,
+		Timestamp:    row.Timestamp,
+	}, nil
+}
+
+// dbsqlcAuditEventsToModels converts a slice of sqlc AuditEvents to auth AuditEvents.
+func dbsqlcAuditEventsToModels(rows []dbsqlc.AuditEvent) ([]*AuditEvent, error) {
+	events := make([]*AuditEvent, 0, len(rows))
+	for i := range rows {
+		event, err := dbsqlcAuditEventToModel(&rows[i])
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+// --- JSON helpers ---
+
+// marshalPermissions converts a Permission slice to JSON.
+func marshalPermissions(perms []Permission) (json.RawMessage, error) {
+	strs := make([]string, len(perms))
+	for i, p := range perms {
+		strs[i] = string(p)
+	}
+	data, err := json.Marshal(strs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal permissions: %w", err)
+	}
+	return data, nil
+}
+
+// unmarshalPermissions converts JSON to a Permission slice.
+func unmarshalPermissions(data json.RawMessage) ([]Permission, error) {
+	var strs []string
+	if err := json.Unmarshal(data, &strs); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal permissions: %w", err)
+	}
+	perms := make([]Permission, len(strs))
+	for i, s := range strs {
+		perms[i] = Permission(s)
+	}
+	return perms, nil
+}
+
+// marshalStringMap converts a map[string]string to JSON, defaulting to "{}".
+func marshalStringMap(m map[string]string) (json.RawMessage, error) {
+	if m == nil {
+		return json.RawMessage("{}"), nil
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal string map: %w", err)
+	}
+	return data, nil
+}
+
+// timeToTimestamptz converts a time.Time to pgtype.Timestamptz.
+// Zero time results in an invalid (NULL) timestamp.
+func timeToTimestamptz(t time.Time) pgtype.Timestamptz {
+	if t.IsZero() {
+		return pgtype.Timestamptz{Valid: false}
+	}
+	return pgtype.Timestamptz{Time: t, Valid: true}
+}
+
+// safeIntToInt32 safely converts int to int32 with clamping at math.MaxInt32.
+func safeIntToInt32(v int) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v)
+}
+
+// isPgUniqueViolation checks if the error is a PostgreSQL unique constraint violation.
+func isPgUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == pgUniqueViolation
+	}
+	return false
+}

--- a/internal/auth/postgres_test.go
+++ b/internal/auth/postgres_test.go
@@ -1,0 +1,987 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/piwi3910/netweave/internal/auth"
+	"github.com/piwi3910/netweave/internal/database"
+)
+
+const (
+	authPgTestImage    = "postgres:16-alpine"
+	authPgTestDB       = "netweave_auth_test"
+	authPgTestUser     = "testuser"
+	authPgTestPassword = "testpass"
+)
+
+// setupAuthPgContainer starts a PostgreSQL container with migrations for auth tests.
+func setupAuthPgContainer(t *testing.T) *database.DB {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image:        authPgTestImage,
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_USER":     authPgTestUser,
+			"POSTGRES_PASSWORD": authPgTestPassword,
+			"POSTGRES_DB":       authPgTestDB,
+		},
+		WaitingFor: wait.ForAll(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+			wait.ForListeningPort("5432/tcp"),
+		).WithDeadline(60 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err, "failed to start PostgreSQL container")
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+
+	mappedPort, err := container.MappedPort(ctx, "5432/tcp")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if termErr := container.Terminate(ctx); termErr != nil {
+			t.Logf("failed to terminate PostgreSQL container: %v", termErr)
+		}
+	})
+
+	cfg := &database.PostgresConfig{
+		Host:           host,
+		Port:           mappedPort.Int(),
+		Database:       authPgTestDB,
+		User:           authPgTestUser,
+		PasswordEnvVar: "TEST_PG_PASSWORD",
+		SSLMode:        "disable",
+		MaxConns:       5,
+		MinConns:       1,
+	}
+
+	db, err := database.New(ctx, cfg, authPgTestPassword)
+	require.NoError(t, err)
+
+	err = database.Migrate(ctx, db.Pool)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func newTestAuthStore(t *testing.T, db *database.DB) *auth.PostgresStore {
+	t.Helper()
+	return auth.NewPostgresStore(db)
+}
+
+// --- Tenant Tests ---
+
+func TestPostgresStore_CreateTenant(t *testing.T) {
+	db := setupAuthPgContainer(t)
+
+	tests := []struct {
+		name    string
+		tenant  *auth.Tenant
+		wantErr error
+	}{
+		{
+			name: "valid tenant",
+			tenant: &auth.Tenant{
+				ID:           "tenant-create-1",
+				Name:         "ACME Corp",
+				Description:  "Test tenant",
+				Status:       auth.TenantStatusActive,
+				Quota:        auth.DefaultQuota(),
+				ContactEmail: "admin@acme.com",
+				Metadata:     map[string]string{"env": "test"},
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "empty ID",
+			tenant:  &auth.Tenant{ID: "", Name: "No ID"},
+			wantErr: auth.ErrInvalidTenantID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestAuthStore(t, db)
+			ctx := context.Background()
+
+			err := store.CreateTenant(ctx, tt.tenant)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.False(t, tt.tenant.CreatedAt.IsZero())
+			}
+		})
+	}
+}
+
+func TestPostgresStore_CreateTenantDuplicate(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	tenant := &auth.Tenant{
+		ID:     "tenant-dup-1",
+		Name:   "Dup Tenant",
+		Status: auth.TenantStatusActive,
+		Quota:  auth.DefaultQuota(),
+	}
+
+	require.NoError(t, store.CreateTenant(ctx, tenant))
+
+	err := store.CreateTenant(ctx, tenant)
+	require.ErrorIs(t, err, auth.ErrTenantExists)
+}
+
+func TestPostgresStore_GetTenant(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	original := &auth.Tenant{
+		ID:           "tenant-get-1",
+		Name:         "Get Tenant",
+		Description:  "A test tenant for get",
+		Status:       auth.TenantStatusActive,
+		Quota:        auth.DefaultQuota(),
+		ContactEmail: "test@example.com",
+		Metadata:     map[string]string{"key": "value"},
+	}
+	require.NoError(t, store.CreateTenant(ctx, original))
+
+	tests := []struct {
+		name    string
+		id      string
+		wantErr error
+	}{
+		{name: "existing tenant", id: "tenant-get-1", wantErr: nil},
+		{name: "not found", id: "tenant-nonexistent", wantErr: auth.ErrTenantNotFound},
+		{name: "empty ID", id: "", wantErr: auth.ErrInvalidTenantID},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := store.GetTenant(ctx, tt.id)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				assert.Equal(t, original.ID, got.ID)
+				assert.Equal(t, original.Name, got.Name)
+				assert.Equal(t, original.Description, got.Description)
+				assert.Equal(t, original.Status, got.Status)
+				assert.Equal(t, original.Quota, got.Quota)
+				assert.Equal(t, original.ContactEmail, got.ContactEmail)
+				assert.Equal(t, original.Metadata, got.Metadata)
+			}
+		})
+	}
+}
+
+func TestPostgresStore_UpdateTenant(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	tenant := &auth.Tenant{
+		ID:     "tenant-update-1",
+		Name:   "Original Name",
+		Status: auth.TenantStatusActive,
+		Quota:  auth.DefaultQuota(),
+	}
+	require.NoError(t, store.CreateTenant(ctx, tenant))
+
+	tests := []struct {
+		name    string
+		update  *auth.Tenant
+		wantErr error
+	}{
+		{
+			name: "valid update",
+			update: &auth.Tenant{
+				ID:     "tenant-update-1",
+				Name:   "Updated Name",
+				Status: auth.TenantStatusSuspended,
+				Quota:  auth.DefaultQuota(),
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "not found",
+			update:  &auth.Tenant{ID: "tenant-nonexistent", Name: "X"},
+			wantErr: auth.ErrTenantNotFound,
+		},
+		{
+			name:    "empty ID",
+			update:  &auth.Tenant{ID: ""},
+			wantErr: auth.ErrInvalidTenantID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := store.UpdateTenant(ctx, tt.update)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				got, getErr := store.GetTenant(ctx, tt.update.ID)
+				require.NoError(t, getErr)
+				assert.Equal(t, "Updated Name", got.Name)
+				assert.Equal(t, auth.TenantStatusSuspended, got.Status)
+			}
+		})
+	}
+}
+
+func TestPostgresStore_DeleteTenant(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	tenant := &auth.Tenant{
+		ID:     "tenant-delete-1",
+		Name:   "Delete Me",
+		Status: auth.TenantStatusActive,
+		Quota:  auth.DefaultQuota(),
+	}
+	require.NoError(t, store.CreateTenant(ctx, tenant))
+
+	tests := []struct {
+		name    string
+		id      string
+		wantErr error
+	}{
+		{name: "existing tenant", id: "tenant-delete-1", wantErr: nil},
+		{name: "not found", id: "tenant-nonexistent", wantErr: auth.ErrTenantNotFound},
+		{name: "empty ID", id: "", wantErr: auth.ErrInvalidTenantID},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := store.DeleteTenant(ctx, tt.id)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				_, getErr := store.GetTenant(ctx, tt.id)
+				assert.ErrorIs(t, getErr, auth.ErrTenantNotFound)
+			}
+		})
+	}
+}
+
+func TestPostgresStore_ListTenants(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	tenants, err := store.ListTenants(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, tenants)
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, store.CreateTenant(ctx, &auth.Tenant{
+			ID:     "tenant-list-" + string(rune('a'+i)),
+			Name:   "List Tenant",
+			Status: auth.TenantStatusActive,
+			Quota:  auth.DefaultQuota(),
+		}))
+	}
+
+	tenants, err = store.ListTenants(ctx)
+	require.NoError(t, err)
+	assert.Len(t, tenants, 3)
+}
+
+func TestPostgresStore_IncrementDecrementUsage(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	tenant := &auth.Tenant{
+		ID:     "tenant-usage-1",
+		Name:   "Usage Tenant",
+		Status: auth.TenantStatusActive,
+		Quota:  auth.DefaultQuota(),
+	}
+	require.NoError(t, store.CreateTenant(ctx, tenant))
+
+	// Increment subscriptions usage.
+	require.NoError(t, store.IncrementUsage(ctx, "tenant-usage-1", "subscriptions"))
+	require.NoError(t, store.IncrementUsage(ctx, "tenant-usage-1", "subscriptions"))
+
+	got, err := store.GetTenant(ctx, "tenant-usage-1")
+	require.NoError(t, err)
+	assert.Equal(t, 2, got.Usage.Subscriptions)
+
+	// Decrement.
+	require.NoError(t, store.DecrementUsage(ctx, "tenant-usage-1", "subscriptions"))
+
+	got, err = store.GetTenant(ctx, "tenant-usage-1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.Usage.Subscriptions)
+
+	// Decrement to zero (not below).
+	require.NoError(t, store.DecrementUsage(ctx, "tenant-usage-1", "subscriptions"))
+	require.NoError(t, store.DecrementUsage(ctx, "tenant-usage-1", "subscriptions"))
+
+	got, err = store.GetTenant(ctx, "tenant-usage-1")
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.Usage.Subscriptions)
+
+	// Error cases.
+	require.ErrorIs(t, store.IncrementUsage(ctx, "", "subscriptions"), auth.ErrInvalidTenantID)
+	require.ErrorIs(t, store.IncrementUsage(ctx, "nonexistent", "subscriptions"), auth.ErrTenantNotFound)
+	require.ErrorIs(t, store.DecrementUsage(ctx, "", "subscriptions"), auth.ErrInvalidTenantID)
+	require.ErrorIs(t, store.DecrementUsage(ctx, "nonexistent", "subscriptions"), auth.ErrTenantNotFound)
+}
+
+// --- User Tests ---
+
+func TestPostgresStore_CreateUser(t *testing.T) {
+	db := setupAuthPgContainer(t)
+
+	tests := []struct {
+		name    string
+		user    *auth.TenantUser
+		wantErr error
+	}{
+		{
+			name: "valid mTLS user",
+			user: &auth.TenantUser{
+				ID:         "user-create-1",
+				TenantID:   "tenant-1",
+				Subject:    "CN=alice,O=ACME",
+				CommonName: "alice",
+				Email:      "alice@acme.com",
+				RoleID:     "role-operator",
+				IsActive:   true,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid OAuth user",
+			user: &auth.TenantUser{
+				ID:            "user-create-2",
+				TenantID:      "tenant-1",
+				OAuthSubject:  "keycloak-123",
+				OAuthProvider: "keycloak",
+				CommonName:    "bob",
+				Email:         "bob@acme.com",
+				RoleID:        "role-viewer",
+				IsActive:      true,
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "empty ID",
+			user:    &auth.TenantUser{ID: ""},
+			wantErr: auth.ErrInvalidUserID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestAuthStore(t, db)
+			ctx := context.Background()
+
+			err := store.CreateUser(ctx, tt.user)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.False(t, tt.user.CreatedAt.IsZero())
+			}
+		})
+	}
+}
+
+func TestPostgresStore_CreateUserDuplicate(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	user := &auth.TenantUser{
+		ID:         "user-dup-1",
+		TenantID:   "tenant-1",
+		CommonName: "alice",
+		RoleID:     "role-1",
+		IsActive:   true,
+	}
+
+	require.NoError(t, store.CreateUser(ctx, user))
+
+	err := store.CreateUser(ctx, user)
+	require.ErrorIs(t, err, auth.ErrUserExists)
+}
+
+func TestPostgresStore_GetUser(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	user := &auth.TenantUser{
+		ID:            "user-get-1",
+		TenantID:      "tenant-1",
+		Subject:       "CN=charlie,O=ACME",
+		CommonName:    "charlie",
+		Email:         "charlie@acme.com",
+		OAuthSubject:  "oauth-charlie",
+		OAuthProvider: "keycloak",
+		RoleID:        "role-admin",
+		IsActive:      true,
+	}
+	require.NoError(t, store.CreateUser(ctx, user))
+
+	got, err := store.GetUser(ctx, "user-get-1")
+	require.NoError(t, err)
+	assert.Equal(t, user.ID, got.ID)
+	assert.Equal(t, user.TenantID, got.TenantID)
+	assert.Equal(t, user.Subject, got.Subject)
+	assert.Equal(t, user.CommonName, got.CommonName)
+	assert.Equal(t, user.Email, got.Email)
+	assert.Equal(t, user.OAuthSubject, got.OAuthSubject)
+	assert.Equal(t, user.OAuthProvider, got.OAuthProvider)
+	assert.Equal(t, user.RoleID, got.RoleID)
+	assert.Equal(t, user.IsActive, got.IsActive)
+
+	_, err = store.GetUser(ctx, "user-nonexistent")
+	require.ErrorIs(t, err, auth.ErrUserNotFound)
+
+	_, err = store.GetUser(ctx, "")
+	require.ErrorIs(t, err, auth.ErrInvalidUserID)
+}
+
+func TestPostgresStore_GetUserBySubject(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	user := &auth.TenantUser{
+		ID:         "user-subject-1",
+		TenantID:   "tenant-1",
+		Subject:    "CN=subjectuser,O=ACME",
+		CommonName: "subjectuser",
+		RoleID:     "role-1",
+		IsActive:   true,
+	}
+	require.NoError(t, store.CreateUser(ctx, user))
+
+	got, err := store.GetUserBySubject(ctx, "CN=subjectuser,O=ACME")
+	require.NoError(t, err)
+	assert.Equal(t, user.ID, got.ID)
+
+	_, err = store.GetUserBySubject(ctx, "CN=nonexistent")
+	require.ErrorIs(t, err, auth.ErrUserNotFound)
+}
+
+func TestPostgresStore_GetUserByOAuthSubject(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	user := &auth.TenantUser{
+		ID:            "user-oauth-1",
+		TenantID:      "tenant-1",
+		OAuthSubject:  "kc-unique-id-123",
+		OAuthProvider: "keycloak",
+		CommonName:    "oauthuser",
+		RoleID:        "role-1",
+		IsActive:      true,
+	}
+	require.NoError(t, store.CreateUser(ctx, user))
+
+	got, err := store.GetUserByOAuthSubject(ctx, "kc-unique-id-123")
+	require.NoError(t, err)
+	assert.Equal(t, user.ID, got.ID)
+
+	_, err = store.GetUserByOAuthSubject(ctx, "nonexistent-oauth")
+	require.ErrorIs(t, err, auth.ErrUserNotFound)
+}
+
+func TestPostgresStore_GetUserByEmail(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	user := &auth.TenantUser{
+		ID:         "user-email-1",
+		TenantID:   "tenant-1",
+		Email:      "unique@acme.com",
+		CommonName: "emailuser",
+		RoleID:     "role-1",
+		IsActive:   true,
+	}
+	require.NoError(t, store.CreateUser(ctx, user))
+
+	got, err := store.GetUserByEmail(ctx, "unique@acme.com")
+	require.NoError(t, err)
+	assert.Equal(t, user.ID, got.ID)
+
+	_, err = store.GetUserByEmail(ctx, "missing@acme.com")
+	require.ErrorIs(t, err, auth.ErrUserNotFound)
+}
+
+func TestPostgresStore_UpdateUser(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	user := &auth.TenantUser{
+		ID:         "user-update-1",
+		TenantID:   "tenant-1",
+		CommonName: "updateme",
+		RoleID:     "role-viewer",
+		IsActive:   true,
+	}
+	require.NoError(t, store.CreateUser(ctx, user))
+
+	user.CommonName = "updated"
+	user.RoleID = "role-admin"
+	user.IsActive = false
+
+	require.NoError(t, store.UpdateUser(ctx, user))
+
+	got, err := store.GetUser(ctx, "user-update-1")
+	require.NoError(t, err)
+	assert.Equal(t, "updated", got.CommonName)
+	assert.Equal(t, "role-admin", got.RoleID)
+	assert.False(t, got.IsActive)
+
+	err = store.UpdateUser(ctx, &auth.TenantUser{ID: "nonexistent"})
+	require.ErrorIs(t, err, auth.ErrUserNotFound)
+
+	err = store.UpdateUser(ctx, &auth.TenantUser{ID: ""})
+	require.ErrorIs(t, err, auth.ErrInvalidUserID)
+}
+
+func TestPostgresStore_DeleteUser(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	user := &auth.TenantUser{
+		ID: "user-delete-1", TenantID: "tenant-1",
+		CommonName: "deleteme", RoleID: "role-1", IsActive: true,
+	}
+	require.NoError(t, store.CreateUser(ctx, user))
+
+	require.NoError(t, store.DeleteUser(ctx, "user-delete-1"))
+
+	_, err := store.GetUser(ctx, "user-delete-1")
+	assert.ErrorIs(t, err, auth.ErrUserNotFound)
+
+	require.ErrorIs(t, store.DeleteUser(ctx, "nonexistent"), auth.ErrUserNotFound)
+	require.ErrorIs(t, store.DeleteUser(ctx, ""), auth.ErrInvalidUserID)
+}
+
+func TestPostgresStore_ListUsersByTenant(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, store.CreateUser(ctx, &auth.TenantUser{
+			ID: "user-list-" + string(rune('a'+i)), TenantID: "tenant-list",
+			CommonName: "user", RoleID: "role-1", IsActive: true,
+		}))
+	}
+
+	users, err := store.ListUsersByTenant(ctx, "tenant-list")
+	require.NoError(t, err)
+	assert.Len(t, users, 3)
+
+	users, err = store.ListUsersByTenant(ctx, "tenant-empty")
+	require.NoError(t, err)
+	assert.Empty(t, users)
+}
+
+func TestPostgresStore_UpdateLastLogin(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	user := &auth.TenantUser{
+		ID: "user-login-1", TenantID: "tenant-1",
+		CommonName: "loginuser", RoleID: "role-1", IsActive: true,
+	}
+	require.NoError(t, store.CreateUser(ctx, user))
+
+	require.NoError(t, store.UpdateLastLogin(ctx, "user-login-1"))
+
+	got, err := store.GetUser(ctx, "user-login-1")
+	require.NoError(t, err)
+	assert.False(t, got.LastLoginAt.IsZero())
+
+	require.ErrorIs(t, store.UpdateLastLogin(ctx, ""), auth.ErrInvalidUserID)
+}
+
+// --- Role Tests ---
+
+func TestPostgresStore_CreateRole(t *testing.T) {
+	db := setupAuthPgContainer(t)
+
+	tests := []struct {
+		name    string
+		role    *auth.Role
+		wantErr error
+	}{
+		{
+			name: "valid role",
+			role: &auth.Role{
+				ID:          "role-create-1",
+				Name:        "custom-role",
+				Type:        auth.RoleTypeTenant,
+				Description: "A custom role",
+				Permissions: []auth.Permission{auth.PermissionSubscriptionRead},
+				TenantID:    "tenant-1",
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "empty ID",
+			role:    &auth.Role{ID: ""},
+			wantErr: auth.ErrInvalidRoleID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestAuthStore(t, db)
+			ctx := context.Background()
+
+			err := store.CreateRole(ctx, tt.role)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.False(t, tt.role.CreatedAt.IsZero())
+			}
+		})
+	}
+}
+
+func TestPostgresStore_CreateRoleDuplicate(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	role := &auth.Role{
+		ID:          "role-dup-1",
+		Name:        "dup-role",
+		Type:        auth.RoleTypeTenant,
+		Permissions: []auth.Permission{auth.PermissionSubscriptionRead},
+	}
+
+	require.NoError(t, store.CreateRole(ctx, role))
+
+	err := store.CreateRole(ctx, role)
+	require.ErrorIs(t, err, auth.ErrRoleExists)
+}
+
+func TestPostgresStore_GetRole(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	role := &auth.Role{
+		ID:          "role-get-1",
+		Name:        "get-role",
+		Type:        auth.RoleTypePlatform,
+		Description: "For get test",
+		Permissions: []auth.Permission{auth.PermissionSubscriptionRead, auth.PermissionResourcePoolRead},
+	}
+	require.NoError(t, store.CreateRole(ctx, role))
+
+	got, err := store.GetRole(ctx, "role-get-1")
+	require.NoError(t, err)
+	assert.Equal(t, role.ID, got.ID)
+	assert.Equal(t, role.Name, got.Name)
+	assert.Equal(t, role.Type, got.Type)
+	assert.Equal(t, role.Description, got.Description)
+	assert.Equal(t, role.Permissions, got.Permissions)
+
+	_, err = store.GetRole(ctx, "role-nonexistent")
+	require.ErrorIs(t, err, auth.ErrRoleNotFound)
+
+	_, err = store.GetRole(ctx, "")
+	require.ErrorIs(t, err, auth.ErrInvalidRoleID)
+}
+
+func TestPostgresStore_GetRoleByName(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	role := &auth.Role{
+		ID:          "role-byname-1",
+		Name:        "named-role",
+		Type:        auth.RoleTypeTenant,
+		Permissions: []auth.Permission{auth.PermissionSubscriptionRead},
+	}
+	require.NoError(t, store.CreateRole(ctx, role))
+
+	got, err := store.GetRoleByName(ctx, "named-role")
+	require.NoError(t, err)
+	assert.Equal(t, role.ID, got.ID)
+
+	_, err = store.GetRoleByName(ctx, "nonexistent-role")
+	require.ErrorIs(t, err, auth.ErrRoleNotFound)
+}
+
+func TestPostgresStore_UpdateRole(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	role := &auth.Role{
+		ID:          "role-update-1",
+		Name:        "update-me-role",
+		Type:        auth.RoleTypeTenant,
+		Permissions: []auth.Permission{auth.PermissionSubscriptionRead},
+	}
+	require.NoError(t, store.CreateRole(ctx, role))
+
+	role.Description = "Updated description"
+	role.Permissions = append(role.Permissions, auth.PermissionResourcePoolRead)
+
+	require.NoError(t, store.UpdateRole(ctx, role))
+
+	got, err := store.GetRole(ctx, "role-update-1")
+	require.NoError(t, err)
+	assert.Equal(t, "Updated description", got.Description)
+	assert.Len(t, got.Permissions, 2)
+
+	err = store.UpdateRole(ctx, &auth.Role{ID: "nonexistent"})
+	require.ErrorIs(t, err, auth.ErrRoleNotFound)
+
+	err = store.UpdateRole(ctx, &auth.Role{ID: ""})
+	require.ErrorIs(t, err, auth.ErrInvalidRoleID)
+}
+
+func TestPostgresStore_DeleteRole(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	role := &auth.Role{
+		ID: "role-delete-1", Name: "delete-role",
+		Type: auth.RoleTypeTenant, Permissions: []auth.Permission{},
+	}
+	require.NoError(t, store.CreateRole(ctx, role))
+
+	require.NoError(t, store.DeleteRole(ctx, "role-delete-1"))
+
+	_, err := store.GetRole(ctx, "role-delete-1")
+	assert.ErrorIs(t, err, auth.ErrRoleNotFound)
+
+	require.ErrorIs(t, store.DeleteRole(ctx, "nonexistent"), auth.ErrRoleNotFound)
+	require.ErrorIs(t, store.DeleteRole(ctx, ""), auth.ErrInvalidRoleID)
+}
+
+func TestPostgresStore_ListRoles(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, store.CreateRole(ctx, &auth.Role{
+			ID: "role-list-" + string(rune('a'+i)), Name: auth.RoleName("list-role-" + string(rune('a'+i))),
+			Type: auth.RoleTypeTenant, Permissions: []auth.Permission{auth.PermissionSubscriptionRead},
+		}))
+	}
+
+	roles, err := store.ListRoles(ctx)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(roles), 3)
+}
+
+func TestPostgresStore_ListRolesByTenant(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	// Create a global role (empty tenant_id) and a tenant-specific role.
+	require.NoError(t, store.CreateRole(ctx, &auth.Role{
+		ID: "role-global-1", Name: "global-role-1",
+		Type: auth.RoleTypePlatform, Permissions: []auth.Permission{auth.PermissionSubscriptionRead},
+	}))
+	require.NoError(t, store.CreateRole(ctx, &auth.Role{
+		ID: "role-tenantx-1", Name: "tenantx-role-1",
+		Type: auth.RoleTypeTenant, TenantID: "tenant-x",
+		Permissions: []auth.Permission{auth.PermissionSubscriptionRead},
+	}))
+	require.NoError(t, store.CreateRole(ctx, &auth.Role{
+		ID: "role-tenanty-1", Name: "tenanty-role-1",
+		Type: auth.RoleTypeTenant, TenantID: "tenant-y",
+		Permissions: []auth.Permission{auth.PermissionSubscriptionRead},
+	}))
+
+	// ListRolesByTenant for "tenant-x" should include global + tenant-x roles.
+	roles, err := store.ListRolesByTenant(ctx, "tenant-x")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(roles), 2)
+}
+
+func TestPostgresStore_InitializeDefaultRoles(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	// Initialize default roles.
+	require.NoError(t, store.InitializeDefaultRoles(ctx))
+
+	// Verify all default roles exist.
+	defaults := auth.GetDefaultRoles()
+	for _, d := range defaults {
+		got, err := store.GetRole(ctx, d.ID)
+		require.NoError(t, err)
+		assert.Equal(t, d.Name, got.Name)
+	}
+
+	// Idempotent: calling again should not error.
+	require.NoError(t, store.InitializeDefaultRoles(ctx))
+}
+
+// --- Audit Tests ---
+
+func TestPostgresStore_LogEvent(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	event := &auth.AuditEvent{
+		ID:           "audit-1",
+		Type:         auth.AuditEventTenantCreated,
+		TenantID:     "tenant-1",
+		UserID:       "user-1",
+		Subject:      "CN=alice",
+		ResourceType: "tenant",
+		ResourceID:   "tenant-1",
+		Action:       "create",
+		Details:      map[string]string{"name": "ACME"},
+		ClientIP:     "10.0.0.1",
+		UserAgent:    "test-agent",
+		Timestamp:    time.Now().UTC(),
+	}
+
+	require.NoError(t, store.LogEvent(ctx, event))
+}
+
+func TestPostgresStore_ListEvents(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	// Log events for different tenants.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, store.LogEvent(ctx, &auth.AuditEvent{
+			ID:       "audit-list-" + string(rune('a'+i)),
+			Type:     auth.AuditEventTenantCreated,
+			TenantID: "tenant-events",
+			Action:   "create",
+		}))
+	}
+	require.NoError(t, store.LogEvent(ctx, &auth.AuditEvent{
+		ID:       "audit-list-other",
+		Type:     auth.AuditEventUserCreated,
+		TenantID: "tenant-other",
+		Action:   "create",
+	}))
+
+	// List all events (empty tenant filter).
+	events, err := store.ListEvents(ctx, "", 100, 0)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(events), 6)
+
+	// List by tenant.
+	events, err = store.ListEvents(ctx, "tenant-events", 100, 0)
+	require.NoError(t, err)
+	assert.Len(t, events, 5)
+
+	// Pagination.
+	events, err = store.ListEvents(ctx, "tenant-events", 2, 0)
+	require.NoError(t, err)
+	assert.Len(t, events, 2)
+}
+
+func TestPostgresStore_ListEventsByType(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	require.NoError(t, store.LogEvent(ctx, &auth.AuditEvent{
+		ID: "audit-type-1", Type: auth.AuditEventAuthSuccess, Action: "login",
+	}))
+	require.NoError(t, store.LogEvent(ctx, &auth.AuditEvent{
+		ID: "audit-type-2", Type: auth.AuditEventAuthFailure, Action: "login",
+	}))
+	require.NoError(t, store.LogEvent(ctx, &auth.AuditEvent{
+		ID: "audit-type-3", Type: auth.AuditEventAuthSuccess, Action: "login",
+	}))
+
+	events, err := store.ListEventsByType(ctx, auth.AuditEventAuthSuccess, 100)
+	require.NoError(t, err)
+	assert.Len(t, events, 2)
+}
+
+func TestPostgresStore_ListEventsByUser(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	require.NoError(t, store.LogEvent(ctx, &auth.AuditEvent{
+		ID: "audit-user-1", Type: auth.AuditEventAuthSuccess, UserID: "user-audit-1", Action: "login",
+	}))
+	require.NoError(t, store.LogEvent(ctx, &auth.AuditEvent{
+		ID: "audit-user-2", Type: auth.AuditEventAuthSuccess, UserID: "user-audit-1", Action: "login",
+	}))
+	require.NoError(t, store.LogEvent(ctx, &auth.AuditEvent{
+		ID: "audit-user-3", Type: auth.AuditEventAuthSuccess, UserID: "user-audit-2", Action: "login",
+	}))
+
+	events, err := store.ListEventsByUser(ctx, "user-audit-1", 100)
+	require.NoError(t, err)
+	assert.Len(t, events, 2)
+}
+
+func TestPostgresStore_Ping(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := newTestAuthStore(t, db)
+	ctx := context.Background()
+
+	require.NoError(t, store.Ping(ctx))
+}
+
+func TestPostgresStore_Close(t *testing.T) {
+	db := setupAuthPgContainer(t)
+	store := auth.NewPostgresStore(db)
+
+	require.NoError(t, store.Close())
+}

--- a/internal/events/postgres_tracker.go
+++ b/internal/events/postgres_tracker.go
@@ -1,0 +1,188 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/piwi3910/netweave/internal/database"
+	"github.com/piwi3910/netweave/internal/database/dbsqlc"
+)
+
+// PostgresDeliveryTracker implements the DeliveryTracker interface using PostgreSQL.
+// It uses sqlc-generated queries for type-safe database access.
+//
+// Example:
+//
+//	db, _ := database.New(ctx, cfg, password)
+//	tracker := NewPostgresDeliveryTracker(db)
+type PostgresDeliveryTracker struct {
+	db      *database.DB
+	queries *dbsqlc.Queries
+}
+
+// NewPostgresDeliveryTracker creates a new PostgresDeliveryTracker backed by the given database.
+func NewPostgresDeliveryTracker(db *database.DB) *PostgresDeliveryTracker {
+	return &PostgresDeliveryTracker{
+		db:      db,
+		queries: dbsqlc.New(db.Pool),
+	}
+}
+
+// Track records a delivery attempt.
+// Uses UPSERT to allow tracking updates for the same delivery ID.
+func (t *PostgresDeliveryTracker) Track(ctx context.Context, delivery *NotificationDelivery) error {
+	if delivery == nil {
+		return errors.New("delivery cannot be nil")
+	}
+	if delivery.ID == "" {
+		return errors.New("delivery ID cannot be empty")
+	}
+
+	if delivery.CreatedAt.IsZero() {
+		delivery.CreatedAt = time.Now().UTC()
+	}
+
+	err := t.queries.TrackDelivery(ctx, dbsqlc.TrackDeliveryParams{
+		ID:             delivery.ID,
+		EventID:        delivery.EventID,
+		SubscriptionID: delivery.SubscriptionID,
+		CallbackUrl:    delivery.CallbackURL,
+		Status:         string(delivery.Status),
+		Attempts:       safeIntToInt32(delivery.Attempts),
+		MaxAttempts:    safeIntToInt32(delivery.MaxAttempts),
+		LastAttemptAt:  timeToTimestamptz(delivery.LastAttemptAt),
+		NextAttemptAt:  timeToTimestamptz(delivery.NextAttemptAt),
+		LastError:      delivery.LastError,
+		HttpStatusCode: safeIntToInt32(delivery.HTTPStatusCode),
+		ResponseTime:   delivery.ResponseTime,
+		CreatedAt:      delivery.CreatedAt,
+		CompletedAt:    timeToTimestamptz(delivery.CompletedAt),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to track delivery: %w", err)
+	}
+
+	return nil
+}
+
+// Get retrieves delivery information by ID.
+func (t *PostgresDeliveryTracker) Get(ctx context.Context, deliveryID string) (*NotificationDelivery, error) {
+	if deliveryID == "" {
+		return nil, errors.New("delivery ID cannot be empty")
+	}
+
+	row, err := t.queries.GetDelivery(ctx, deliveryID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("delivery not found: %w", err)
+		}
+		return nil, fmt.Errorf("failed to get delivery: %w", err)
+	}
+
+	return dbsqlcDeliveryToModel(&row), nil
+}
+
+// ListByEvent retrieves all deliveries for a specific event.
+func (t *PostgresDeliveryTracker) ListByEvent(ctx context.Context, eventID string) ([]*NotificationDelivery, error) {
+	if eventID == "" {
+		return nil, errors.New("event ID cannot be empty")
+	}
+
+	rows, err := t.queries.ListDeliveriesByEvent(ctx, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list deliveries by event: %w", err)
+	}
+
+	return dbsqlcDeliveriesToModels(rows), nil
+}
+
+// ListBySubscription retrieves all deliveries for a specific subscription.
+func (t *PostgresDeliveryTracker) ListBySubscription(
+	ctx context.Context,
+	subscriptionID string,
+) ([]*NotificationDelivery, error) {
+	if subscriptionID == "" {
+		return nil, errors.New("subscription ID cannot be empty")
+	}
+
+	rows, err := t.queries.ListDeliveriesBySubscription(ctx, subscriptionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list deliveries by subscription: %w", err)
+	}
+
+	return dbsqlcDeliveriesToModels(rows), nil
+}
+
+// ListFailed retrieves all failed deliveries that need attention.
+func (t *PostgresDeliveryTracker) ListFailed(ctx context.Context) ([]*NotificationDelivery, error) {
+	rows, err := t.queries.ListFailedDeliveries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list failed deliveries: %w", err)
+	}
+
+	return dbsqlcDeliveriesToModels(rows), nil
+}
+
+// --- Conversion helpers ---
+
+// dbsqlcDeliveryToModel converts a sqlc NotificationDelivery to an events NotificationDelivery.
+func dbsqlcDeliveryToModel(row *dbsqlc.NotificationDelivery) *NotificationDelivery {
+	d := &NotificationDelivery{
+		ID:             row.ID,
+		EventID:        row.EventID,
+		SubscriptionID: row.SubscriptionID,
+		CallbackURL:    row.CallbackUrl,
+		Status:         DeliveryStatus(row.Status),
+		Attempts:       int(row.Attempts),
+		MaxAttempts:    int(row.MaxAttempts),
+		LastError:      row.LastError,
+		HTTPStatusCode: int(row.HttpStatusCode),
+		ResponseTime:   row.ResponseTime,
+		CreatedAt:      row.CreatedAt,
+	}
+	if row.LastAttemptAt.Valid {
+		d.LastAttemptAt = row.LastAttemptAt.Time
+	}
+	if row.NextAttemptAt.Valid {
+		d.NextAttemptAt = row.NextAttemptAt.Time
+	}
+	if row.CompletedAt.Valid {
+		d.CompletedAt = row.CompletedAt.Time
+	}
+	return d
+}
+
+// dbsqlcDeliveriesToModels converts a slice of sqlc NotificationDeliveries to events models.
+func dbsqlcDeliveriesToModels(rows []dbsqlc.NotificationDelivery) []*NotificationDelivery {
+	deliveries := make([]*NotificationDelivery, 0, len(rows))
+	for i := range rows {
+		deliveries = append(deliveries, dbsqlcDeliveryToModel(&rows[i]))
+	}
+	return deliveries
+}
+
+// safeIntToInt32 safely converts int to int32 with clamping at math.MaxInt32.
+func safeIntToInt32(v int) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v)
+}
+
+// timeToTimestamptz converts a time.Time to pgtype.Timestamptz.
+// Zero time results in an invalid (NULL) timestamp.
+func timeToTimestamptz(t time.Time) pgtype.Timestamptz {
+	if t.IsZero() {
+		return pgtype.Timestamptz{Valid: false}
+	}
+	return pgtype.Timestamptz{Time: t, Valid: true}
+}

--- a/internal/events/postgres_tracker_test.go
+++ b/internal/events/postgres_tracker_test.go
@@ -1,0 +1,327 @@
+package events_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/piwi3910/netweave/internal/database"
+	"github.com/piwi3910/netweave/internal/events"
+)
+
+const (
+	eventsPgTestImage    = "postgres:16-alpine"
+	eventsPgTestDB       = "netweave_events_test"
+	eventsPgTestUser     = "testuser"
+	eventsPgTestPassword = "testpass"
+)
+
+// setupEventsPgContainer starts a PostgreSQL container with migrations for events tests.
+func setupEventsPgContainer(t *testing.T) *database.DB {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image:        eventsPgTestImage,
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_USER":     eventsPgTestUser,
+			"POSTGRES_PASSWORD": eventsPgTestPassword,
+			"POSTGRES_DB":       eventsPgTestDB,
+		},
+		WaitingFor: wait.ForAll(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+			wait.ForListeningPort("5432/tcp"),
+		).WithDeadline(60 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err, "failed to start PostgreSQL container")
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+
+	mappedPort, err := container.MappedPort(ctx, "5432/tcp")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if termErr := container.Terminate(ctx); termErr != nil {
+			t.Logf("failed to terminate PostgreSQL container: %v", termErr)
+		}
+	})
+
+	cfg := &database.PostgresConfig{
+		Host:           host,
+		Port:           mappedPort.Int(),
+		Database:       eventsPgTestDB,
+		User:           eventsPgTestUser,
+		PasswordEnvVar: "TEST_PG_PASSWORD",
+		SSLMode:        "disable",
+		MaxConns:       5,
+		MinConns:       1,
+	}
+
+	db, err := database.New(ctx, cfg, eventsPgTestPassword)
+	require.NoError(t, err)
+
+	err = database.Migrate(ctx, db.Pool)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func newTestTracker(t *testing.T, db *database.DB) *events.PostgresDeliveryTracker {
+	t.Helper()
+	return events.NewPostgresDeliveryTracker(db)
+}
+
+func TestPostgresDeliveryTracker_Track(t *testing.T) {
+	db := setupEventsPgContainer(t)
+
+	tests := []struct {
+		name     string
+		delivery *events.NotificationDelivery
+		wantErr  bool
+	}{
+		{
+			name: "valid delivery",
+			delivery: &events.NotificationDelivery{
+				ID:             "delivery-1",
+				EventID:        "event-1",
+				SubscriptionID: "sub-1",
+				CallbackURL:    "https://example.com/webhook",
+				Status:         events.DeliveryStatusPending,
+				Attempts:       0,
+				MaxAttempts:    3,
+				CreatedAt:      time.Now().UTC(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "delivery with all fields",
+			delivery: &events.NotificationDelivery{
+				ID:             "delivery-2",
+				EventID:        "event-2",
+				SubscriptionID: "sub-2",
+				CallbackURL:    "https://example.com/webhook",
+				Status:         events.DeliveryStatusDelivered,
+				Attempts:       1,
+				MaxAttempts:    3,
+				LastAttemptAt:  time.Now().UTC(),
+				HTTPStatusCode: 200,
+				ResponseTime:   42,
+				CreatedAt:      time.Now().UTC(),
+				CompletedAt:    time.Now().UTC(),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "nil delivery",
+			wantErr: true,
+		},
+		{
+			name:     "empty ID",
+			delivery: &events.NotificationDelivery{ID: ""},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker := newTestTracker(t, db)
+			ctx := context.Background()
+
+			err := tracker.Track(ctx, tt.delivery)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPostgresDeliveryTracker_TrackUpsert(t *testing.T) {
+	db := setupEventsPgContainer(t)
+	tracker := newTestTracker(t, db)
+	ctx := context.Background()
+
+	// Create initial delivery.
+	delivery := &events.NotificationDelivery{
+		ID:             "delivery-upsert-1",
+		EventID:        "event-upsert",
+		SubscriptionID: "sub-upsert",
+		CallbackURL:    "https://example.com/webhook",
+		Status:         events.DeliveryStatusPending,
+		Attempts:       0,
+		MaxAttempts:    3,
+	}
+	require.NoError(t, tracker.Track(ctx, delivery))
+
+	// Update with retry status.
+	delivery.Status = events.DeliveryStatusRetrying
+	delivery.Attempts = 1
+	delivery.LastAttemptAt = time.Now().UTC()
+	delivery.LastError = "connection refused"
+	delivery.HTTPStatusCode = 503
+	require.NoError(t, tracker.Track(ctx, delivery))
+
+	// Verify update.
+	got, err := tracker.Get(ctx, "delivery-upsert-1")
+	require.NoError(t, err)
+	assert.Equal(t, events.DeliveryStatusRetrying, got.Status)
+	assert.Equal(t, 1, got.Attempts)
+	assert.Equal(t, "connection refused", got.LastError)
+	assert.Equal(t, 503, got.HTTPStatusCode)
+}
+
+func TestPostgresDeliveryTracker_Get(t *testing.T) {
+	db := setupEventsPgContainer(t)
+	tracker := newTestTracker(t, db)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	delivery := &events.NotificationDelivery{
+		ID:             "delivery-get-1",
+		EventID:        "event-get",
+		SubscriptionID: "sub-get",
+		CallbackURL:    "https://example.com/webhook",
+		Status:         events.DeliveryStatusDelivered,
+		Attempts:       1,
+		MaxAttempts:    3,
+		LastAttemptAt:  now,
+		HTTPStatusCode: 200,
+		ResponseTime:   25,
+		CompletedAt:    now,
+	}
+	require.NoError(t, tracker.Track(ctx, delivery))
+
+	got, err := tracker.Get(ctx, "delivery-get-1")
+	require.NoError(t, err)
+	assert.Equal(t, delivery.ID, got.ID)
+	assert.Equal(t, delivery.EventID, got.EventID)
+	assert.Equal(t, delivery.SubscriptionID, got.SubscriptionID)
+	assert.Equal(t, delivery.CallbackURL, got.CallbackURL)
+	assert.Equal(t, delivery.Status, got.Status)
+	assert.Equal(t, delivery.Attempts, got.Attempts)
+	assert.Equal(t, delivery.MaxAttempts, got.MaxAttempts)
+	assert.Equal(t, delivery.HTTPStatusCode, got.HTTPStatusCode)
+	assert.Equal(t, delivery.ResponseTime, got.ResponseTime)
+
+	// Not found.
+	_, err = tracker.Get(ctx, "delivery-nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	// Empty ID.
+	_, err = tracker.Get(ctx, "")
+	require.Error(t, err)
+}
+
+func TestPostgresDeliveryTracker_ListByEvent(t *testing.T) {
+	db := setupEventsPgContainer(t)
+	tracker := newTestTracker(t, db)
+	ctx := context.Background()
+
+	// Track deliveries for different events.
+	require.NoError(t, tracker.Track(ctx, &events.NotificationDelivery{
+		ID: "d-event-1", EventID: "event-alpha", SubscriptionID: "sub-1",
+		CallbackURL: "https://example.com/w", Status: events.DeliveryStatusPending,
+	}))
+	require.NoError(t, tracker.Track(ctx, &events.NotificationDelivery{
+		ID: "d-event-2", EventID: "event-alpha", SubscriptionID: "sub-2",
+		CallbackURL: "https://example.com/w", Status: events.DeliveryStatusPending,
+	}))
+	require.NoError(t, tracker.Track(ctx, &events.NotificationDelivery{
+		ID: "d-event-3", EventID: "event-beta", SubscriptionID: "sub-1",
+		CallbackURL: "https://example.com/w", Status: events.DeliveryStatusPending,
+	}))
+
+	deliveries, err := tracker.ListByEvent(ctx, "event-alpha")
+	require.NoError(t, err)
+	assert.Len(t, deliveries, 2)
+
+	deliveries, err = tracker.ListByEvent(ctx, "event-beta")
+	require.NoError(t, err)
+	assert.Len(t, deliveries, 1)
+
+	deliveries, err = tracker.ListByEvent(ctx, "event-nonexistent")
+	require.NoError(t, err)
+	assert.Empty(t, deliveries)
+
+	_, err = tracker.ListByEvent(ctx, "")
+	require.Error(t, err)
+}
+
+func TestPostgresDeliveryTracker_ListBySubscription(t *testing.T) {
+	db := setupEventsPgContainer(t)
+	tracker := newTestTracker(t, db)
+	ctx := context.Background()
+
+	require.NoError(t, tracker.Track(ctx, &events.NotificationDelivery{
+		ID: "d-sub-1", EventID: "e-1", SubscriptionID: "sub-tracked",
+		CallbackURL: "https://example.com/w", Status: events.DeliveryStatusPending,
+	}))
+	require.NoError(t, tracker.Track(ctx, &events.NotificationDelivery{
+		ID: "d-sub-2", EventID: "e-2", SubscriptionID: "sub-tracked",
+		CallbackURL: "https://example.com/w", Status: events.DeliveryStatusDelivered,
+	}))
+	require.NoError(t, tracker.Track(ctx, &events.NotificationDelivery{
+		ID: "d-sub-3", EventID: "e-3", SubscriptionID: "sub-other",
+		CallbackURL: "https://example.com/w", Status: events.DeliveryStatusPending,
+	}))
+
+	deliveries, err := tracker.ListBySubscription(ctx, "sub-tracked")
+	require.NoError(t, err)
+	assert.Len(t, deliveries, 2)
+
+	_, err = tracker.ListBySubscription(ctx, "")
+	require.Error(t, err)
+}
+
+func TestPostgresDeliveryTracker_ListFailed(t *testing.T) {
+	db := setupEventsPgContainer(t)
+	tracker := newTestTracker(t, db)
+	ctx := context.Background()
+
+	require.NoError(t, tracker.Track(ctx, &events.NotificationDelivery{
+		ID: "d-fail-1", EventID: "e-1", SubscriptionID: "sub-1",
+		CallbackURL: "https://example.com/w", Status: events.DeliveryStatusFailed,
+		LastError: "timeout", Attempts: 3, MaxAttempts: 3,
+	}))
+	require.NoError(t, tracker.Track(ctx, &events.NotificationDelivery{
+		ID: "d-fail-2", EventID: "e-2", SubscriptionID: "sub-1",
+		CallbackURL: "https://example.com/w", Status: events.DeliveryStatusDelivered,
+	}))
+	require.NoError(t, tracker.Track(ctx, &events.NotificationDelivery{
+		ID: "d-fail-3", EventID: "e-3", SubscriptionID: "sub-1",
+		CallbackURL: "https://example.com/w", Status: events.DeliveryStatusFailed,
+		LastError: "server error", Attempts: 3, MaxAttempts: 3,
+	}))
+
+	failed, err := tracker.ListFailed(ctx)
+	require.NoError(t, err)
+	assert.Len(t, failed, 2)
+
+	for _, d := range failed {
+		assert.Equal(t, events.DeliveryStatusFailed, d.Status)
+	}
+}

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1,0 +1,260 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/piwi3910/netweave/internal/database"
+	"github.com/piwi3910/netweave/internal/database/dbsqlc"
+)
+
+// pgUniqueViolation is the PostgreSQL error code for unique constraint violations.
+const pgUniqueViolation = "23505"
+
+// PostgresStore implements the Store interface using PostgreSQL as the backend.
+// It uses sqlc-generated queries for type-safe database access.
+//
+// Example:
+//
+//	db, _ := database.New(ctx, cfg, password)
+//	store := NewPostgresStore(db, true)
+//	defer store.Close()
+//
+//	sub := &Subscription{ID: "sub-123", Callback: "https://smo.example.com/notify"}
+//	err := store.Create(ctx, sub)
+type PostgresStore struct {
+	db                     *database.DB
+	queries                *dbsqlc.Queries
+	allowInsecureCallbacks bool
+}
+
+// NewPostgresStore creates a new PostgresStore backed by the given database connection.
+// The allowInsecureCallbacks parameter controls whether HTTP callbacks are permitted.
+func NewPostgresStore(db *database.DB, allowInsecureCallbacks bool) *PostgresStore {
+	return &PostgresStore{
+		db:                     db,
+		queries:                dbsqlc.New(db.Pool),
+		allowInsecureCallbacks: allowInsecureCallbacks,
+	}
+}
+
+// Create creates a new subscription in PostgreSQL.
+// Returns ErrSubscriptionExists if a subscription with the same ID already exists.
+// Returns ErrInvalidCallback if the callback URL is invalid.
+// Returns ErrInvalidID if the subscription ID is empty.
+func (s *PostgresStore) Create(ctx context.Context, sub *Subscription) error {
+	if sub.ID == "" {
+		return ErrInvalidID
+	}
+	if err := ValidateCallbackURL(sub.Callback, s.allowInsecureCallbacks); err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidCallback, err.Error())
+	}
+
+	now := time.Now().UTC()
+	sub.CreatedAt = now
+	sub.UpdatedAt = now
+
+	err := s.queries.CreateSubscription(ctx, dbsqlc.CreateSubscriptionParams{
+		ID:                     sub.ID,
+		TenantID:               sub.TenantID,
+		Callback:               sub.Callback,
+		ConsumerSubscriptionID: sub.ConsumerSubscriptionID,
+		FilterResourcePoolID:   sub.Filter.ResourcePoolID,
+		FilterResourceTypeID:   sub.Filter.ResourceTypeID,
+		FilterResourceID:       sub.Filter.ResourceID,
+		CreatedAt:              sub.CreatedAt,
+		UpdatedAt:              sub.UpdatedAt,
+	})
+	if err != nil {
+		if isPgUniqueViolation(err) {
+			return ErrSubscriptionExists
+		}
+		return fmt.Errorf("failed to create subscription: %w", err)
+	}
+
+	return nil
+}
+
+// Get retrieves a subscription by ID.
+// Returns ErrSubscriptionNotFound if the subscription does not exist.
+func (s *PostgresStore) Get(ctx context.Context, id string) (*Subscription, error) {
+	if id == "" {
+		return nil, ErrInvalidID
+	}
+
+	row, err := s.queries.GetSubscription(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrSubscriptionNotFound
+		}
+		return nil, fmt.Errorf("failed to get subscription: %w", err)
+	}
+
+	return dbsqlcSubscriptionToModel(&row), nil
+}
+
+// Update updates an existing subscription.
+// Returns ErrSubscriptionNotFound if the subscription does not exist.
+// Returns ErrInvalidCallback if the callback URL is invalid.
+func (s *PostgresStore) Update(ctx context.Context, sub *Subscription) error {
+	if sub.ID == "" {
+		return ErrInvalidID
+	}
+	if err := ValidateCallbackURL(sub.Callback, s.allowInsecureCallbacks); err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidCallback, err.Error())
+	}
+
+	exists, err := s.queries.SubscriptionExists(ctx, sub.ID)
+	if err != nil {
+		return fmt.Errorf("failed to check subscription existence: %w", err)
+	}
+	if !exists {
+		return ErrSubscriptionNotFound
+	}
+
+	sub.UpdatedAt = time.Now().UTC()
+
+	err = s.queries.UpdateSubscription(ctx, dbsqlc.UpdateSubscriptionParams{
+		ID:                     sub.ID,
+		Callback:               sub.Callback,
+		ConsumerSubscriptionID: sub.ConsumerSubscriptionID,
+		FilterResourcePoolID:   sub.Filter.ResourcePoolID,
+		FilterResourceTypeID:   sub.Filter.ResourceTypeID,
+		FilterResourceID:       sub.Filter.ResourceID,
+		UpdatedAt:              sub.UpdatedAt,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update subscription: %w", err)
+	}
+
+	return nil
+}
+
+// Delete deletes a subscription by ID.
+// Returns ErrSubscriptionNotFound if the subscription does not exist.
+func (s *PostgresStore) Delete(ctx context.Context, id string) error {
+	if id == "" {
+		return ErrInvalidID
+	}
+
+	rowsAffected, err := s.queries.DeleteSubscription(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete subscription: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrSubscriptionNotFound
+	}
+
+	return nil
+}
+
+// List retrieves all subscriptions.
+// Returns an empty slice if no subscriptions exist.
+func (s *PostgresStore) List(ctx context.Context) ([]*Subscription, error) {
+	rows, err := s.queries.ListSubscriptions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list subscriptions: %w", err)
+	}
+
+	return dbsqlcSubscriptionsToModels(rows), nil
+}
+
+// ListByResourcePool retrieves subscriptions filtered by resource pool ID.
+// Returns an empty slice if no matching subscriptions exist.
+func (s *PostgresStore) ListByResourcePool(ctx context.Context, resourcePoolID string) ([]*Subscription, error) {
+	if resourcePoolID == "" {
+		return []*Subscription{}, nil
+	}
+
+	rows, err := s.queries.ListSubscriptionsByResourcePool(ctx, resourcePoolID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list subscriptions by resource pool: %w", err)
+	}
+
+	return dbsqlcSubscriptionsToModels(rows), nil
+}
+
+// ListByResourceType retrieves subscriptions filtered by resource type ID.
+// Returns an empty slice if no matching subscriptions exist.
+func (s *PostgresStore) ListByResourceType(ctx context.Context, resourceTypeID string) ([]*Subscription, error) {
+	if resourceTypeID == "" {
+		return []*Subscription{}, nil
+	}
+
+	rows, err := s.queries.ListSubscriptionsByResourceType(ctx, resourceTypeID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list subscriptions by resource type: %w", err)
+	}
+
+	return dbsqlcSubscriptionsToModels(rows), nil
+}
+
+// ListByTenant retrieves subscriptions filtered by tenant ID.
+// Returns an empty slice if no matching subscriptions exist.
+func (s *PostgresStore) ListByTenant(ctx context.Context, tenantID string) ([]*Subscription, error) {
+	if tenantID == "" {
+		return []*Subscription{}, nil
+	}
+
+	rows, err := s.queries.ListSubscriptionsByTenant(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list subscriptions by tenant: %w", err)
+	}
+
+	return dbsqlcSubscriptionsToModels(rows), nil
+}
+
+// Close closes the PostgreSQL connection pool and releases resources.
+func (s *PostgresStore) Close() error {
+	s.db.Close()
+	return nil
+}
+
+// Ping checks if PostgreSQL is available.
+// Returns ErrStorageUnavailable if the database cannot be reached.
+func (s *PostgresStore) Ping(ctx context.Context) error {
+	if err := s.db.Ping(ctx); err != nil {
+		return fmt.Errorf("%w: %s", ErrStorageUnavailable, err.Error())
+	}
+	return nil
+}
+
+// dbsqlcSubscriptionToModel converts a sqlc Subscription to a storage Subscription.
+func dbsqlcSubscriptionToModel(row *dbsqlc.Subscription) *Subscription {
+	return &Subscription{
+		ID:                     row.ID,
+		TenantID:               row.TenantID,
+		Callback:               row.Callback,
+		ConsumerSubscriptionID: row.ConsumerSubscriptionID,
+		Filter: SubscriptionFilter{
+			ResourcePoolID: row.FilterResourcePoolID,
+			ResourceTypeID: row.FilterResourceTypeID,
+			ResourceID:     row.FilterResourceID,
+		},
+		CreatedAt: row.CreatedAt,
+		UpdatedAt: row.UpdatedAt,
+	}
+}
+
+// dbsqlcSubscriptionsToModels converts a slice of sqlc Subscriptions to storage Subscriptions.
+func dbsqlcSubscriptionsToModels(rows []dbsqlc.Subscription) []*Subscription {
+	subs := make([]*Subscription, 0, len(rows))
+	for i := range rows {
+		subs = append(subs, dbsqlcSubscriptionToModel(&rows[i]))
+	}
+	return subs
+}
+
+// isPgUniqueViolation checks if the error is a PostgreSQL unique constraint violation.
+func isPgUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == pgUniqueViolation
+	}
+	return false
+}

--- a/internal/storage/postgres_test.go
+++ b/internal/storage/postgres_test.go
@@ -1,0 +1,544 @@
+package storage_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/piwi3910/netweave/internal/database"
+	"github.com/piwi3910/netweave/internal/storage"
+)
+
+const (
+	pgTestImage    = "postgres:16-alpine"
+	pgTestDB       = "netweave_test"
+	pgTestUser     = "testuser"
+	pgTestPassword = "testpass"
+)
+
+// pgTestContainer represents a running PostgreSQL test container.
+type pgTestContainer struct {
+	host string
+	port int
+}
+
+// setupPgContainer starts a PostgreSQL container with migrations applied.
+func setupPgContainer(t *testing.T) (*pgTestContainer, *database.DB) {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image:        pgTestImage,
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_USER":     pgTestUser,
+			"POSTGRES_PASSWORD": pgTestPassword,
+			"POSTGRES_DB":       pgTestDB,
+		},
+		WaitingFor: wait.ForAll(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+			wait.ForListeningPort("5432/tcp"),
+		).WithDeadline(60 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err, "failed to start PostgreSQL container")
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+
+	mappedPort, err := container.MappedPort(ctx, "5432/tcp")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if termErr := container.Terminate(ctx); termErr != nil {
+			t.Logf("failed to terminate PostgreSQL container: %v", termErr)
+		}
+	})
+
+	pc := &pgTestContainer{
+		host: host,
+		port: mappedPort.Int(),
+	}
+
+	cfg := &database.PostgresConfig{
+		Host:           pc.host,
+		Port:           pc.port,
+		Database:       pgTestDB,
+		User:           pgTestUser,
+		PasswordEnvVar: "TEST_PG_PASSWORD",
+		SSLMode:        "disable",
+		MaxConns:       5,
+		MinConns:       1,
+	}
+
+	db, err := database.New(ctx, cfg, pgTestPassword)
+	require.NoError(t, err)
+
+	err = database.Migrate(ctx, db.Pool)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return pc, db
+}
+
+func newTestPostgresStore(t *testing.T, db *database.DB) *storage.PostgresStore {
+	t.Helper()
+	return storage.NewPostgresStore(db, true)
+}
+
+func TestPostgresStore_Create(t *testing.T) {
+	_, db := setupPgContainer(t)
+
+	tests := []struct {
+		name    string
+		sub     *storage.Subscription
+		wantErr error
+	}{
+		{
+			name: "valid subscription",
+			sub: &storage.Subscription{
+				ID:                     "sub-create-1",
+				TenantID:               "tenant-1",
+				Callback:               "https://smo.example.com/notify",
+				ConsumerSubscriptionID: "consumer-1",
+				Filter: storage.SubscriptionFilter{
+					ResourcePoolID: "pool-1",
+					ResourceTypeID: "type-1",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid subscription with http callback",
+			sub: &storage.Subscription{
+				ID:       "sub-create-2",
+				Callback: "http://dev.example.com/notify",
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "empty ID",
+			sub:     &storage.Subscription{ID: "", Callback: "https://example.com/notify"},
+			wantErr: storage.ErrInvalidID,
+		},
+		{
+			name:    "empty callback",
+			sub:     &storage.Subscription{ID: "sub-create-3", Callback: ""},
+			wantErr: storage.ErrInvalidCallback,
+		},
+		{
+			name:    "invalid callback scheme",
+			sub:     &storage.Subscription{ID: "sub-create-4", Callback: "ftp://example.com/notify"},
+			wantErr: storage.ErrInvalidCallback,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestPostgresStore(t, db)
+			ctx := context.Background()
+
+			err := store.Create(ctx, tt.sub)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.False(t, tt.sub.CreatedAt.IsZero())
+				assert.False(t, tt.sub.UpdatedAt.IsZero())
+			}
+		})
+	}
+}
+
+func TestPostgresStore_CreateDuplicate(t *testing.T) {
+	_, db := setupPgContainer(t)
+	store := newTestPostgresStore(t, db)
+	ctx := context.Background()
+
+	sub := &storage.Subscription{
+		ID:       "sub-dup-1",
+		Callback: "https://smo.example.com/notify",
+	}
+
+	err := store.Create(ctx, sub)
+	require.NoError(t, err)
+
+	err = store.Create(ctx, sub)
+	require.ErrorIs(t, err, storage.ErrSubscriptionExists)
+}
+
+func TestPostgresStore_Get(t *testing.T) {
+	_, db := setupPgContainer(t)
+	store := newTestPostgresStore(t, db)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		setup   func()
+		id      string
+		wantErr error
+	}{
+		{
+			name: "existing subscription",
+			setup: func() {
+				sub := &storage.Subscription{
+					ID:       "sub-get-1",
+					TenantID: "tenant-1",
+					Callback: "https://smo.example.com/notify",
+					Filter:   storage.SubscriptionFilter{ResourcePoolID: "pool-1"},
+				}
+				require.NoError(t, store.Create(ctx, sub))
+			},
+			id:      "sub-get-1",
+			wantErr: nil,
+		},
+		{
+			name:    "not found",
+			setup:   func() {},
+			id:      "sub-nonexistent",
+			wantErr: storage.ErrSubscriptionNotFound,
+		},
+		{
+			name:    "empty ID",
+			setup:   func() {},
+			id:      "",
+			wantErr: storage.ErrInvalidID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+
+			got, err := store.Get(ctx, tt.id)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				assert.Equal(t, tt.id, got.ID)
+				assert.Equal(t, "tenant-1", got.TenantID)
+				assert.Equal(t, "pool-1", got.Filter.ResourcePoolID)
+			}
+		})
+	}
+}
+
+func TestPostgresStore_Update(t *testing.T) {
+	_, db := setupPgContainer(t)
+	store := newTestPostgresStore(t, db)
+	ctx := context.Background()
+
+	// Create initial subscription.
+	original := &storage.Subscription{
+		ID:       "sub-update-1",
+		TenantID: "tenant-1",
+		Callback: "https://smo.example.com/notify",
+		Filter:   storage.SubscriptionFilter{ResourcePoolID: "pool-1"},
+	}
+	require.NoError(t, store.Create(ctx, original))
+
+	tests := []struct {
+		name    string
+		sub     *storage.Subscription
+		wantErr error
+	}{
+		{
+			name: "valid update",
+			sub: &storage.Subscription{
+				ID:       "sub-update-1",
+				TenantID: "tenant-1",
+				Callback: "https://smo.example.com/v2/notify",
+				Filter:   storage.SubscriptionFilter{ResourcePoolID: "pool-2"},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "not found",
+			sub: &storage.Subscription{
+				ID:       "sub-nonexistent",
+				Callback: "https://example.com/notify",
+			},
+			wantErr: storage.ErrSubscriptionNotFound,
+		},
+		{
+			name: "empty ID",
+			sub: &storage.Subscription{
+				ID:       "",
+				Callback: "https://example.com/notify",
+			},
+			wantErr: storage.ErrInvalidID,
+		},
+		{
+			name: "invalid callback",
+			sub: &storage.Subscription{
+				ID:       "sub-update-1",
+				Callback: "",
+			},
+			wantErr: storage.ErrInvalidCallback,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := store.Update(ctx, tt.sub)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+
+				updated, getErr := store.Get(ctx, tt.sub.ID)
+				require.NoError(t, getErr)
+				assert.Equal(t, "https://smo.example.com/v2/notify", updated.Callback)
+				assert.Equal(t, "pool-2", updated.Filter.ResourcePoolID)
+			}
+		})
+	}
+}
+
+func TestPostgresStore_Delete(t *testing.T) {
+	_, db := setupPgContainer(t)
+	store := newTestPostgresStore(t, db)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		setup   func()
+		id      string
+		wantErr error
+	}{
+		{
+			name: "existing subscription",
+			setup: func() {
+				sub := &storage.Subscription{
+					ID:       "sub-delete-1",
+					Callback: "https://smo.example.com/notify",
+				}
+				require.NoError(t, store.Create(ctx, sub))
+			},
+			id:      "sub-delete-1",
+			wantErr: nil,
+		},
+		{
+			name:    "not found",
+			setup:   func() {},
+			id:      "sub-nonexistent",
+			wantErr: storage.ErrSubscriptionNotFound,
+		},
+		{
+			name:    "empty ID",
+			setup:   func() {},
+			id:      "",
+			wantErr: storage.ErrInvalidID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+
+			err := store.Delete(ctx, tt.id)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+
+				_, getErr := store.Get(ctx, tt.id)
+				assert.ErrorIs(t, getErr, storage.ErrSubscriptionNotFound)
+			}
+		})
+	}
+}
+
+func TestPostgresStore_List(t *testing.T) {
+	_, db := setupPgContainer(t)
+	store := newTestPostgresStore(t, db)
+	ctx := context.Background()
+
+	// Initially empty.
+	subs, err := store.List(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, subs)
+
+	// Create subscriptions.
+	for i := 0; i < 3; i++ {
+		sub := &storage.Subscription{
+			ID:       "sub-list-" + strconv.Itoa(i),
+			TenantID: "tenant-1",
+			Callback: "https://smo.example.com/notify",
+		}
+		require.NoError(t, store.Create(ctx, sub))
+	}
+
+	subs, err = store.List(ctx)
+	require.NoError(t, err)
+	assert.Len(t, subs, 3)
+}
+
+func TestPostgresStore_ListByResourcePool(t *testing.T) {
+	_, db := setupPgContainer(t)
+	store := newTestPostgresStore(t, db)
+	ctx := context.Background()
+
+	// Create subscriptions with different pools.
+	require.NoError(t, store.Create(ctx, &storage.Subscription{
+		ID: "sub-pool-1", Callback: "https://smo.example.com/notify",
+		Filter: storage.SubscriptionFilter{ResourcePoolID: "pool-alpha"},
+	}))
+	require.NoError(t, store.Create(ctx, &storage.Subscription{
+		ID: "sub-pool-2", Callback: "https://smo.example.com/notify",
+		Filter: storage.SubscriptionFilter{ResourcePoolID: "pool-alpha"},
+	}))
+	require.NoError(t, store.Create(ctx, &storage.Subscription{
+		ID: "sub-pool-3", Callback: "https://smo.example.com/notify",
+		Filter: storage.SubscriptionFilter{ResourcePoolID: "pool-beta"},
+	}))
+
+	tests := []struct {
+		name      string
+		poolID    string
+		wantLen   int
+		wantEmpty bool
+	}{
+		{name: "pool-alpha", poolID: "pool-alpha", wantLen: 2},
+		{name: "pool-beta", poolID: "pool-beta", wantLen: 1},
+		{name: "nonexistent pool", poolID: "pool-nonexistent", wantLen: 0},
+		{name: "empty pool ID", poolID: "", wantLen: 0, wantEmpty: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subs, listErr := store.ListByResourcePool(ctx, tt.poolID)
+			require.NoError(t, listErr)
+			assert.Len(t, subs, tt.wantLen)
+		})
+	}
+}
+
+func TestPostgresStore_ListByResourceType(t *testing.T) {
+	_, db := setupPgContainer(t)
+	store := newTestPostgresStore(t, db)
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, &storage.Subscription{
+		ID: "sub-type-1", Callback: "https://smo.example.com/notify",
+		Filter: storage.SubscriptionFilter{ResourceTypeID: "type-compute"},
+	}))
+	require.NoError(t, store.Create(ctx, &storage.Subscription{
+		ID: "sub-type-2", Callback: "https://smo.example.com/notify",
+		Filter: storage.SubscriptionFilter{ResourceTypeID: "type-storage"},
+	}))
+
+	subs, err := store.ListByResourceType(ctx, "type-compute")
+	require.NoError(t, err)
+	assert.Len(t, subs, 1)
+	assert.Equal(t, "sub-type-1", subs[0].ID)
+
+	subs, err = store.ListByResourceType(ctx, "")
+	require.NoError(t, err)
+	assert.Empty(t, subs)
+}
+
+func TestPostgresStore_ListByTenant(t *testing.T) {
+	_, db := setupPgContainer(t)
+	store := newTestPostgresStore(t, db)
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, &storage.Subscription{
+		ID: "sub-tenant-1", TenantID: "tenant-a",
+		Callback: "https://smo.example.com/notify",
+	}))
+	require.NoError(t, store.Create(ctx, &storage.Subscription{
+		ID: "sub-tenant-2", TenantID: "tenant-a",
+		Callback: "https://smo.example.com/notify",
+	}))
+	require.NoError(t, store.Create(ctx, &storage.Subscription{
+		ID: "sub-tenant-3", TenantID: "tenant-b",
+		Callback: "https://smo.example.com/notify",
+	}))
+
+	subs, err := store.ListByTenant(ctx, "tenant-a")
+	require.NoError(t, err)
+	assert.Len(t, subs, 2)
+
+	subs, err = store.ListByTenant(ctx, "")
+	require.NoError(t, err)
+	assert.Empty(t, subs)
+}
+
+func TestPostgresStore_Ping(t *testing.T) {
+	_, db := setupPgContainer(t)
+	store := newTestPostgresStore(t, db)
+	ctx := context.Background()
+
+	err := store.Ping(ctx)
+	require.NoError(t, err)
+}
+
+func TestPostgresStore_ConcurrentAccess(t *testing.T) {
+	_, db := setupPgContainer(t)
+	store := newTestPostgresStore(t, db)
+	ctx := context.Background()
+
+	const workers = 10
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			sub := &storage.Subscription{
+				ID:       "sub-concurrent-" + strconv.Itoa(idx),
+				TenantID: "tenant-concurrent",
+				Callback: "https://smo.example.com/notify",
+			}
+			if createErr := store.Create(ctx, sub); createErr != nil {
+				errCh <- createErr
+				return
+			}
+			if _, getErr := store.Get(ctx, sub.ID); getErr != nil {
+				errCh <- getErr
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Errorf("concurrent operation failed: %v", err)
+	}
+
+	subs, err := store.ListByTenant(ctx, "tenant-concurrent")
+	require.NoError(t, err)
+	assert.Len(t, subs, workers)
+}
+
+func TestPostgresStore_Close(t *testing.T) {
+	_, db := setupPgContainer(t)
+	store := storage.NewPostgresStore(db, true)
+
+	err := store.Close()
+	require.NoError(t, err)
+}

--- a/internal/storage/redis.go
+++ b/internal/storage/redis.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -582,28 +581,5 @@ func (r *RedisStore) Ping(ctx context.Context) error {
 // validateCallbackURL validates that a callback URL is properly formatted and secure.
 // It enforces HTTPS unless AllowInsecureCallbacks is enabled in the configuration.
 func (r *RedisStore) validateCallbackURL(callback string) error {
-	if callback == "" {
-		return fmt.Errorf("callback URL is empty")
-	}
-
-	u, err := url.Parse(callback)
-	if err != nil {
-		return fmt.Errorf("invalid URL format: %w", err)
-	}
-
-	// Enforce HTTPS unless explicitly allowed
-	if u.Scheme == "http" {
-		if !r.config.AllowInsecureCallbacks {
-			return fmt.Errorf("HTTP callbacks are not allowed in production. Use HTTPS for secure webhook delivery. " +
-				"To allow HTTP callbacks in development/testing, set allow_insecure_callbacks=true in security configuration")
-		}
-	} else if u.Scheme != "https" {
-		return fmt.Errorf("callback URL must use http or https scheme")
-	}
-
-	if u.Host == "" {
-		return fmt.Errorf("callback URL must have a host")
-	}
-
-	return nil
+	return ValidateCallbackURL(callback, r.config.AllowInsecureCallbacks)
 }

--- a/internal/storage/validation.go
+++ b/internal/storage/validation.go
@@ -1,0 +1,35 @@
+package storage
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ValidateCallbackURL validates that a callback URL is properly formatted and secure.
+// If allowInsecure is true, HTTP (non-HTTPS) callbacks are permitted.
+// Otherwise, only HTTPS is allowed for production security.
+func ValidateCallbackURL(callback string, allowInsecure bool) error {
+	if callback == "" {
+		return fmt.Errorf("callback URL is empty")
+	}
+
+	u, err := url.Parse(callback)
+	if err != nil {
+		return fmt.Errorf("invalid URL format: %w", err)
+	}
+
+	if u.Scheme == "http" {
+		if !allowInsecure {
+			return fmt.Errorf("HTTP callbacks are not allowed in production. Use HTTPS for secure webhook delivery. " +
+				"To allow HTTP callbacks in development/testing, set allow_insecure_callbacks=true in security configuration")
+		}
+	} else if u.Scheme != "https" {
+		return fmt.Errorf("callback URL must use http or https scheme")
+	}
+
+	if u.Host == "" {
+		return fmt.Errorf("callback URL must have a host")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

- Implement `storage.PostgresStore` with full CRUD operations for subscriptions (Create, Get, Update, Delete, List, ListByResourcePool, ListByResourceType, ListByTenant, Close, Ping)
- Implement `auth.PostgresStore` covering TenantStore, UserStore, RoleStore, and AuditStore interfaces with JSONB serialization for quota/usage/metadata/permissions
- Implement `events.PostgresDeliveryTracker` for notification delivery tracking with UPSERT support
- Extract `ValidateCallbackURL` as a shared package-level function reused by both Redis and Postgres stores
- Add comprehensive integration tests using testcontainers-go with real PostgreSQL 16 instances

## Key Design Decisions

- Maps `pgx.ErrNoRows` to domain sentinel errors (`ErrSubscriptionNotFound`, `ErrTenantNotFound`, etc.)
- Maps PostgreSQL `unique_violation` (23505) to domain exists errors
- Safe `int` to `int32` conversion with bounds clamping for gosec G115 compliance
- `pgtype.Timestamptz` handling for nullable timestamp fields (LastLoginAt, CompletedAt, etc.)
- All external errors wrapped per wrapcheck linter requirements

## Test Plan

- [x] All storage tests pass (`TestPostgresStore_Create`, `_Get`, `_Update`, `_Delete`, `_List*`, `_ConcurrentAccess`)
- [x] All auth tests pass (Tenant CRUD, User CRUD + lookups by subject/email/oauth, Role CRUD + InitializeDefaultRoles, Audit logging + queries)
- [x] All events tests pass (Track, TrackUpsert, Get, ListByEvent, ListBySubscription, ListFailed)
- [x] Race detector passes (`go test -race`)
- [x] golangci-lint passes with zero issues
- [x] Existing Redis store tests still pass after ValidateCallbackURL refactor

Resolves #363