### PR TITLE
Add multi-backend registry with admin API and credential encryption

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -293,6 +293,10 @@ linters:
         path: internal/adapter/
         text: interface has more than.*methods
       - linters:
+          - interfacebloat
+        path: internal/backend/
+        text: interface has more than.*methods
+      - linters:
           - revive
         path: internal/adapters/
         text: unused-parameter.*ctx

--- a/internal/backend/postgres_store.go
+++ b/internal/backend/postgres_store.go
@@ -1,0 +1,399 @@
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/piwi3910/netweave/internal/database/dbsqlc"
+)
+
+// pgUniqueViolation is the PostgreSQL error code for unique constraint violations.
+const pgUniqueViolation = "23505"
+
+// PostgresStore implements Store using PostgreSQL via sqlc-generated queries.
+type PostgresStore struct {
+	pool    *pgxpool.Pool
+	queries *dbsqlc.Queries
+}
+
+// NewPostgresStore creates a new PostgresStore backed by the given connection pool.
+func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
+	return &PostgresStore{
+		pool:    pool,
+		queries: dbsqlc.New(pool),
+	}
+}
+
+// CreateBackend creates a new backend instance.
+func (s *PostgresStore) CreateBackend(ctx context.Context, instance *Instance) error {
+	params := dbsqlc.CreateBackendParams{
+		ID:              instance.ID,
+		Name:            instance.Name,
+		Category:        instance.Category,
+		AdapterType:     instance.AdapterType,
+		Description:     instance.Description,
+		Config:          instance.Config,
+		Credentials:     instance.Credentials,
+		Status:          instance.Status,
+		StatusMessage:   instance.StatusMessage,
+		LastHealthCheck: timestamptzFromTime(instance.LastHealthCheck),
+		CreatedAt:       instance.CreatedAt,
+		UpdatedAt:       instance.UpdatedAt,
+	}
+
+	if err := s.queries.CreateBackend(ctx, params); err != nil {
+		if isUniqueViolation(err) {
+			return ErrBackendExists
+		}
+		return fmt.Errorf("failed to create backend: %w", err)
+	}
+	return nil
+}
+
+// GetBackend retrieves a backend instance by ID.
+func (s *PostgresStore) GetBackend(ctx context.Context, id string) (*Instance, error) {
+	row, err := s.queries.GetBackend(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrBackendNotFound
+		}
+		return nil, fmt.Errorf("failed to get backend: %w", err)
+	}
+	return dbBackendToModel(&row), nil
+}
+
+// UpdateBackend updates an existing backend instance.
+func (s *PostgresStore) UpdateBackend(ctx context.Context, instance *Instance) error {
+	exists, err := s.queries.BackendExists(ctx, instance.ID)
+	if err != nil {
+		return fmt.Errorf("failed to check backend existence: %w", err)
+	}
+	if !exists {
+		return ErrBackendNotFound
+	}
+
+	params := dbsqlc.UpdateBackendParams{
+		ID:              instance.ID,
+		Name:            instance.Name,
+		Description:     instance.Description,
+		Config:          instance.Config,
+		Credentials:     instance.Credentials,
+		Status:          instance.Status,
+		StatusMessage:   instance.StatusMessage,
+		LastHealthCheck: timestamptzFromTime(instance.LastHealthCheck),
+		UpdatedAt:       instance.UpdatedAt,
+	}
+
+	if err := s.queries.UpdateBackend(ctx, params); err != nil {
+		return fmt.Errorf("failed to update backend: %w", err)
+	}
+	return nil
+}
+
+// DeleteBackend deletes a backend instance by ID.
+func (s *PostgresStore) DeleteBackend(ctx context.Context, id string) error {
+	rows, err := s.queries.DeleteBackend(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete backend: %w", err)
+	}
+	if rows == 0 {
+		return ErrBackendNotFound
+	}
+	return nil
+}
+
+// ListBackends retrieves all backend instances.
+func (s *PostgresStore) ListBackends(ctx context.Context) ([]*Instance, error) {
+	rows, err := s.queries.ListBackends(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list backends: %w", err)
+	}
+	return dbBackendsToModels(rows), nil
+}
+
+// ListBackendsByCategory retrieves backend instances filtered by category.
+func (s *PostgresStore) ListBackendsByCategory(ctx context.Context, category string) ([]*Instance, error) {
+	rows, err := s.queries.ListBackendsByCategory(ctx, category)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list backends by category: %w", err)
+	}
+	return dbBackendsToModels(rows), nil
+}
+
+// UpdateBackendStatus updates the status fields of a backend instance.
+func (s *PostgresStore) UpdateBackendStatus(ctx context.Context, id, status, message string) error {
+	now := time.Now().UTC()
+	params := dbsqlc.UpdateBackendStatusParams{
+		ID:            id,
+		Status:        status,
+		StatusMessage: message,
+		LastHealthCheck: pgtype.Timestamptz{
+			Time:  now,
+			Valid: true,
+		},
+		UpdatedAt: now,
+	}
+
+	if err := s.queries.UpdateBackendStatus(ctx, params); err != nil {
+		return fmt.Errorf("failed to update backend status: %w", err)
+	}
+	return nil
+}
+
+// CreateBackendLink creates a link between an IMS and DMS backend.
+func (s *PostgresStore) CreateBackendLink(ctx context.Context, imsID, dmsID string) error {
+	params := dbsqlc.CreateBackendLinkParams{
+		ImsID:     imsID,
+		DmsID:     dmsID,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	if err := s.queries.CreateBackendLink(ctx, params); err != nil {
+		if isUniqueViolation(err) {
+			return ErrBackendLinkExists
+		}
+		return fmt.Errorf("failed to create backend link: %w", err)
+	}
+	return nil
+}
+
+// DeleteBackendLink removes a link between an IMS and DMS backend.
+func (s *PostgresStore) DeleteBackendLink(ctx context.Context, imsID, dmsID string) error {
+	params := dbsqlc.DeleteBackendLinkParams{
+		ImsID: imsID,
+		DmsID: dmsID,
+	}
+
+	rows, err := s.queries.DeleteBackendLink(ctx, params)
+	if err != nil {
+		return fmt.Errorf("failed to delete backend link: %w", err)
+	}
+	if rows == 0 {
+		return ErrBackendLinkNotFound
+	}
+	return nil
+}
+
+// ListDMSLinksByIMS retrieves all DMS backends linked to an IMS backend.
+func (s *PostgresStore) ListDMSLinksByIMS(ctx context.Context, imsID string) ([]*Instance, error) {
+	rows, err := s.queries.ListDMSLinksByIMS(ctx, imsID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list DMS links: %w", err)
+	}
+	return dbBackendsToModels(rows), nil
+}
+
+// ListIMSLinksByDMS retrieves all IMS backends linked to a DMS backend.
+func (s *PostgresStore) ListIMSLinksByDMS(ctx context.Context, dmsID string) ([]*Instance, error) {
+	rows, err := s.queries.ListIMSLinksByDMS(ctx, dmsID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list IMS links: %w", err)
+	}
+	return dbBackendsToModels(rows), nil
+}
+
+// CreateAccess creates a new backend access record.
+func (s *PostgresStore) CreateBackendAccess(ctx context.Context, access *Access) error {
+	permJSON, err := json.Marshal(access.Permissions)
+	if err != nil {
+		return fmt.Errorf("failed to marshal permissions: %w", err)
+	}
+
+	constraintsJSON, err := json.Marshal(access.Constraints)
+	if err != nil {
+		return fmt.Errorf("failed to marshal constraints: %w", err)
+	}
+
+	params := dbsqlc.CreateBackendAccessParams{
+		ID:          access.ID,
+		TenantID:    access.TenantID,
+		BackendID:   access.BackendID,
+		Permissions: permJSON,
+		Constraints: constraintsJSON,
+		GrantedAt:   access.GrantedAt,
+		GrantedBy:   access.GrantedBy,
+	}
+
+	if err := s.queries.CreateBackendAccess(ctx, params); err != nil {
+		if isUniqueViolation(err) {
+			return ErrAccessExists
+		}
+		return fmt.Errorf("failed to create backend access: %w", err)
+	}
+	return nil
+}
+
+// GetAccess retrieves a backend access record by ID.
+func (s *PostgresStore) GetBackendAccess(ctx context.Context, id string) (*Access, error) {
+	row, err := s.queries.GetBackendAccess(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrAccessNotFound
+		}
+		return nil, fmt.Errorf("failed to get backend access: %w", err)
+	}
+	return dbAccessToModel(&row)
+}
+
+// UpdateAccess updates an existing backend access record.
+func (s *PostgresStore) UpdateBackendAccess(ctx context.Context, access *Access) error {
+	permJSON, err := json.Marshal(access.Permissions)
+	if err != nil {
+		return fmt.Errorf("failed to marshal permissions: %w", err)
+	}
+
+	constraintsJSON, err := json.Marshal(access.Constraints)
+	if err != nil {
+		return fmt.Errorf("failed to marshal constraints: %w", err)
+	}
+
+	params := dbsqlc.UpdateBackendAccessParams{
+		ID:          access.ID,
+		Permissions: permJSON,
+		Constraints: constraintsJSON,
+	}
+
+	if err := s.queries.UpdateBackendAccess(ctx, params); err != nil {
+		return fmt.Errorf("failed to update backend access: %w", err)
+	}
+	return nil
+}
+
+// DeleteAccess deletes a backend access record by ID.
+func (s *PostgresStore) DeleteBackendAccess(ctx context.Context, id string) error {
+	rows, err := s.queries.DeleteBackendAccess(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete backend access: %w", err)
+	}
+	if rows == 0 {
+		return ErrAccessNotFound
+	}
+	return nil
+}
+
+// ListAccessByTenant retrieves all access records for a tenant.
+func (s *PostgresStore) ListBackendAccessByTenant(ctx context.Context, tenantID string) ([]*Access, error) {
+	rows, err := s.queries.ListBackendAccessByTenant(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list backend access by tenant: %w", err)
+	}
+	return dbAccessListToModels(rows)
+}
+
+// ListAccessByBackend retrieves all access records for a backend.
+func (s *PostgresStore) ListBackendAccessByBackend(ctx context.Context, backendID string) ([]*Access, error) {
+	rows, err := s.queries.ListBackendAccessByBackend(ctx, backendID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list backend access by backend: %w", err)
+	}
+	return dbAccessListToModels(rows)
+}
+
+// Close closes the connection pool.
+func (s *PostgresStore) Close() error {
+	s.pool.Close()
+	return nil
+}
+
+// Ping checks if the database is reachable.
+func (s *PostgresStore) Ping(ctx context.Context) error {
+	if err := s.pool.Ping(ctx); err != nil {
+		return fmt.Errorf("postgres ping failed: %w", err)
+	}
+	return nil
+}
+
+// isUniqueViolation checks if the error is a PostgreSQL unique constraint violation.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == pgUniqueViolation
+	}
+	return false
+}
+
+// timestamptzFromTime converts a time.Time to pgtype.Timestamptz.
+func timestamptzFromTime(t time.Time) pgtype.Timestamptz {
+	if t.IsZero() {
+		return pgtype.Timestamptz{Valid: false}
+	}
+	return pgtype.Timestamptz{Time: t, Valid: true}
+}
+
+// timeFromTimestamptz converts a pgtype.Timestamptz to time.Time.
+func timeFromTimestamptz(ts pgtype.Timestamptz) time.Time {
+	if !ts.Valid {
+		return time.Time{}
+	}
+	return ts.Time
+}
+
+// dbBackendToModel converts a dbsqlc.BackendInstance to a backend.Instance.
+func dbBackendToModel(row *dbsqlc.BackendInstance) *Instance {
+	return &Instance{
+		ID:              row.ID,
+		Name:            row.Name,
+		Category:        row.Category,
+		AdapterType:     row.AdapterType,
+		Description:     row.Description,
+		Config:          row.Config,
+		Credentials:     row.Credentials,
+		Status:          row.Status,
+		StatusMessage:   row.StatusMessage,
+		LastHealthCheck: timeFromTimestamptz(row.LastHealthCheck),
+		CreatedAt:       row.CreatedAt,
+		UpdatedAt:       row.UpdatedAt,
+	}
+}
+
+// dbBackendsToModels converts a slice of dbsqlc.BackendInstance to backend.Instance models.
+func dbBackendsToModels(rows []dbsqlc.BackendInstance) []*Instance {
+	result := make([]*Instance, 0, len(rows))
+	for i := range rows {
+		result = append(result, dbBackendToModel(&rows[i]))
+	}
+	return result
+}
+
+// dbAccessToModel converts a dbsqlc.BackendAccess to a backend.Access.
+func dbAccessToModel(row *dbsqlc.BackendAccess) (*Access, error) {
+	var perms []string
+	if err := json.Unmarshal(row.Permissions, &perms); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal permissions: %w", err)
+	}
+
+	var constraints map[string]interface{}
+	if err := json.Unmarshal(row.Constraints, &constraints); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal constraints: %w", err)
+	}
+
+	return &Access{
+		ID:          row.ID,
+		TenantID:    row.TenantID,
+		BackendID:   row.BackendID,
+		Permissions: perms,
+		Constraints: constraints,
+		GrantedAt:   row.GrantedAt,
+		GrantedBy:   row.GrantedBy,
+	}, nil
+}
+
+// dbAccessListToModels converts a slice of dbsqlc.BackendAccess to backend.Access models.
+func dbAccessListToModels(rows []dbsqlc.BackendAccess) ([]*Access, error) {
+	result := make([]*Access, 0, len(rows))
+	for i := range rows {
+		access, err := dbAccessToModel(&rows[i])
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, access)
+	}
+	return result, nil
+}

--- a/internal/backend/postgres_store_test.go
+++ b/internal/backend/postgres_store_test.go
@@ -1,0 +1,376 @@
+package backend_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/piwi3910/netweave/internal/backend"
+	"github.com/piwi3910/netweave/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	testPostgresImage = "postgres:16-alpine"
+	testDBName        = "netweave_test"
+	testDBUser        = "testuser"
+	testDBPassword    = "testpass"
+)
+
+func setupTestDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image:        testPostgresImage,
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_USER":     testDBUser,
+			"POSTGRES_PASSWORD": testDBPassword,
+			"POSTGRES_DB":       testDBName,
+		},
+		WaitingFor: wait.ForAll(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+			wait.ForListeningPort("5432/tcp"),
+		).WithDeadline(60 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err, "failed to start PostgreSQL container")
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+
+	mappedPort, err := container.MappedPort(ctx, "5432/tcp")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if termErr := container.Terminate(ctx); termErr != nil {
+			t.Logf("failed to terminate PostgreSQL container: %v", termErr)
+		}
+	})
+
+	cfg := &database.PostgresConfig{
+		Host:           host,
+		Port:           mappedPort.Int(),
+		Database:       testDBName,
+		User:           testDBUser,
+		PasswordEnvVar: "TEST_PG_PASSWORD",
+		SSLMode:        "disable",
+		MaxConns:       5,
+		MinConns:       1,
+	}
+
+	db, err := database.New(ctx, cfg, testDBPassword)
+	require.NoError(t, err)
+
+	err = database.Migrate(ctx, db.Pool)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db.Pool
+}
+
+func newTestBackend(id, name, category, adapterType string) *backend.Instance {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	return &backend.Instance{
+		ID:          id,
+		Name:        name,
+		Category:    category,
+		AdapterType: adapterType,
+		Description: "test backend",
+		Config:      []byte(`{"key":"value"}`),
+		Credentials: []byte(`{"secret":"encrypted"}`),
+		Status:      "unknown",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+}
+
+func TestPostgresStore_BackendCRUD(t *testing.T) {
+	pool := setupTestDB(t)
+	store := backend.NewPostgresStore(pool)
+	ctx := context.Background()
+
+	t.Run("create and get backend", func(t *testing.T) {
+		b := newTestBackend("be-1", "test-k8s", "ims", "kubernetes")
+		err := store.CreateBackend(ctx, b)
+		require.NoError(t, err)
+
+		got, err := store.GetBackend(ctx, "be-1")
+		require.NoError(t, err)
+		assert.Equal(t, b.Name, got.Name)
+		assert.Equal(t, b.Category, got.Category)
+		assert.Equal(t, b.AdapterType, got.AdapterType)
+		assert.Equal(t, b.Config, got.Config)
+		assert.Equal(t, b.Credentials, got.Credentials)
+	})
+
+	t.Run("create duplicate name returns error", func(t *testing.T) {
+		b := newTestBackend("be-dup-1", "duplicate-name", "ims", "kubernetes")
+		err := store.CreateBackend(ctx, b)
+		require.NoError(t, err)
+
+		b2 := newTestBackend("be-dup-2", "duplicate-name", "dms", "helm")
+		err = store.CreateBackend(ctx, b2)
+		require.ErrorIs(t, err, backend.ErrBackendExists)
+	})
+
+	t.Run("get non-existent backend returns not found", func(t *testing.T) {
+		_, err := store.GetBackend(ctx, "non-existent")
+		require.ErrorIs(t, err, backend.ErrBackendNotFound)
+	})
+
+	t.Run("update backend", func(t *testing.T) {
+		b := newTestBackend("be-upd", "update-me", "ims", "aws")
+		err := store.CreateBackend(ctx, b)
+		require.NoError(t, err)
+
+		b.Name = "updated-name"
+		b.Description = "updated description"
+		b.UpdatedAt = time.Now().UTC().Truncate(time.Microsecond)
+		err = store.UpdateBackend(ctx, b)
+		require.NoError(t, err)
+
+		got, err := store.GetBackend(ctx, "be-upd")
+		require.NoError(t, err)
+		assert.Equal(t, "updated-name", got.Name)
+		assert.Equal(t, "updated description", got.Description)
+	})
+
+	t.Run("update non-existent backend returns not found", func(t *testing.T) {
+		b := newTestBackend("non-existent", "name", "ims", "aws")
+		err := store.UpdateBackend(ctx, b)
+		require.ErrorIs(t, err, backend.ErrBackendNotFound)
+	})
+
+	t.Run("delete backend", func(t *testing.T) {
+		b := newTestBackend("be-del", "delete-me", "dms", "helm")
+		err := store.CreateBackend(ctx, b)
+		require.NoError(t, err)
+
+		err = store.DeleteBackend(ctx, "be-del")
+		require.NoError(t, err)
+
+		_, err = store.GetBackend(ctx, "be-del")
+		require.ErrorIs(t, err, backend.ErrBackendNotFound)
+	})
+
+	t.Run("delete non-existent backend returns not found", func(t *testing.T) {
+		err := store.DeleteBackend(ctx, "non-existent")
+		require.ErrorIs(t, err, backend.ErrBackendNotFound)
+	})
+}
+
+func TestPostgresStore_ListBackends(t *testing.T) {
+	pool := setupTestDB(t)
+	store := backend.NewPostgresStore(pool)
+	ctx := context.Background()
+
+	backends := []*backend.Instance{
+		newTestBackend("lb-1", "k8s-prod", "ims", "kubernetes"),
+		newTestBackend("lb-2", "aws-staging", "ims", "aws"),
+		newTestBackend("lb-3", "helm-repo", "dms", "helm"),
+	}
+	for _, b := range backends {
+		err := store.CreateBackend(ctx, b)
+		require.NoError(t, err)
+	}
+
+	t.Run("list all backends", func(t *testing.T) {
+		result, err := store.ListBackends(ctx)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(result), 3)
+	})
+
+	t.Run("list IMS backends", func(t *testing.T) {
+		result, err := store.ListBackendsByCategory(ctx, "ims")
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(result), 2)
+		for _, b := range result {
+			assert.Equal(t, "ims", b.Category)
+		}
+	})
+
+	t.Run("list DMS backends", func(t *testing.T) {
+		result, err := store.ListBackendsByCategory(ctx, "dms")
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(result), 1)
+		for _, b := range result {
+			assert.Equal(t, "dms", b.Category)
+		}
+	})
+}
+
+func TestPostgresStore_BackendStatus(t *testing.T) {
+	pool := setupTestDB(t)
+	store := backend.NewPostgresStore(pool)
+	ctx := context.Background()
+
+	b := newTestBackend("bs-1", "status-test", "ims", "kubernetes")
+	err := store.CreateBackend(ctx, b)
+	require.NoError(t, err)
+
+	err = store.UpdateBackendStatus(ctx, "bs-1", "connected", "healthy")
+	require.NoError(t, err)
+
+	got, err := store.GetBackend(ctx, "bs-1")
+	require.NoError(t, err)
+	assert.Equal(t, "connected", got.Status)
+	assert.Equal(t, "healthy", got.StatusMessage)
+	assert.False(t, got.LastHealthCheck.IsZero())
+}
+
+func TestPostgresStore_BackendLinks(t *testing.T) {
+	pool := setupTestDB(t)
+	store := backend.NewPostgresStore(pool)
+	ctx := context.Background()
+
+	ims := newTestBackend("link-ims", "my-k8s", "ims", "kubernetes")
+	dms1 := newTestBackend("link-dms1", "my-helm", "dms", "helm")
+	dms2 := newTestBackend("link-dms2", "my-argocd", "dms", "argocd")
+
+	for _, b := range []*backend.Instance{ims, dms1, dms2} {
+		err := store.CreateBackend(ctx, b)
+		require.NoError(t, err)
+	}
+
+	t.Run("create and list links", func(t *testing.T) {
+		err := store.CreateBackendLink(ctx, "link-ims", "link-dms1")
+		require.NoError(t, err)
+
+		err = store.CreateBackendLink(ctx, "link-ims", "link-dms2")
+		require.NoError(t, err)
+
+		dmsLinks, err := store.ListDMSLinksByIMS(ctx, "link-ims")
+		require.NoError(t, err)
+		assert.Len(t, dmsLinks, 2)
+
+		imsLinks, err := store.ListIMSLinksByDMS(ctx, "link-dms1")
+		require.NoError(t, err)
+		assert.Len(t, imsLinks, 1)
+		assert.Equal(t, "link-ims", imsLinks[0].ID)
+	})
+
+	t.Run("create duplicate link returns error", func(t *testing.T) {
+		err := store.CreateBackendLink(ctx, "link-ims", "link-dms1")
+		require.ErrorIs(t, err, backend.ErrBackendLinkExists)
+	})
+
+	t.Run("delete link", func(t *testing.T) {
+		err := store.DeleteBackendLink(ctx, "link-ims", "link-dms2")
+		require.NoError(t, err)
+
+		dmsLinks, err := store.ListDMSLinksByIMS(ctx, "link-ims")
+		require.NoError(t, err)
+		assert.Len(t, dmsLinks, 1)
+	})
+
+	t.Run("delete non-existent link returns not found", func(t *testing.T) {
+		err := store.DeleteBackendLink(ctx, "link-ims", "non-existent")
+		require.ErrorIs(t, err, backend.ErrBackendLinkNotFound)
+	})
+}
+
+func TestPostgresStore_Access(t *testing.T) {
+	pool := setupTestDB(t)
+	store := backend.NewPostgresStore(pool)
+	ctx := context.Background()
+
+	b := newTestBackend("acc-be", "access-backend", "ims", "kubernetes")
+	err := store.CreateBackend(ctx, b)
+	require.NoError(t, err)
+
+	t.Run("create and get access", func(t *testing.T) {
+		access := &backend.Access{
+			ID:          "acc-1",
+			TenantID:    "tenant-1",
+			BackendID:   "acc-be",
+			Permissions: []string{"read", "list"},
+			Constraints: map[string]interface{}{"namespace": "default"},
+			GrantedAt:   time.Now().UTC().Truncate(time.Microsecond),
+			GrantedBy:   "admin-user",
+		}
+		err := store.CreateBackendAccess(ctx, access)
+		require.NoError(t, err)
+
+		got, err := store.GetBackendAccess(ctx, "acc-1")
+		require.NoError(t, err)
+		assert.Equal(t, "tenant-1", got.TenantID)
+		assert.Equal(t, "acc-be", got.BackendID)
+		assert.Equal(t, []string{"read", "list"}, got.Permissions)
+		assert.Equal(t, "default", got.Constraints["namespace"])
+	})
+
+	t.Run("get non-existent access returns not found", func(t *testing.T) {
+		_, err := store.GetBackendAccess(ctx, "non-existent")
+		require.ErrorIs(t, err, backend.ErrAccessNotFound)
+	})
+
+	t.Run("update access", func(t *testing.T) {
+		access := &backend.Access{
+			ID:          "acc-1",
+			Permissions: []string{"read", "list", "write"},
+			Constraints: map[string]interface{}{"namespace": "production"},
+		}
+		err := store.UpdateBackendAccess(ctx, access)
+		require.NoError(t, err)
+
+		got, err := store.GetBackendAccess(ctx, "acc-1")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"read", "list", "write"}, got.Permissions)
+		assert.Equal(t, "production", got.Constraints["namespace"])
+	})
+
+	t.Run("list access by tenant", func(t *testing.T) {
+		result, err := store.ListBackendAccessByTenant(ctx, "tenant-1")
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+	})
+
+	t.Run("list access by backend", func(t *testing.T) {
+		result, err := store.ListBackendAccessByBackend(ctx, "acc-be")
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+	})
+
+	t.Run("delete access", func(t *testing.T) {
+		err := store.DeleteBackendAccess(ctx, "acc-1")
+		require.NoError(t, err)
+
+		_, err = store.GetBackendAccess(ctx, "acc-1")
+		require.ErrorIs(t, err, backend.ErrAccessNotFound)
+	})
+
+	t.Run("delete non-existent access returns not found", func(t *testing.T) {
+		err := store.DeleteBackendAccess(ctx, "non-existent")
+		require.ErrorIs(t, err, backend.ErrAccessNotFound)
+	})
+}
+
+func TestPostgresStore_PingAndClose(t *testing.T) {
+	pool := setupTestDB(t)
+	store := backend.NewPostgresStore(pool)
+	ctx := context.Background()
+
+	err := store.Ping(ctx)
+	require.NoError(t, err)
+
+	err = store.Close()
+	require.NoError(t, err)
+}

--- a/internal/backend/schema.go
+++ b/internal/backend/schema.go
@@ -1,0 +1,120 @@
+// Package backend provides multi-backend instance management for the O2-IMS gateway.
+// It supports registering, configuring, and managing IMS and DMS adapter backends
+// with encrypted credential storage and tenant-scoped access control.
+package backend
+
+import "sync"
+
+// FieldType represents a form field type for adapter configuration.
+type FieldType string
+
+// Supported field types.
+const (
+	FieldTypeString  FieldType = "string"
+	FieldTypeNumber  FieldType = "number"
+	FieldTypeBoolean FieldType = "boolean"
+	FieldTypeText    FieldType = "text"
+)
+
+// FieldSpec defines a single configuration or credential field.
+type FieldSpec struct {
+	// Name is the field identifier used in configuration maps.
+	Name string `json:"name"`
+
+	// Label is the human-readable label for the field.
+	Label string `json:"label"`
+
+	// Type is the field data type.
+	Type FieldType `json:"type"`
+
+	// Required indicates whether the field must be provided.
+	Required bool `json:"required"`
+
+	// Secret indicates whether the field contains sensitive data.
+	Secret bool `json:"secret"`
+
+	// Default is the default value for the field, if any.
+	Default string `json:"default,omitempty"`
+
+	// Placeholder is the placeholder text for the field.
+	Placeholder string `json:"placeholder,omitempty"`
+
+	// Regex is an optional validation regex pattern.
+	Regex string `json:"regex,omitempty"`
+
+	// Description provides additional help text for the field.
+	Description string `json:"description,omitempty"`
+}
+
+// AdapterTypeSchema defines the configuration schema for an adapter type.
+type AdapterTypeSchema struct {
+	// Type is the adapter type identifier (e.g., "kubernetes", "helm").
+	Type string `json:"type"`
+
+	// Category is the adapter category ("ims" or "dms").
+	Category string `json:"category"`
+
+	// DisplayName is the human-readable name for the adapter type.
+	DisplayName string `json:"displayName"`
+
+	// Description provides a brief summary of the adapter type.
+	Description string `json:"description"`
+
+	// ConfigSchema defines the non-secret configuration fields.
+	ConfigSchema []FieldSpec `json:"configSchema"`
+
+	// CredentialSchema defines the secret credential fields.
+	CredentialSchema []FieldSpec `json:"credentialSchema"`
+}
+
+// SchemaRegistry provides thread-safe lookup for adapter type schemas.
+type SchemaRegistry struct {
+	mu      sync.RWMutex
+	schemas map[string]*AdapterTypeSchema
+}
+
+// NewSchemaRegistry creates a new empty SchemaRegistry.
+func NewSchemaRegistry() *SchemaRegistry {
+	return &SchemaRegistry{
+		schemas: make(map[string]*AdapterTypeSchema),
+	}
+}
+
+// Register adds an adapter type schema to the registry.
+func (r *SchemaRegistry) Register(schema *AdapterTypeSchema) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.schemas[schema.Type] = schema
+}
+
+// Get retrieves an adapter type schema by type name.
+func (r *SchemaRegistry) Get(adapterType string) (*AdapterTypeSchema, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	schema, ok := r.schemas[adapterType]
+	return schema, ok
+}
+
+// List returns all registered adapter type schemas.
+func (r *SchemaRegistry) List() []*AdapterTypeSchema {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]*AdapterTypeSchema, 0, len(r.schemas))
+	for _, schema := range r.schemas {
+		result = append(result, schema)
+	}
+	return result
+}
+
+// ListByCategory returns adapter type schemas filtered by category ("ims" or "dms").
+func (r *SchemaRegistry) ListByCategory(category string) []*AdapterTypeSchema {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]*AdapterTypeSchema, 0)
+	for _, schema := range r.schemas {
+		if schema.Category == category {
+			result = append(result, schema)
+		}
+	}
+	return result
+}

--- a/internal/backend/schemas_builtin.go
+++ b/internal/backend/schemas_builtin.go
@@ -1,0 +1,301 @@
+package backend
+
+// RegisterBuiltinSchemas registers all built-in adapter type schemas.
+func RegisterBuiltinSchemas(registry *SchemaRegistry) {
+	registerIMSSchemas(registry)
+	registerDMSSchemas(registry)
+}
+
+func registerIMSSchemas(registry *SchemaRegistry) {
+	registry.Register(kubernetesSchema())
+	registry.Register(awsSchema())
+	registry.Register(azureSchema())
+	registry.Register(openstackSchema())
+}
+
+func registerDMSSchemas(registry *SchemaRegistry) {
+	registry.Register(helmSchema())
+	registry.Register(argocdSchema())
+	registry.Register(fluxSchema())
+}
+
+func kubernetesSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "kubernetes",
+		Category:    "ims",
+		DisplayName: "Kubernetes",
+		Description: "Kubernetes cluster via kubeconfig.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "context",
+				Label:       "Context",
+				Type:        FieldTypeString,
+				Description: "Kubernetes context name from the kubeconfig.",
+			},
+			{
+				Name:        "namespace",
+				Label:       "Namespace",
+				Type:        FieldTypeString,
+				Default:     "default",
+				Description: "Default namespace for resource discovery.",
+			},
+		},
+		CredentialSchema: []FieldSpec{
+			{
+				Name:        "kubeconfig",
+				Label:       "Kubeconfig",
+				Type:        FieldTypeText,
+				Required:    true,
+				Secret:      true,
+				Description: "Kubeconfig YAML content for cluster authentication.",
+			},
+		},
+	}
+}
+
+func awsSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "aws",
+		Category:    "ims",
+		DisplayName: "AWS",
+		Description: "Amazon Web Services infrastructure.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "region",
+				Label:       "Region",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "us-east-1",
+				Description: "AWS region for resource discovery.",
+			},
+		},
+		CredentialSchema: []FieldSpec{
+			{
+				Name:        "access_key_id",
+				Label:       "Access Key ID",
+				Type:        FieldTypeString,
+				Required:    true,
+				Secret:      true,
+				Description: "AWS access key ID.",
+			},
+			{
+				Name:        "secret_access_key",
+				Label:       "Secret Access Key",
+				Type:        FieldTypeString,
+				Required:    true,
+				Secret:      true,
+				Description: "AWS secret access key.",
+			},
+		},
+	}
+}
+
+func azureSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "azure",
+		Category:    "ims",
+		DisplayName: "Azure",
+		Description: "Microsoft Azure infrastructure.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "subscription_id",
+				Label:       "Subscription ID",
+				Type:        FieldTypeString,
+				Required:    true,
+				Description: "Azure subscription identifier.",
+			},
+			{
+				Name:        "resource_group",
+				Label:       "Resource Group",
+				Type:        FieldTypeString,
+				Required:    true,
+				Description: "Azure resource group name.",
+			},
+			{
+				Name:        "tenant_id",
+				Label:       "Tenant ID",
+				Type:        FieldTypeString,
+				Required:    true,
+				Description: "Azure Active Directory tenant identifier.",
+			},
+			{
+				Name:        "client_id",
+				Label:       "Client ID",
+				Type:        FieldTypeString,
+				Required:    true,
+				Description: "Azure service principal client identifier.",
+			},
+		},
+		CredentialSchema: []FieldSpec{
+			{
+				Name:        "client_secret",
+				Label:       "Client Secret",
+				Type:        FieldTypeString,
+				Required:    true,
+				Secret:      true,
+				Description: "Azure service principal client secret.",
+			},
+		},
+	}
+}
+
+func openstackSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "openstack",
+		Category:    "ims",
+		DisplayName: "OpenStack",
+		Description: "OpenStack cloud infrastructure.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "auth_url",
+				Label:       "Auth URL",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "https://keystone.example.com:5000/v3",
+				Description: "OpenStack Keystone authentication URL.",
+			},
+			{
+				Name:        "region",
+				Label:       "Region",
+				Type:        FieldTypeString,
+				Description: "OpenStack region name.",
+			},
+			{
+				Name:        "project_name",
+				Label:       "Project Name",
+				Type:        FieldTypeString,
+				Description: "OpenStack project (tenant) name.",
+			},
+			{
+				Name:        "domain_name",
+				Label:       "Domain Name",
+				Type:        FieldTypeString,
+				Description: "OpenStack domain name.",
+			},
+		},
+		CredentialSchema: []FieldSpec{
+			{
+				Name:        "username",
+				Label:       "Username",
+				Type:        FieldTypeString,
+				Required:    true,
+				Secret:      true,
+				Description: "OpenStack username.",
+			},
+			{
+				Name:        "password",
+				Label:       "Password",
+				Type:        FieldTypeString,
+				Required:    true,
+				Secret:      true,
+				Description: "OpenStack password.",
+			},
+		},
+	}
+}
+
+func helmSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "helm",
+		Category:    "dms",
+		DisplayName: "Helm",
+		Description: "Helm chart repository for deployment management.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "repo_url",
+				Label:       "Repository URL",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "oci://registry.example.com/charts",
+				Description: "Helm chart repository URL.",
+			},
+			{
+				Name:        "repo_type",
+				Label:       "Repository Type",
+				Type:        FieldTypeString,
+				Default:     "oci",
+				Description: "Repository type (oci or http).",
+			},
+		},
+		CredentialSchema: []FieldSpec{
+			{
+				Name:        "username",
+				Label:       "Username",
+				Type:        FieldTypeString,
+				Secret:      true,
+				Description: "Repository authentication username.",
+			},
+			{
+				Name:        "password",
+				Label:       "Password",
+				Type:        FieldTypeString,
+				Secret:      true,
+				Description: "Repository authentication password.",
+			},
+		},
+	}
+}
+
+func argocdSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "argocd",
+		Category:    "dms",
+		DisplayName: "Argo CD",
+		Description: "Argo CD GitOps continuous delivery.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "server_url",
+				Label:       "Server URL",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "https://argocd.example.com",
+				Description: "Argo CD server URL.",
+			},
+		},
+		CredentialSchema: []FieldSpec{
+			{
+				Name:        "auth_token",
+				Label:       "Auth Token",
+				Type:        FieldTypeString,
+				Required:    true,
+				Secret:      true,
+				Description: "Argo CD API authentication token.",
+			},
+		},
+	}
+}
+
+func fluxSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "flux",
+		Category:    "dms",
+		DisplayName: "Flux CD",
+		Description: "Flux CD GitOps toolkit for Kubernetes.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "git_url",
+				Label:       "Git URL",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "git@github.com:org/repo.git",
+				Description: "Git repository URL for Flux source.",
+			},
+			{
+				Name:        "branch",
+				Label:       "Branch",
+				Type:        FieldTypeString,
+				Default:     "main",
+				Description: "Git branch to track.",
+			},
+		},
+		CredentialSchema: []FieldSpec{
+			{
+				Name:        "ssh_key",
+				Label:       "SSH Key",
+				Type:        FieldTypeText,
+				Secret:      true,
+				Description: "SSH private key for Git repository authentication.",
+			},
+		},
+	}
+}

--- a/internal/backend/store.go
+++ b/internal/backend/store.go
@@ -1,0 +1,162 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Sentinel errors for backend storage operations.
+var (
+	// ErrBackendNotFound is returned when a backend instance does not exist.
+	ErrBackendNotFound = errors.New("backend instance not found")
+
+	// ErrBackendExists is returned when attempting to create a duplicate backend.
+	ErrBackendExists = errors.New("backend instance already exists")
+
+	// ErrBackendLinkExists is returned when a DMS-IMS link already exists.
+	ErrBackendLinkExists = errors.New("backend link already exists")
+
+	// ErrBackendLinkNotFound is returned when a DMS-IMS link does not exist.
+	ErrBackendLinkNotFound = errors.New("backend link not found")
+
+	// ErrAccessNotFound is returned when a backend access record does not exist.
+	ErrAccessNotFound = errors.New("backend access not found")
+
+	// ErrAccessExists is returned when a backend access record already exists for the tenant-backend pair.
+	ErrAccessExists = errors.New("backend access already exists")
+)
+
+// Instance represents a configured adapter backend instance.
+type Instance struct {
+	// ID is the unique backend instance identifier.
+	ID string `json:"id"`
+
+	// Name is the human-readable name.
+	Name string `json:"name"`
+
+	// Category is "ims" or "dms".
+	Category string `json:"category"`
+
+	// AdapterType is the adapter type (e.g., "kubernetes", "helm").
+	AdapterType string `json:"adapterType"`
+
+	// Description provides a summary of the backend.
+	Description string `json:"description,omitempty"`
+
+	// Config holds the encrypted configuration data.
+	Config []byte `json:"-"`
+
+	// Credentials holds the encrypted credential data.
+	Credentials []byte `json:"-"`
+
+	// Status is the current health status (e.g., "connected", "error", "unknown").
+	Status string `json:"status"`
+
+	// StatusMessage provides details about the current status.
+	StatusMessage string `json:"statusMessage,omitempty"`
+
+	// LastHealthCheck is the timestamp of the last health check.
+	LastHealthCheck time.Time `json:"lastHealthCheck,omitempty"`
+
+	// CreatedAt is the creation timestamp.
+	CreatedAt time.Time `json:"createdAt"`
+
+	// UpdatedAt is the last update timestamp.
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// Access represents a tenant's access to a backend instance.
+type Access struct {
+	// ID is the unique access record identifier.
+	ID string `json:"id"`
+
+	// TenantID is the tenant this access belongs to.
+	TenantID string `json:"tenantId"`
+
+	// BackendID is the backend instance this access grants.
+	BackendID string `json:"backendId"`
+
+	// Permissions is the list of permitted actions.
+	Permissions []string `json:"permissions"`
+
+	// Constraints holds optional access constraints (e.g., namespace restrictions).
+	Constraints map[string]interface{} `json:"constraints,omitempty"`
+
+	// GrantedAt is when the access was granted.
+	GrantedAt time.Time `json:"grantedAt"`
+
+	// GrantedBy is the user ID who granted the access.
+	GrantedBy string `json:"grantedBy"`
+}
+
+// Store defines the interface for backend instance storage operations.
+// Implementations must be safe for concurrent use.
+type Store interface {
+	// CreateBackend creates a new backend instance.
+	// Returns ErrBackendExists if a backend with the same name already exists.
+	CreateBackend(ctx context.Context, instance *Instance) error
+
+	// GetBackend retrieves a backend instance by ID.
+	// Returns ErrBackendNotFound if the backend does not exist.
+	GetBackend(ctx context.Context, id string) (*Instance, error)
+
+	// UpdateBackend updates an existing backend instance.
+	// Returns ErrBackendNotFound if the backend does not exist.
+	UpdateBackend(ctx context.Context, instance *Instance) error
+
+	// DeleteBackend deletes a backend instance by ID.
+	// Returns ErrBackendNotFound if the backend does not exist.
+	DeleteBackend(ctx context.Context, id string) error
+
+	// ListBackends retrieves all backend instances.
+	ListBackends(ctx context.Context) ([]*Instance, error)
+
+	// ListBackendsByCategory retrieves backend instances by category ("ims" or "dms").
+	ListBackendsByCategory(ctx context.Context, category string) ([]*Instance, error)
+
+	// UpdateBackendStatus updates the status fields of a backend instance.
+	UpdateBackendStatus(ctx context.Context, id, status, message string) error
+
+	// CreateBackendLink creates a link between an IMS and DMS backend.
+	// Returns ErrBackendLinkExists if the link already exists.
+	CreateBackendLink(ctx context.Context, imsID, dmsID string) error
+
+	// DeleteBackendLink removes a link between an IMS and DMS backend.
+	// Returns ErrBackendLinkNotFound if the link does not exist.
+	DeleteBackendLink(ctx context.Context, imsID, dmsID string) error
+
+	// ListDMSLinksByIMS retrieves all DMS backends linked to an IMS backend.
+	ListDMSLinksByIMS(ctx context.Context, imsID string) ([]*Instance, error)
+
+	// ListIMSLinksByDMS retrieves all IMS backends linked to a DMS backend.
+	ListIMSLinksByDMS(ctx context.Context, dmsID string) ([]*Instance, error)
+
+	// CreateAccess creates a new backend access record.
+	// Returns ErrAccessExists if access already exists for the tenant-backend pair.
+	CreateBackendAccess(ctx context.Context, access *Access) error
+
+	// GetAccess retrieves a backend access record by ID.
+	// Returns ErrAccessNotFound if the access does not exist.
+	GetBackendAccess(ctx context.Context, id string) (*Access, error)
+
+	// UpdateAccess updates an existing backend access record.
+	// Returns ErrAccessNotFound if the access does not exist.
+	UpdateBackendAccess(ctx context.Context, access *Access) error
+
+	// DeleteAccess deletes a backend access record by ID.
+	// Returns ErrAccessNotFound if the access does not exist.
+	DeleteBackendAccess(ctx context.Context, id string) error
+
+	// ListAccessByTenant retrieves all access records for a tenant.
+	ListBackendAccessByTenant(ctx context.Context, tenantID string) ([]*Access, error)
+
+	// ListAccessByBackend retrieves all access records for a backend.
+	ListBackendAccessByBackend(ctx context.Context, backendID string) ([]*Access, error)
+
+	// Close closes the storage connection and releases resources.
+	Close() error
+
+	// Ping checks if the storage backend is available.
+	Ping(ctx context.Context) error
+}

--- a/internal/encryption/aes.go
+++ b/internal/encryption/aes.go
@@ -1,0 +1,81 @@
+package encryption
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// AESKeySize is the required key size for AES-256-GCM encryption (32 bytes).
+const AESKeySize = 32
+
+// AES-256-GCM errors.
+var (
+	// ErrInvalidKeySize is returned when the key is not exactly 32 bytes.
+	ErrInvalidKeySize = errors.New("key must be exactly 32 bytes for AES-256")
+
+	// ErrCiphertextTooShort is returned when the ciphertext is shorter than the nonce.
+	ErrCiphertextTooShort = errors.New("ciphertext too short")
+
+	// ErrDecryptionFailed is returned when decryption fails due to wrong key or corrupted data.
+	ErrDecryptionFailed = errors.New("decryption failed")
+)
+
+// AESEncryptor implements Encryptor using AES-256-GCM.
+// It prepends the nonce to the ciphertext for storage.
+type AESEncryptor struct {
+	gcm cipher.AEAD
+}
+
+// NewAESEncryptor creates a new AESEncryptor with the given 32-byte key.
+func NewAESEncryptor(key []byte) (*AESEncryptor, error) {
+	if len(key) != AESKeySize {
+		return nil, ErrInvalidKeySize
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	return &AESEncryptor{gcm: gcm}, nil
+}
+
+// Encrypt encrypts the plaintext using AES-256-GCM.
+// The nonce is prepended to the ciphertext.
+func (e *AESEncryptor) Encrypt(plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, e.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	ciphertext := e.gcm.Seal(nonce, nonce, plaintext, nil)
+	return ciphertext, nil
+}
+
+// Decrypt decrypts the ciphertext using AES-256-GCM.
+// It expects the nonce to be prepended to the ciphertext.
+func (e *AESEncryptor) Decrypt(ciphertext []byte) ([]byte, error) {
+	nonceSize := e.gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, ErrCiphertextTooShort
+	}
+
+	nonce := ciphertext[:nonceSize]
+	encryptedData := ciphertext[nonceSize:]
+
+	plaintext, err := e.gcm.Open(nil, nonce, encryptedData, nil)
+	if err != nil {
+		return nil, ErrDecryptionFailed
+	}
+
+	return plaintext, nil
+}

--- a/internal/encryption/aes_test.go
+++ b/internal/encryption/aes_test.go
@@ -1,0 +1,176 @@
+package encryption_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/piwi3910/netweave/internal/encryption"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, encryption.AESKeySize)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+	return key
+}
+
+func TestNewAESEncryptor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		keyLen  int
+		wantErr error
+	}{
+		{
+			name:    "valid 32-byte key",
+			keyLen:  32,
+			wantErr: nil,
+		},
+		{
+			name:    "key too short",
+			keyLen:  16,
+			wantErr: encryption.ErrInvalidKeySize,
+		},
+		{
+			name:    "key too long",
+			keyLen:  64,
+			wantErr: encryption.ErrInvalidKeySize,
+		},
+		{
+			name:    "empty key",
+			keyLen:  0,
+			wantErr: encryption.ErrInvalidKeySize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			key := make([]byte, tt.keyLen)
+			enc, err := encryption.NewAESEncryptor(key)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, enc)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, enc)
+			}
+		})
+	}
+}
+
+func TestAESEncryptor_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		plaintext []byte
+	}{
+		{
+			name:      "simple text",
+			plaintext: []byte("hello world"),
+		},
+		{
+			name:      "json data",
+			plaintext: []byte(`{"key":"value","secret":"s3cr3t"}`),
+		},
+		{
+			name:      "binary data",
+			plaintext: []byte{0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd},
+		},
+		{
+			name:      "empty data",
+			plaintext: []byte(""),
+		},
+		{
+			name:      "large data",
+			plaintext: make([]byte, 4096),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			enc, err := encryption.NewAESEncryptor(validKey(t))
+			require.NoError(t, err)
+
+			ciphertext, err := enc.Encrypt(tt.plaintext)
+			require.NoError(t, err)
+			assert.NotEqual(t, tt.plaintext, ciphertext)
+
+			decrypted, err := enc.Decrypt(ciphertext)
+			require.NoError(t, err)
+			assert.Equal(t, string(tt.plaintext), string(decrypted))
+		})
+	}
+}
+
+func TestAESEncryptor_DifferentCiphertexts(t *testing.T) {
+	t.Parallel()
+
+	enc, err := encryption.NewAESEncryptor(validKey(t))
+	require.NoError(t, err)
+
+	plaintext := []byte("same input each time")
+
+	ct1, err := enc.Encrypt(plaintext)
+	require.NoError(t, err)
+
+	ct2, err := enc.Encrypt(plaintext)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, ct1, ct2, "encrypting the same plaintext should produce different ciphertexts")
+}
+
+func TestAESEncryptor_WrongKeyFails(t *testing.T) {
+	t.Parallel()
+
+	key1 := validKey(t)
+	key2 := validKey(t)
+
+	enc1, err := encryption.NewAESEncryptor(key1)
+	require.NoError(t, err)
+
+	enc2, err := encryption.NewAESEncryptor(key2)
+	require.NoError(t, err)
+
+	plaintext := []byte("secret data")
+	ciphertext, err := enc1.Encrypt(plaintext)
+	require.NoError(t, err)
+
+	_, err = enc2.Decrypt(ciphertext)
+	require.ErrorIs(t, err, encryption.ErrDecryptionFailed)
+}
+
+func TestAESEncryptor_CorruptedCiphertext(t *testing.T) {
+	t.Parallel()
+
+	enc, err := encryption.NewAESEncryptor(validKey(t))
+	require.NoError(t, err)
+
+	plaintext := []byte("important data")
+	ciphertext, err := enc.Encrypt(plaintext)
+	require.NoError(t, err)
+
+	// Flip a byte in the encrypted portion (after nonce).
+	corrupted := make([]byte, len(ciphertext))
+	copy(corrupted, ciphertext)
+	corrupted[len(corrupted)-1] ^= 0xff
+
+	_, err = enc.Decrypt(corrupted)
+	require.ErrorIs(t, err, encryption.ErrDecryptionFailed)
+}
+
+func TestAESEncryptor_CiphertextTooShort(t *testing.T) {
+	t.Parallel()
+
+	enc, err := encryption.NewAESEncryptor(validKey(t))
+	require.NoError(t, err)
+
+	_, err = enc.Decrypt([]byte{0x01, 0x02})
+	require.ErrorIs(t, err, encryption.ErrCiphertextTooShort)
+}

--- a/internal/encryption/crypto.go
+++ b/internal/encryption/crypto.go
@@ -1,0 +1,14 @@
+// Package encryption provides encryption and decryption for sensitive data such as
+// backend credentials and configuration. It defines the Encryptor interface and
+// provides implementations using AES-256-GCM (for development/testing) and
+// HashiCorp Vault Transit (for production).
+package encryption
+
+// Encryptor provides encryption and decryption for sensitive data.
+type Encryptor interface {
+	// Encrypt encrypts the given plaintext and returns the ciphertext.
+	Encrypt(plaintext []byte) ([]byte, error)
+
+	// Decrypt decrypts the given ciphertext and returns the plaintext.
+	Decrypt(ciphertext []byte) ([]byte, error)
+}

--- a/internal/encryption/vault.go
+++ b/internal/encryption/vault.go
@@ -1,0 +1,168 @@
+package encryption
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Vault transit errors.
+var (
+	// ErrVaultUnavailable is returned when the Vault server is unreachable.
+	ErrVaultUnavailable = errors.New("vault server unavailable")
+
+	// ErrVaultEncryptFailed is returned when the Vault transit encrypt operation fails.
+	ErrVaultEncryptFailed = errors.New("vault encrypt failed")
+
+	// ErrVaultDecryptFailed is returned when the Vault transit decrypt operation fails.
+	ErrVaultDecryptFailed = errors.New("vault decrypt failed")
+
+	// ErrVaultInvalidResponse is returned when the Vault API returns an unexpected response.
+	ErrVaultInvalidResponse = errors.New("vault returned invalid response")
+)
+
+// VaultConfig holds configuration for connecting to HashiCorp Vault's transit engine.
+type VaultConfig struct {
+	// Address is the Vault server URL (e.g. "https://vault.example.com:8200").
+	Address string
+
+	// Token is the Vault authentication token.
+	Token string
+
+	// MountPath is the transit secrets engine mount path (default: "transit").
+	MountPath string
+
+	// KeyName is the name of the transit encryption key.
+	KeyName string
+}
+
+// VaultEncryptor implements Encryptor using HashiCorp Vault's transit secrets engine.
+type VaultEncryptor struct {
+	cfg    VaultConfig
+	client *http.Client
+}
+
+// NewVaultEncryptor creates a new VaultEncryptor with the given configuration.
+func NewVaultEncryptor(cfg VaultConfig) *VaultEncryptor {
+	if cfg.MountPath == "" {
+		cfg.MountPath = "transit"
+	}
+
+	return &VaultEncryptor{
+		cfg: cfg,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// vaultEncryptRequest is the request body for Vault transit encrypt.
+type vaultEncryptRequest struct {
+	Plaintext string `json:"plaintext"`
+}
+
+// vaultDecryptRequest is the request body for Vault transit decrypt.
+type vaultDecryptRequest struct {
+	Ciphertext string `json:"ciphertext"`
+}
+
+// vaultResponse is the common Vault API response envelope.
+type vaultResponse struct {
+	Data   *vaultResponseData `json:"data"`
+	Errors []string           `json:"errors"`
+}
+
+// vaultResponseData holds the data portion of a Vault transit response.
+type vaultResponseData struct {
+	Ciphertext string `json:"ciphertext"`
+	Plaintext  string `json:"plaintext"`
+}
+
+// Encrypt encrypts the plaintext using Vault's transit secrets engine.
+func (v *VaultEncryptor) Encrypt(plaintext []byte) ([]byte, error) {
+	encoded := base64.StdEncoding.EncodeToString(plaintext)
+	reqBody := vaultEncryptRequest{Plaintext: encoded}
+
+	url := fmt.Sprintf("%s/v1/%s/encrypt/%s", v.cfg.Address, v.cfg.MountPath, v.cfg.KeyName)
+	resp, err := v.doRequest(context.Background(), http.MethodPost, url, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrVaultEncryptFailed, err)
+	}
+
+	if resp.Data == nil || resp.Data.Ciphertext == "" {
+		return nil, fmt.Errorf("%w: missing ciphertext in response", ErrVaultEncryptFailed)
+	}
+
+	return []byte(resp.Data.Ciphertext), nil
+}
+
+// Decrypt decrypts the ciphertext using Vault's transit secrets engine.
+func (v *VaultEncryptor) Decrypt(ciphertext []byte) ([]byte, error) {
+	reqBody := vaultDecryptRequest{Ciphertext: string(ciphertext)}
+
+	url := fmt.Sprintf("%s/v1/%s/decrypt/%s", v.cfg.Address, v.cfg.MountPath, v.cfg.KeyName)
+	resp, err := v.doRequest(context.Background(), http.MethodPost, url, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrVaultDecryptFailed, err)
+	}
+
+	if resp.Data == nil {
+		return nil, fmt.Errorf("%w: missing data in response", ErrVaultDecryptFailed)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(resp.Data.Plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to decode base64 plaintext: %w", ErrVaultDecryptFailed, err)
+	}
+
+	return decoded, nil
+}
+
+// doRequest sends an HTTP request to the Vault API and decodes the response.
+func (v *VaultEncryptor) doRequest(ctx context.Context, method, url string, body interface{}) (*vaultResponse, error) {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("X-Vault-Token", v.cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrVaultUnavailable, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("vault returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var vaultResp vaultResponse
+	if err := json.Unmarshal(respBody, &vaultResp); err != nil {
+		return nil, fmt.Errorf("failed to decode vault response: %w", err)
+	}
+
+	if len(vaultResp.Errors) > 0 {
+		return nil, fmt.Errorf("vault errors: %v", vaultResp.Errors)
+	}
+
+	return &vaultResp, nil
+}

--- a/internal/encryption/vault_test.go
+++ b/internal/encryption/vault_test.go
@@ -1,0 +1,273 @@
+package encryption_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/piwi3910/netweave/internal/encryption"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMockVaultServer creates a test HTTP server that simulates Vault transit API.
+func newMockVaultServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/v1/transit/encrypt/test-key", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		token := r.Header.Get("X-Vault-Token")
+		if token != "test-token" {
+			w.WriteHeader(http.StatusForbidden)
+			resp := map[string]interface{}{"errors": []string{"permission denied"}}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		var req struct {
+			Plaintext string `json:"plaintext"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		// Simulate Vault: prefix with "vault:v1:" and keep the base64 data.
+		ciphertext := "vault:v1:" + req.Plaintext
+
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{
+				"ciphertext": ciphertext,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	mux.HandleFunc("/v1/transit/decrypt/test-key", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		token := r.Header.Get("X-Vault-Token")
+		if token != "test-token" {
+			w.WriteHeader(http.StatusForbidden)
+			resp := map[string]interface{}{"errors": []string{"permission denied"}}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		var req struct {
+			Ciphertext string `json:"ciphertext"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		// Reverse the mock encryption: strip "vault:v1:" prefix.
+		plaintext := strings.TrimPrefix(req.Ciphertext, "vault:v1:")
+
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{
+				"plaintext": plaintext,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestVaultEncryptor_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	server := newMockVaultServer(t)
+
+	enc := encryption.NewVaultEncryptor(encryption.VaultConfig{
+		Address:   server.URL,
+		Token:     "test-token",
+		MountPath: "transit",
+		KeyName:   "test-key",
+	})
+
+	tests := []struct {
+		name      string
+		plaintext []byte
+	}{
+		{
+			name:      "simple text",
+			plaintext: []byte("hello vault"),
+		},
+		{
+			name:      "json credentials",
+			plaintext: []byte(`{"username":"admin","password":"s3cr3t"}`),
+		},
+		{
+			name:      "empty data",
+			plaintext: []byte(""),
+		},
+		{
+			name:      "binary data",
+			plaintext: []byte{0x00, 0x01, 0xff},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ciphertext, err := enc.Encrypt(tt.plaintext)
+			require.NoError(t, err)
+			assert.NotEmpty(t, ciphertext)
+			assert.True(t, strings.HasPrefix(string(ciphertext), "vault:v1:"))
+
+			decrypted, err := enc.Decrypt(ciphertext)
+			require.NoError(t, err)
+			assert.Equal(t, string(tt.plaintext), string(decrypted))
+		})
+	}
+}
+
+func TestVaultEncryptor_InvalidToken(t *testing.T) {
+	t.Parallel()
+
+	server := newMockVaultServer(t)
+
+	enc := encryption.NewVaultEncryptor(encryption.VaultConfig{
+		Address:   server.URL,
+		Token:     "wrong-token",
+		MountPath: "transit",
+		KeyName:   "test-key",
+	})
+
+	_, err := enc.Encrypt([]byte("secret"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, encryption.ErrVaultEncryptFailed)
+}
+
+func TestVaultEncryptor_ServerUnavailable(t *testing.T) {
+	t.Parallel()
+
+	enc := encryption.NewVaultEncryptor(encryption.VaultConfig{
+		Address:   "http://127.0.0.1:1",
+		Token:     "token",
+		MountPath: "transit",
+		KeyName:   "key",
+	})
+
+	_, err := enc.Encrypt([]byte("data"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, encryption.ErrVaultEncryptFailed)
+}
+
+func TestVaultEncryptor_DefaultMountPath(t *testing.T) {
+	t.Parallel()
+
+	server := newMockVaultServer(t)
+
+	// Do not set MountPath; it should default to "transit".
+	enc := encryption.NewVaultEncryptor(encryption.VaultConfig{
+		Address: server.URL,
+		Token:   "test-token",
+		KeyName: "test-key",
+	})
+
+	ciphertext, err := enc.Encrypt([]byte("test"))
+	require.NoError(t, err)
+
+	decrypted, err := enc.Decrypt(ciphertext)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("test"), decrypted)
+}
+
+func TestVaultEncryptor_EncryptReturnsBase64(t *testing.T) {
+	t.Parallel()
+
+	server := newMockVaultServer(t)
+
+	enc := encryption.NewVaultEncryptor(encryption.VaultConfig{
+		Address:   server.URL,
+		Token:     "test-token",
+		MountPath: "transit",
+		KeyName:   "test-key",
+	})
+
+	plaintext := []byte("hello")
+	ciphertext, err := enc.Encrypt(plaintext)
+	require.NoError(t, err)
+
+	// The mock server returns "vault:v1:" + base64(plaintext).
+	// Verify the base64 portion decodes correctly.
+	b64Part := strings.TrimPrefix(string(ciphertext), "vault:v1:")
+	decoded, err := base64.StdEncoding.DecodeString(b64Part)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decoded)
+}
+
+func TestVaultEncryptor_DecryptNilData(t *testing.T) {
+	t.Parallel()
+
+	// Create a server that returns null data for decrypt.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/transit/decrypt/test-key", func(w http.ResponseWriter, _ *http.Request) {
+		resp := map[string]interface{}{
+			"data": nil,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	enc := encryption.NewVaultEncryptor(encryption.VaultConfig{
+		Address:   server.URL,
+		Token:     "test-token",
+		MountPath: "transit",
+		KeyName:   "test-key",
+	})
+
+	_, err := enc.Decrypt([]byte("vault:v1:invalid"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, encryption.ErrVaultDecryptFailed)
+}
+
+func TestVaultEncryptor_EncryptNilData(t *testing.T) {
+	t.Parallel()
+
+	// Create a server that returns null data for encrypt.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/transit/encrypt/test-key", func(w http.ResponseWriter, _ *http.Request) {
+		resp := map[string]interface{}{
+			"data": nil,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	enc := encryption.NewVaultEncryptor(encryption.VaultConfig{
+		Address:   server.URL,
+		Token:     "test-token",
+		MountPath: "transit",
+		KeyName:   "test-key",
+	})
+
+	_, err := enc.Encrypt([]byte("data"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, encryption.ErrVaultEncryptFailed)
+}

--- a/internal/handlers/backend.go
+++ b/internal/handlers/backend.go
@@ -1,0 +1,161 @@
+package handlers
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/piwi3910/netweave/internal/backend"
+	"github.com/piwi3910/netweave/internal/encryption"
+	"go.uber.org/zap"
+)
+
+// BackendHandler handles admin API endpoints for backend instance management.
+type BackendHandler struct {
+	store     backend.Store
+	encryptor encryption.Encryptor
+	registry  *backend.SchemaRegistry
+	logger    *zap.Logger
+}
+
+// NewBackendHandler creates a new BackendHandler.
+func NewBackendHandler(
+	store backend.Store,
+	encryptor encryption.Encryptor,
+	registry *backend.SchemaRegistry,
+	logger *zap.Logger,
+) *BackendHandler {
+	if store == nil {
+		panic("backend store cannot be nil")
+	}
+	if encryptor == nil {
+		panic("encryptor cannot be nil")
+	}
+	if registry == nil {
+		panic("schema registry cannot be nil")
+	}
+	if logger == nil {
+		panic("logger cannot be nil")
+	}
+
+	return &BackendHandler{
+		store:     store,
+		encryptor: encryptor,
+		registry:  registry,
+		logger:    logger,
+	}
+}
+
+// RegisterRoutes registers all backend admin API routes on the given router group.
+// Routes:
+//
+//	GET    /backends
+//	POST   /backends
+//	GET    /backends/:id
+//	PUT    /backends/:id
+//	DELETE /backends/:id
+//	POST   /backends/:id/test
+//	GET    /backends/:id/dms-links
+//	POST   /backends/:id/dms-links
+//	DELETE /backends/:id/dms-links/:dmsId
+//	GET    /tenants/:tid/backend-access
+//	POST   /tenants/:tid/backend-access
+//	PUT    /tenants/:tid/backend-access/:aid
+//	DELETE /tenants/:tid/backend-access/:aid
+//	GET    /backend-types
+//	GET    /backend-types/:type/schema
+func (h *BackendHandler) RegisterRoutes(router *gin.RouterGroup) {
+	router.GET("/backends", h.ListBackends)
+	router.POST("/backends", h.CreateBackend)
+	router.GET("/backends/:id", h.GetBackend)
+	router.PUT("/backends/:id", h.UpdateBackend)
+	router.DELETE("/backends/:id", h.DeleteBackend)
+	router.POST("/backends/:id/test", h.TestBackend)
+
+	router.GET("/backends/:id/dms-links", h.ListDMSLinks)
+	router.POST("/backends/:id/dms-links", h.CreateDMSLink)
+	router.DELETE("/backends/:id/dms-links/:dmsId", h.DeleteDMSLink)
+
+	router.GET("/tenants/:tid/backend-access", h.ListBackendAccess)
+	router.POST("/tenants/:tid/backend-access", h.CreateBackendAccess)
+	router.PUT("/tenants/:tid/backend-access/:aid", h.UpdateBackendAccess)
+	router.DELETE("/tenants/:tid/backend-access/:aid", h.DeleteBackendAccess)
+
+	router.GET("/backend-types", h.ListBackendTypes)
+	router.GET("/backend-types/:type/schema", h.GetBackendTypeSchema)
+}
+
+// CreateBackendRequest is the request body for creating a backend instance.
+type CreateBackendRequest struct {
+	Name        string            `json:"name" binding:"required"`
+	Category    string            `json:"category" binding:"required"`
+	AdapterType string            `json:"adapterType" binding:"required"`
+	Description string            `json:"description,omitempty"`
+	Config      map[string]string `json:"config,omitempty"`
+	Credentials map[string]string `json:"credentials,omitempty"`
+}
+
+// UpdateBackendRequest is the request body for updating a backend instance.
+type UpdateBackendRequest struct {
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Config      map[string]string `json:"config,omitempty"`
+	Credentials map[string]string `json:"credentials,omitempty"`
+}
+
+// CreateDMSLinkRequest is the request body for creating a DMS link.
+type CreateDMSLinkRequest struct {
+	DMSID string `json:"dmsId" binding:"required"`
+}
+
+// CreateBackendAccessRequest is the request body for creating backend access.
+type CreateBackendAccessRequest struct {
+	BackendID   string                 `json:"backendId" binding:"required"`
+	Permissions []string               `json:"permissions" binding:"required"`
+	Constraints map[string]interface{} `json:"constraints,omitempty"`
+}
+
+// UpdateBackendAccessRequest is the request body for updating backend access.
+type UpdateBackendAccessRequest struct {
+	Permissions []string               `json:"permissions" binding:"required"`
+	Constraints map[string]interface{} `json:"constraints,omitempty"`
+}
+
+// BackendResponse is the API response for a backend instance.
+// It never exposes raw credentials.
+type BackendResponse struct {
+	ID              string    `json:"id"`
+	Name            string    `json:"name"`
+	Category        string    `json:"category"`
+	AdapterType     string    `json:"adapterType"`
+	Description     string    `json:"description,omitempty"`
+	Status          string    `json:"status"`
+	StatusMessage   string    `json:"statusMessage,omitempty"`
+	HasCredentials  bool      `json:"hasCredentials"`
+	LastHealthCheck time.Time `json:"lastHealthCheck,omitempty"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
+}
+
+func backendToResponse(b *backend.Instance) *BackendResponse {
+	return &BackendResponse{
+		ID:              b.ID,
+		Name:            b.Name,
+		Category:        b.Category,
+		AdapterType:     b.AdapterType,
+		Description:     b.Description,
+		Status:          b.Status,
+		StatusMessage:   b.StatusMessage,
+		HasCredentials:  len(b.Credentials) > 0,
+		LastHealthCheck: b.LastHealthCheck,
+		CreatedAt:       b.CreatedAt,
+		UpdatedAt:       b.UpdatedAt,
+	}
+}
+
+func backendsToResponses(backends []*backend.Instance) []*BackendResponse {
+	result := make([]*BackendResponse, 0, len(backends))
+	for _, b := range backends {
+		result = append(result, backendToResponse(b))
+	}
+	return result
+}

--- a/internal/handlers/backend_access.go
+++ b/internal/handlers/backend_access.go
@@ -1,0 +1,217 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/piwi3910/netweave/internal/auth"
+	"github.com/piwi3910/netweave/internal/backend"
+	"github.com/piwi3910/netweave/internal/o2ims/models"
+	"go.uber.org/zap"
+)
+
+// ListBackendAccess handles GET /admin/tenants/:tid/backend-access.
+func (h *BackendHandler) ListBackendAccess(c *gin.Context) {
+	tenantID := c.Param("tid")
+	if tenantID == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Tenant ID is required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	accessList, err := h.store.ListBackendAccessByTenant(c.Request.Context(), tenantID)
+	if err != nil {
+		h.logger.Error("failed to list backend access",
+			zap.String("tenant_id", tenantID),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "InternalError",
+			Message: "Failed to list backend access",
+			Code:    http.StatusInternalServerError,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"access": accessList,
+		"total":  len(accessList),
+	})
+}
+
+// CreateBackendAccess handles POST /admin/tenants/:tid/backend-access.
+func (h *BackendHandler) CreateBackendAccess(c *gin.Context) {
+	tenantID := c.Param("tid")
+	if tenantID == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Tenant ID is required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	var req CreateBackendAccessRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Invalid request body",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	grantedBy := extractUserID(c)
+	access := &backend.Access{
+		ID:          uuid.New().String(),
+		TenantID:    tenantID,
+		BackendID:   req.BackendID,
+		Permissions: req.Permissions,
+		Constraints: req.Constraints,
+		GrantedAt:   time.Now().UTC(),
+		GrantedBy:   grantedBy,
+	}
+
+	if err := h.store.CreateBackendAccess(c.Request.Context(), access); err != nil {
+		h.handleCreateAccessError(c, tenantID, err)
+		return
+	}
+
+	h.logger.Info("backend access created",
+		zap.String("access_id", access.ID),
+		zap.String("tenant_id", tenantID),
+		zap.String("backend_id", req.BackendID),
+	)
+
+	c.JSON(http.StatusCreated, access)
+}
+
+func (h *BackendHandler) handleCreateAccessError(c *gin.Context, tenantID string, err error) {
+	if errors.Is(err, backend.ErrAccessExists) {
+		c.JSON(http.StatusConflict, models.ErrorResponse{
+			Error:   "Conflict",
+			Message: "Access already exists for this tenant-backend pair",
+			Code:    http.StatusConflict,
+		})
+		return
+	}
+
+	h.logger.Error("failed to create backend access",
+		zap.String("tenant_id", tenantID),
+		zap.Error(err),
+	)
+	c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+		Error:   "InternalError",
+		Message: "Failed to create backend access",
+		Code:    http.StatusInternalServerError,
+	})
+}
+
+// UpdateBackendAccess handles PUT /admin/tenants/:tid/backend-access/:aid.
+func (h *BackendHandler) UpdateBackendAccess(c *gin.Context) {
+	tenantID := c.Param("tid")
+	accessID := c.Param("aid")
+
+	if tenantID == "" || accessID == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Tenant ID and access ID are required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	var req UpdateBackendAccessRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Invalid request body",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	access := &backend.Access{
+		ID:          accessID,
+		Permissions: req.Permissions,
+		Constraints: req.Constraints,
+	}
+
+	if err := h.store.UpdateBackendAccess(c.Request.Context(), access); err != nil {
+		h.logger.Error("failed to update backend access",
+			zap.String("access_id", accessID),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "InternalError",
+			Message: "Failed to update backend access",
+			Code:    http.StatusInternalServerError,
+		})
+		return
+	}
+
+	h.logger.Info("backend access updated",
+		zap.String("access_id", accessID),
+		zap.String("tenant_id", tenantID),
+	)
+
+	c.JSON(http.StatusOK, access)
+}
+
+// DeleteBackendAccess handles DELETE /admin/tenants/:tid/backend-access/:aid.
+func (h *BackendHandler) DeleteBackendAccess(c *gin.Context) {
+	tenantID := c.Param("tid")
+	accessID := c.Param("aid")
+
+	if tenantID == "" || accessID == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Tenant ID and access ID are required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	if err := h.store.DeleteBackendAccess(c.Request.Context(), accessID); err != nil {
+		if errors.Is(err, backend.ErrAccessNotFound) {
+			c.JSON(http.StatusNotFound, models.ErrorResponse{
+				Error:   "NotFound",
+				Message: "Backend access not found",
+				Code:    http.StatusNotFound,
+			})
+			return
+		}
+
+		h.logger.Error("failed to delete backend access",
+			zap.String("access_id", accessID),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "InternalError",
+			Message: "Failed to delete backend access",
+			Code:    http.StatusInternalServerError,
+		})
+		return
+	}
+
+	h.logger.Info("backend access deleted",
+		zap.String("access_id", accessID),
+		zap.String("tenant_id", tenantID),
+	)
+	c.Status(http.StatusNoContent)
+}
+
+// extractUserID retrieves the authenticated user ID from the Gin context.
+func extractUserID(c *gin.Context) string {
+	user := auth.UserFromContext(c.Request.Context())
+	if user != nil {
+		return user.UserID
+	}
+	return "unknown"
+}

--- a/internal/handlers/backend_crud.go
+++ b/internal/handlers/backend_crud.go
@@ -1,0 +1,348 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/piwi3910/netweave/internal/backend"
+	"github.com/piwi3910/netweave/internal/o2ims/models"
+	"go.uber.org/zap"
+)
+
+// ListBackends handles GET /admin/backends.
+func (h *BackendHandler) ListBackends(c *gin.Context) {
+	ctx := c.Request.Context()
+	category := c.Query("category")
+
+	var (
+		backends []*backend.Instance
+		err      error
+	)
+
+	if category != "" {
+		backends, err = h.store.ListBackendsByCategory(ctx, category)
+	} else {
+		backends, err = h.store.ListBackends(ctx)
+	}
+
+	if err != nil {
+		h.logger.Error("failed to list backends", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "InternalError",
+			Message: "Failed to list backends",
+			Code:    http.StatusInternalServerError,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"backends": backendsToResponses(backends),
+		"total":    len(backends),
+	})
+}
+
+// CreateBackend handles POST /admin/backends.
+func (h *BackendHandler) CreateBackend(c *gin.Context) {
+	var req CreateBackendRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Invalid request body",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	if err := h.validateCreateBackendRequest(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: err.Error(),
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	instance, err := h.buildBackendInstance(&req)
+	if err != nil {
+		h.logger.Error("failed to build backend instance", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "InternalError",
+			Message: "Failed to encrypt backend data",
+			Code:    http.StatusInternalServerError,
+		})
+		return
+	}
+
+	if err := h.store.CreateBackend(c.Request.Context(), instance); err != nil {
+		h.handleCreateBackendError(c, err)
+		return
+	}
+
+	h.logger.Info("backend created",
+		zap.String("backend_id", instance.ID),
+		zap.String("name", instance.Name),
+	)
+
+	c.JSON(http.StatusCreated, backendToResponse(instance))
+}
+
+func (h *BackendHandler) validateCreateBackendRequest(req *CreateBackendRequest) error {
+	if req.Category != "ims" && req.Category != "dms" {
+		return errors.New("category must be 'ims' or 'dms'")
+	}
+
+	if _, ok := h.registry.Get(req.AdapterType); !ok {
+		return errors.New("unknown adapter type")
+	}
+
+	return nil
+}
+
+func (h *BackendHandler) buildBackendInstance(req *CreateBackendRequest) (*backend.Instance, error) {
+	now := time.Now().UTC()
+
+	encConfig, err := h.encryptMap(req.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	encCreds, err := h.encryptMap(req.Credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	return &backend.Instance{
+		ID:          uuid.New().String(),
+		Name:        req.Name,
+		Category:    req.Category,
+		AdapterType: req.AdapterType,
+		Description: req.Description,
+		Config:      encConfig,
+		Credentials: encCreds,
+		Status:      "unknown",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}, nil
+}
+
+func (h *BackendHandler) handleCreateBackendError(c *gin.Context, err error) {
+	if errors.Is(err, backend.ErrBackendExists) {
+		c.JSON(http.StatusConflict, models.ErrorResponse{
+			Error:   "Conflict",
+			Message: "Backend with this name already exists",
+			Code:    http.StatusConflict,
+		})
+		return
+	}
+
+	h.logger.Error("failed to create backend", zap.Error(err))
+	c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+		Error:   "InternalError",
+		Message: "Failed to create backend",
+		Code:    http.StatusInternalServerError,
+	})
+}
+
+// GetBackend handles GET /admin/backends/:id.
+func (h *BackendHandler) GetBackend(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Backend ID is required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	b, err := h.store.GetBackend(c.Request.Context(), id)
+	if err != nil {
+		h.handleGetBackendError(c, id, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, backendToResponse(b))
+}
+
+func (h *BackendHandler) handleGetBackendError(c *gin.Context, id string, err error) {
+	if errors.Is(err, backend.ErrBackendNotFound) {
+		c.JSON(http.StatusNotFound, models.ErrorResponse{
+			Error:   "NotFound",
+			Message: "Backend not found",
+			Code:    http.StatusNotFound,
+		})
+		return
+	}
+
+	h.logger.Error("failed to get backend", zap.String("id", id), zap.Error(err))
+	c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+		Error:   "InternalError",
+		Message: "Failed to retrieve backend",
+		Code:    http.StatusInternalServerError,
+	})
+}
+
+// UpdateBackend handles PUT /admin/backends/:id.
+func (h *BackendHandler) UpdateBackend(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Backend ID is required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	var req UpdateBackendRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Invalid request body",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	existing, err := h.store.GetBackend(c.Request.Context(), id)
+	if err != nil {
+		h.handleGetBackendError(c, id, err)
+		return
+	}
+
+	if err := h.applyBackendUpdates(existing, &req); err != nil {
+		h.logger.Error("failed to encrypt backend data", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "InternalError",
+			Message: "Failed to encrypt backend data",
+			Code:    http.StatusInternalServerError,
+		})
+		return
+	}
+
+	if err := h.store.UpdateBackend(c.Request.Context(), existing); err != nil {
+		h.logger.Error("failed to update backend", zap.String("id", id), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "InternalError",
+			Message: "Failed to update backend",
+			Code:    http.StatusInternalServerError,
+		})
+		return
+	}
+
+	h.logger.Info("backend updated", zap.String("backend_id", id))
+	c.JSON(http.StatusOK, backendToResponse(existing))
+}
+
+func (h *BackendHandler) applyBackendUpdates(existing *backend.Instance, req *UpdateBackendRequest) error {
+	if req.Name != "" {
+		existing.Name = req.Name
+	}
+	if req.Description != "" {
+		existing.Description = req.Description
+	}
+	if req.Config != nil {
+		encConfig, err := h.encryptMap(req.Config)
+		if err != nil {
+			return err
+		}
+		existing.Config = encConfig
+	}
+	if req.Credentials != nil {
+		encCreds, err := h.encryptMap(req.Credentials)
+		if err != nil {
+			return err
+		}
+		existing.Credentials = encCreds
+	}
+	existing.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
+// DeleteBackend handles DELETE /admin/backends/:id.
+func (h *BackendHandler) DeleteBackend(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Backend ID is required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	if err := h.store.DeleteBackend(c.Request.Context(), id); err != nil {
+		if errors.Is(err, backend.ErrBackendNotFound) {
+			c.JSON(http.StatusNotFound, models.ErrorResponse{
+				Error:   "NotFound",
+				Message: "Backend not found",
+				Code:    http.StatusNotFound,
+			})
+			return
+		}
+
+		h.logger.Error("failed to delete backend", zap.String("id", id), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "InternalError",
+			Message: "Failed to delete backend",
+			Code:    http.StatusInternalServerError,
+		})
+		return
+	}
+
+	h.logger.Info("backend deleted", zap.String("backend_id", id))
+	c.Status(http.StatusNoContent)
+}
+
+// TestBackend handles POST /admin/backends/:id/test.
+func (h *BackendHandler) TestBackend(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Backend ID is required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	_, err := h.store.GetBackend(c.Request.Context(), id)
+	if err != nil {
+		h.handleGetBackendError(c, id, err)
+		return
+	}
+
+	// Update status to indicate test was run.
+	if err := h.store.UpdateBackendStatus(c.Request.Context(), id, "unknown", "connection test not yet implemented"); err != nil {
+		h.logger.Error("failed to update backend status", zap.String("id", id), zap.Error(err))
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"backendId": id,
+		"status":    "unknown",
+		"message":   "Connection test not yet implemented",
+	})
+}
+
+// encryptMap marshals a map to JSON and encrypts it.
+func (h *BackendHandler) encryptMap(data map[string]string) ([]byte, error) {
+	if data == nil {
+		return nil, nil
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	encrypted, err := h.encryptor.Encrypt(jsonData)
+	if err != nil {
+		return nil, err
+	}
+
+	return encrypted, nil
+}

--- a/internal/handlers/backend_links.go
+++ b/internal/handlers/backend_links.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/piwi3910/netweave/internal/backend"
+	"github.com/piwi3910/netweave/internal/o2ims/models"
+	"go.uber.org/zap"
+)
+
+// ListDMSLinks handles GET /admin/backends/:id/dms-links.
+func (h *BackendHandler) ListDMSLinks(c *gin.Context) {
+	imsID := c.Param("id")
+	if imsID == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "IMS backend ID is required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	links, err := h.store.ListDMSLinksByIMS(c.Request.Context(), imsID)
+	if err != nil {
+		h.logger.Error("failed to list DMS links", zap.String("ims_id", imsID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "InternalError",
+			Message: "Failed to list DMS links",
+			Code:    http.StatusInternalServerError,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"links": backendsToResponses(links),
+		"total": len(links),
+	})
+}
+
+// CreateDMSLink handles POST /admin/backends/:id/dms-links.
+func (h *BackendHandler) CreateDMSLink(c *gin.Context) {
+	imsID := c.Param("id")
+	if imsID == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "IMS backend ID is required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	var req CreateDMSLinkRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Invalid request body",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	if err := h.store.CreateBackendLink(c.Request.Context(), imsID, req.DMSID); err != nil {
+		h.handleCreateLinkError(c, imsID, req.DMSID, err)
+		return
+	}
+
+	h.logger.Info("DMS link created",
+		zap.String("ims_id", imsID),
+		zap.String("dms_id", req.DMSID),
+	)
+
+	c.JSON(http.StatusCreated, gin.H{
+		"imsId": imsID,
+		"dmsId": req.DMSID,
+	})
+}
+
+func (h *BackendHandler) handleCreateLinkError(c *gin.Context, imsID, dmsID string, err error) {
+	if errors.Is(err, backend.ErrBackendLinkExists) {
+		c.JSON(http.StatusConflict, models.ErrorResponse{
+			Error:   "Conflict",
+			Message: "Link already exists",
+			Code:    http.StatusConflict,
+		})
+		return
+	}
+
+	h.logger.Error("failed to create DMS link",
+		zap.String("ims_id", imsID),
+		zap.String("dms_id", dmsID),
+		zap.Error(err),
+	)
+	c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+		Error:   "InternalError",
+		Message: "Failed to create DMS link",
+		Code:    http.StatusInternalServerError,
+	})
+}
+
+// DeleteDMSLink handles DELETE /admin/backends/:id/dms-links/:dmsId.
+func (h *BackendHandler) DeleteDMSLink(c *gin.Context) {
+	imsID := c.Param("id")
+	dmsID := c.Param("dmsId")
+
+	if imsID == "" || dmsID == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "IMS and DMS backend IDs are required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	if err := h.store.DeleteBackendLink(c.Request.Context(), imsID, dmsID); err != nil {
+		if errors.Is(err, backend.ErrBackendLinkNotFound) {
+			c.JSON(http.StatusNotFound, models.ErrorResponse{
+				Error:   "NotFound",
+				Message: "Link not found",
+				Code:    http.StatusNotFound,
+			})
+			return
+		}
+
+		h.logger.Error("failed to delete DMS link",
+			zap.String("ims_id", imsID),
+			zap.String("dms_id", dmsID),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "InternalError",
+			Message: "Failed to delete DMS link",
+			Code:    http.StatusInternalServerError,
+		})
+		return
+	}
+
+	h.logger.Info("DMS link deleted",
+		zap.String("ims_id", imsID),
+		zap.String("dms_id", dmsID),
+	)
+	c.Status(http.StatusNoContent)
+}

--- a/internal/handlers/backend_test.go
+++ b/internal/handlers/backend_test.go
@@ -1,0 +1,783 @@
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/piwi3910/netweave/internal/backend"
+	"github.com/piwi3910/netweave/internal/handlers"
+	"github.com/piwi3910/netweave/internal/o2ims/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// mockEncryptor is a test Encryptor that simply prepends "enc:" to data.
+type mockEncryptor struct {
+	failEncrypt bool
+}
+
+func (m *mockEncryptor) Encrypt(plaintext []byte) ([]byte, error) {
+	if m.failEncrypt {
+		return nil, errors.New("encryption failed")
+	}
+	return append([]byte("enc:"), plaintext...), nil
+}
+
+func (m *mockEncryptor) Decrypt(ciphertext []byte) ([]byte, error) {
+	if len(ciphertext) < 4 {
+		return nil, errors.New("invalid ciphertext")
+	}
+	return ciphertext[4:], nil
+}
+
+// mockBackendStore is a test implementation of backend.Store.
+type mockBackendStore struct {
+	backends   map[string]*backend.Instance
+	links      map[string][]string // imsID -> []dmsID
+	accessList map[string]*backend.Access
+}
+
+func newMockBackendStore() *mockBackendStore {
+	return &mockBackendStore{
+		backends:   make(map[string]*backend.Instance),
+		links:      make(map[string][]string),
+		accessList: make(map[string]*backend.Access),
+	}
+}
+
+func (m *mockBackendStore) CreateBackend(_ context.Context, instance *backend.Instance) error {
+	for _, b := range m.backends {
+		if b.Name == instance.Name {
+			return backend.ErrBackendExists
+		}
+	}
+	m.backends[instance.ID] = instance
+	return nil
+}
+
+func (m *mockBackendStore) GetBackend(_ context.Context, id string) (*backend.Instance, error) {
+	b, ok := m.backends[id]
+	if !ok {
+		return nil, backend.ErrBackendNotFound
+	}
+	return b, nil
+}
+
+func (m *mockBackendStore) UpdateBackend(_ context.Context, instance *backend.Instance) error {
+	if _, ok := m.backends[instance.ID]; !ok {
+		return backend.ErrBackendNotFound
+	}
+	m.backends[instance.ID] = instance
+	return nil
+}
+
+func (m *mockBackendStore) DeleteBackend(_ context.Context, id string) error {
+	if _, ok := m.backends[id]; !ok {
+		return backend.ErrBackendNotFound
+	}
+	delete(m.backends, id)
+	return nil
+}
+
+func (m *mockBackendStore) ListBackends(_ context.Context) ([]*backend.Instance, error) {
+	result := make([]*backend.Instance, 0, len(m.backends))
+	for _, b := range m.backends {
+		result = append(result, b)
+	}
+	return result, nil
+}
+
+func (m *mockBackendStore) ListBackendsByCategory(_ context.Context, category string) ([]*backend.Instance, error) {
+	result := make([]*backend.Instance, 0)
+	for _, b := range m.backends {
+		if b.Category == category {
+			result = append(result, b)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockBackendStore) UpdateBackendStatus(_ context.Context, id, status, message string) error {
+	b, ok := m.backends[id]
+	if !ok {
+		return backend.ErrBackendNotFound
+	}
+	b.Status = status
+	b.StatusMessage = message
+	b.LastHealthCheck = time.Now().UTC()
+	return nil
+}
+
+func (m *mockBackendStore) CreateBackendLink(_ context.Context, imsID, dmsID string) error {
+	for _, existing := range m.links[imsID] {
+		if existing == dmsID {
+			return backend.ErrBackendLinkExists
+		}
+	}
+	m.links[imsID] = append(m.links[imsID], dmsID)
+	return nil
+}
+
+func (m *mockBackendStore) DeleteBackendLink(_ context.Context, imsID, dmsID string) error {
+	dmsIDs, ok := m.links[imsID]
+	if !ok {
+		return backend.ErrBackendLinkNotFound
+	}
+	for i, id := range dmsIDs {
+		if id == dmsID {
+			m.links[imsID] = append(dmsIDs[:i], dmsIDs[i+1:]...)
+			return nil
+		}
+	}
+	return backend.ErrBackendLinkNotFound
+}
+
+func (m *mockBackendStore) ListDMSLinksByIMS(_ context.Context, imsID string) ([]*backend.Instance, error) {
+	dmsIDs := m.links[imsID]
+	result := make([]*backend.Instance, 0, len(dmsIDs))
+	for _, dmsID := range dmsIDs {
+		if b, ok := m.backends[dmsID]; ok {
+			result = append(result, b)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockBackendStore) ListIMSLinksByDMS(_ context.Context, _ string) ([]*backend.Instance, error) {
+	return []*backend.Instance{}, nil
+}
+
+func (m *mockBackendStore) CreateBackendAccess(_ context.Context, access *backend.Access) error {
+	for _, a := range m.accessList {
+		if a.TenantID == access.TenantID && a.BackendID == access.BackendID {
+			return backend.ErrAccessExists
+		}
+	}
+	m.accessList[access.ID] = access
+	return nil
+}
+
+func (m *mockBackendStore) GetBackendAccess(_ context.Context, id string) (*backend.Access, error) {
+	a, ok := m.accessList[id]
+	if !ok {
+		return nil, backend.ErrAccessNotFound
+	}
+	return a, nil
+}
+
+func (m *mockBackendStore) UpdateBackendAccess(_ context.Context, access *backend.Access) error {
+	if _, ok := m.accessList[access.ID]; !ok {
+		return backend.ErrAccessNotFound
+	}
+	m.accessList[access.ID] = access
+	return nil
+}
+
+func (m *mockBackendStore) DeleteBackendAccess(_ context.Context, id string) error {
+	if _, ok := m.accessList[id]; !ok {
+		return backend.ErrAccessNotFound
+	}
+	delete(m.accessList, id)
+	return nil
+}
+
+func (m *mockBackendStore) ListBackendAccessByTenant(_ context.Context, tenantID string) ([]*backend.Access, error) {
+	result := make([]*backend.Access, 0)
+	for _, a := range m.accessList {
+		if a.TenantID == tenantID {
+			result = append(result, a)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockBackendStore) ListBackendAccessByBackend(_ context.Context, backendID string) ([]*backend.Access, error) {
+	result := make([]*backend.Access, 0)
+	for _, a := range m.accessList {
+		if a.BackendID == backendID {
+			result = append(result, a)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockBackendStore) Close() error {
+	return nil
+}
+
+func (m *mockBackendStore) Ping(_ context.Context) error {
+	return nil
+}
+
+func setupBackendTestRouter(
+	t *testing.T,
+	store *mockBackendStore,
+	enc *mockEncryptor,
+) *gin.Engine {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	logger := zap.NewNop()
+
+	registry := backend.NewSchemaRegistry()
+	backend.RegisterBuiltinSchemas(registry)
+
+	handler := handlers.NewBackendHandler(store, enc, registry, logger)
+	admin := router.Group("/admin")
+	handler.RegisterRoutes(admin)
+
+	return router
+}
+
+func TestBackendHandler_ListBackends(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		setup      func(*mockBackendStore)
+		wantStatus int
+		wantTotal  float64
+	}{
+		{
+			name:  "list all backends",
+			query: "",
+			setup: func(s *mockBackendStore) {
+				s.backends["b1"] = &backend.Instance{
+					ID: "b1", Name: "k8s", Category: "ims", AdapterType: "kubernetes",
+				}
+				s.backends["b2"] = &backend.Instance{
+					ID: "b2", Name: "helm", Category: "dms", AdapterType: "helm",
+				}
+			},
+			wantStatus: http.StatusOK,
+			wantTotal:  2,
+		},
+		{
+			name:  "filter by category",
+			query: "?category=ims",
+			setup: func(s *mockBackendStore) {
+				s.backends["b1"] = &backend.Instance{
+					ID: "b1", Name: "k8s", Category: "ims", AdapterType: "kubernetes",
+				}
+				s.backends["b2"] = &backend.Instance{
+					ID: "b2", Name: "helm", Category: "dms", AdapterType: "helm",
+				}
+			},
+			wantStatus: http.StatusOK,
+			wantTotal:  1,
+		},
+		{
+			name:       "empty result",
+			query:      "",
+			setup:      func(_ *mockBackendStore) {},
+			wantStatus: http.StatusOK,
+			wantTotal:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMockBackendStore()
+			tt.setup(store)
+			router := setupBackendTestRouter(t, store, &mockEncryptor{})
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/admin/backends"+tt.query, nil)
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+
+			var resp map[string]interface{}
+			err := json.Unmarshal(w.Body.Bytes(), &resp)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTotal, resp["total"])
+		})
+	}
+}
+
+func TestBackendHandler_CreateBackend(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       interface{}
+		encFail    bool
+		wantStatus int
+	}{
+		{
+			name: "valid creation",
+			body: handlers.CreateBackendRequest{
+				Name:        "my-k8s",
+				Category:    "ims",
+				AdapterType: "kubernetes",
+				Description: "production cluster",
+				Config:      map[string]string{"context": "prod"},
+				Credentials: map[string]string{"kubeconfig": "yaml-content"},
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "invalid category",
+			body: handlers.CreateBackendRequest{
+				Name:        "bad",
+				Category:    "invalid",
+				AdapterType: "kubernetes",
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "unknown adapter type",
+			body: handlers.CreateBackendRequest{
+				Name:        "bad",
+				Category:    "ims",
+				AdapterType: "unknown-type",
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "duplicate name",
+			body: handlers.CreateBackendRequest{
+				Name:        "existing",
+				Category:    "ims",
+				AdapterType: "kubernetes",
+			},
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name:       "missing required fields",
+			body:       map[string]string{},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "encryption failure",
+			body: handlers.CreateBackendRequest{
+				Name:        "fail-enc",
+				Category:    "ims",
+				AdapterType: "kubernetes",
+				Config:      map[string]string{"key": "val"},
+			},
+			encFail:    true,
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMockBackendStore()
+			// Pre-create for duplicate test.
+			store.backends["existing-id"] = &backend.Instance{
+				ID: "existing-id", Name: "existing", Category: "ims",
+			}
+
+			enc := &mockEncryptor{failEncrypt: tt.encFail}
+			router := setupBackendTestRouter(t, store, enc)
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequestWithContext(
+				context.Background(),
+				http.MethodPost,
+				"/admin/backends",
+				bytes.NewReader(bodyBytes),
+			)
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+
+			if tt.wantStatus == http.StatusCreated {
+				var resp map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &resp)
+				require.NoError(t, err)
+				assert.NotEmpty(t, resp["id"])
+				assert.Equal(t, "my-k8s", resp["name"])
+				assert.Equal(t, true, resp["hasCredentials"])
+			}
+		})
+	}
+}
+
+func TestBackendHandler_GetBackend(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		setup      func(*mockBackendStore)
+		wantStatus int
+	}{
+		{
+			name: "found",
+			id:   "b1",
+			setup: func(s *mockBackendStore) {
+				s.backends["b1"] = &backend.Instance{
+					ID: "b1", Name: "k8s", Category: "ims", AdapterType: "kubernetes",
+					Credentials: []byte("encrypted"),
+				}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not found",
+			id:         "non-existent",
+			setup:      func(_ *mockBackendStore) {},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMockBackendStore()
+			tt.setup(store)
+			router := setupBackendTestRouter(t, store, &mockEncryptor{})
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequestWithContext(
+				context.Background(), http.MethodGet, "/admin/backends/"+tt.id, nil,
+			)
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+
+			if tt.wantStatus == http.StatusOK {
+				var resp map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &resp)
+				require.NoError(t, err)
+				// Verify credentials are NOT exposed.
+				assert.Equal(t, true, resp["hasCredentials"])
+				assert.Nil(t, resp["config"])
+				assert.Nil(t, resp["credentials"])
+			}
+		})
+	}
+}
+
+func TestBackendHandler_UpdateBackend(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		body       interface{}
+		setup      func(*mockBackendStore)
+		wantStatus int
+	}{
+		{
+			name: "successful update",
+			id:   "b1",
+			body: handlers.UpdateBackendRequest{
+				Name:        "updated-k8s",
+				Description: "updated desc",
+			},
+			setup: func(s *mockBackendStore) {
+				s.backends["b1"] = &backend.Instance{
+					ID: "b1", Name: "k8s", Category: "ims", AdapterType: "kubernetes",
+				}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not found",
+			id:         "missing",
+			body:       handlers.UpdateBackendRequest{Name: "new"},
+			setup:      func(_ *mockBackendStore) {},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMockBackendStore()
+			tt.setup(store)
+			router := setupBackendTestRouter(t, store, &mockEncryptor{})
+
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequestWithContext(
+				context.Background(), http.MethodPut, "/admin/backends/"+tt.id, bytes.NewReader(bodyBytes),
+			)
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+		})
+	}
+}
+
+func TestBackendHandler_DeleteBackend(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		setup      func(*mockBackendStore)
+		wantStatus int
+	}{
+		{
+			name: "successful delete",
+			id:   "b1",
+			setup: func(s *mockBackendStore) {
+				s.backends["b1"] = &backend.Instance{ID: "b1", Name: "k8s"}
+			},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "not found",
+			id:         "missing",
+			setup:      func(_ *mockBackendStore) {},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMockBackendStore()
+			tt.setup(store)
+			router := setupBackendTestRouter(t, store, &mockEncryptor{})
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequestWithContext(
+				context.Background(), http.MethodDelete, "/admin/backends/"+tt.id, nil,
+			)
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+		})
+	}
+}
+
+func TestBackendHandler_TestBackend(t *testing.T) {
+	store := newMockBackendStore()
+	store.backends["b1"] = &backend.Instance{ID: "b1", Name: "k8s", Status: "unknown"}
+	router := setupBackendTestRouter(t, store, &mockEncryptor{})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, "/admin/backends/b1/test", nil,
+	)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "b1", resp["backendId"])
+}
+
+func TestBackendHandler_DMSLinks(t *testing.T) {
+	store := newMockBackendStore()
+	store.backends["ims1"] = &backend.Instance{
+		ID: "ims1", Name: "k8s", Category: "ims",
+	}
+	store.backends["dms1"] = &backend.Instance{
+		ID: "dms1", Name: "helm", Category: "dms",
+	}
+	router := setupBackendTestRouter(t, store, &mockEncryptor{})
+
+	t.Run("create link", func(t *testing.T) {
+		body, _ := json.Marshal(handlers.CreateDMSLinkRequest{DMSID: "dms1"})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodPost, "/admin/backends/ims1/dms-links", bytes.NewReader(body),
+		)
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusCreated, w.Code)
+	})
+
+	t.Run("list links", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodGet, "/admin/backends/ims1/dms-links", nil,
+		)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, float64(1), resp["total"])
+	})
+
+	t.Run("duplicate link", func(t *testing.T) {
+		body, _ := json.Marshal(handlers.CreateDMSLinkRequest{DMSID: "dms1"})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodPost, "/admin/backends/ims1/dms-links", bytes.NewReader(body),
+		)
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusConflict, w.Code)
+	})
+
+	t.Run("delete link", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodDelete, "/admin/backends/ims1/dms-links/dms1", nil,
+		)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNoContent, w.Code)
+	})
+
+	t.Run("delete non-existent link", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodDelete, "/admin/backends/ims1/dms-links/missing", nil,
+		)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
+func TestBackendHandler_BackendAccess(t *testing.T) {
+	store := newMockBackendStore()
+	store.backends["b1"] = &backend.Instance{ID: "b1", Name: "k8s"}
+	router := setupBackendTestRouter(t, store, &mockEncryptor{})
+
+	var accessID string
+
+	t.Run("create access", func(t *testing.T) {
+		body, _ := json.Marshal(handlers.CreateBackendAccessRequest{
+			BackendID:   "b1",
+			Permissions: []string{"read", "list"},
+			Constraints: map[string]interface{}{"namespace": "default"},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodPost, "/admin/tenants/t1/backend-access", bytes.NewReader(body),
+		)
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusCreated, w.Code)
+
+		var resp backend.Access
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.ID)
+		assert.Equal(t, "t1", resp.TenantID)
+		accessID = resp.ID
+	})
+
+	t.Run("list access", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodGet, "/admin/tenants/t1/backend-access", nil,
+		)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, float64(1), resp["total"])
+	})
+
+	t.Run("duplicate access", func(t *testing.T) {
+		body, _ := json.Marshal(handlers.CreateBackendAccessRequest{
+			BackendID:   "b1",
+			Permissions: []string{"read"},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodPost, "/admin/tenants/t1/backend-access", bytes.NewReader(body),
+		)
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusConflict, w.Code)
+	})
+
+	t.Run("update access", func(t *testing.T) {
+		body, _ := json.Marshal(handlers.UpdateBackendAccessRequest{
+			Permissions: []string{"read", "write"},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodPut, "/admin/tenants/t1/backend-access/"+accessID, bytes.NewReader(body),
+		)
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("delete access", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodDelete, "/admin/tenants/t1/backend-access/"+accessID, nil,
+		)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNoContent, w.Code)
+	})
+
+	t.Run("delete non-existent access", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodDelete, "/admin/tenants/t1/backend-access/missing", nil,
+		)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
+func TestBackendHandler_BackendTypes(t *testing.T) {
+	store := newMockBackendStore()
+	router := setupBackendTestRouter(t, store, &mockEncryptor{})
+
+	t.Run("list all types", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodGet, "/admin/backend-types", nil,
+		)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		types, ok := resp["types"].([]interface{})
+		require.True(t, ok)
+		assert.GreaterOrEqual(t, len(types), 7)
+	})
+
+	t.Run("filter by category", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodGet, "/admin/backend-types?category=dms", nil,
+		)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("get specific schema", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodGet, "/admin/backend-types/kubernetes/schema", nil,
+		)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var schema backend.AdapterTypeSchema
+		err := json.Unmarshal(w.Body.Bytes(), &schema)
+		require.NoError(t, err)
+		assert.Equal(t, "kubernetes", schema.Type)
+		assert.Equal(t, "ims", schema.Category)
+	})
+
+	t.Run("schema not found", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(
+			context.Background(), http.MethodGet, "/admin/backend-types/unknown/schema", nil,
+		)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		var errResp models.ErrorResponse
+		err := json.Unmarshal(w.Body.Bytes(), &errResp)
+		require.NoError(t, err)
+		assert.Equal(t, "NotFound", errResp.Error)
+	})
+}

--- a/internal/handlers/backend_types.go
+++ b/internal/handlers/backend_types.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/piwi3910/netweave/internal/o2ims/models"
+)
+
+// ListBackendTypes handles GET /admin/backend-types.
+func (h *BackendHandler) ListBackendTypes(c *gin.Context) {
+	category := c.Query("category")
+
+	var schemas interface{}
+	if category != "" {
+		schemas = h.registry.ListByCategory(category)
+	} else {
+		schemas = h.registry.List()
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"types": schemas,
+	})
+}
+
+// GetBackendTypeSchema handles GET /admin/backend-types/:type/schema.
+func (h *BackendHandler) GetBackendTypeSchema(c *gin.Context) {
+	adapterType := c.Param("type")
+	if adapterType == "" {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "BadRequest",
+			Message: "Adapter type is required",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	schema, ok := h.registry.Get(adapterType)
+	if !ok {
+		c.JSON(http.StatusNotFound, models.ErrorResponse{
+			Error:   "NotFound",
+			Message: "Adapter type not found",
+			Code:    http.StatusNotFound,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, schema)
+}


### PR DESCRIPTION
## Summary

- Adds `internal/encryption` package with `Encryptor` interface, AES-256-GCM implementation (dev/test), and HashiCorp Vault Transit implementation (production)
- Adds `internal/backend` package with `Store` interface, PostgreSQL implementation using sqlc-generated queries, schema registry with 7 built-in adapter types (Kubernetes, AWS, Azure, OpenStack, Helm, ArgoCD, Flux)
- Adds 15 admin API handler endpoints for backend CRUD, IMS-DMS linking, tenant access grants, and adapter type discovery
- All credentials encrypted at rest via `Encryptor` interface; never exposed in API responses

## Test plan

- [x] Unit tests for AES-256-GCM encryption (round-trip, wrong key, corrupted data, empty data)
- [x] Unit tests for Vault transit encryption with mock HTTP server
- [x] Integration tests for PostgreSQL store with testcontainers (backend CRUD, links, access)
- [x] Unit tests for all 15 handler endpoints with mock store and mock encryptor
- [x] Linter passes with zero issues
- [x] Race detector passes

Resolves #363