### PR TITLE
Add admin portal infrastructure management pages

### DIFF
--- a/web/admin-portal/src/app/(dashboard)/infrastructure/dms/[id]/page.tsx
+++ b/web/admin-portal/src/app/(dashboard)/infrastructure/dms/[id]/page.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft, Save } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { CardSkeleton } from "@/components/shared/loading-skeleton";
+import { BackendStatusBadge } from "@/components/backends/backend-status-badge";
+import { TestConnectionButton } from "@/components/backends/test-connection-button";
+import { getBackend, updateBackend } from "@/lib/api/backends";
+import { getDisplayError } from "@/lib/utils/sanitize-error";
+import { formatDate } from "@/lib/utils";
+import type { BackendResponse } from "@/types/backends";
+
+export default function DMSDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const backendId = params.id as string;
+  const [backend, setBackend] = useState<BackendResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    name: "",
+    description: "",
+  });
+
+  async function load() {
+    try {
+      const backendData = await getBackend(backendId);
+      setBackend(backendData);
+      setForm({
+        name: backendData.name,
+        description: backendData.description,
+      });
+    } catch (err) {
+      setError(getDisplayError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, [backendId]);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateBackend(backendId, form);
+      setBackend(updated);
+    } catch (err) {
+      setError(getDisplayError(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="max-w-2xl space-y-6">
+        <CardSkeleton />
+      </div>
+    );
+  }
+
+  if (!backend) {
+    return (
+      <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+        <p className="text-sm text-destructive">{error || "DMS not found"}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <div>
+          <h1 className="text-3xl font-bold">{backend.name}</h1>
+          <p className="text-sm text-muted-foreground">{backend.id}</p>
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <Badge variant="outline">{backend.adapterType}</Badge>
+          <BackendStatusBadge status={backend.status} />
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+
+      <form onSubmit={handleSave} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>DMS Details</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label className="text-sm font-medium" htmlFor="name">
+                Name
+              </label>
+              <Input
+                id="name"
+                value={form.name}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, name: e.target.value }))
+                }
+                required
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium" htmlFor="desc">
+                Description
+              </label>
+              <Input
+                id="desc"
+                value={form.description}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, description: e.target.value }))
+                }
+              />
+            </div>
+            <div>
+              <p className="text-sm font-medium mb-1">Status</p>
+              <p className="text-sm text-muted-foreground">
+                {backend.statusMessage || "No status message"}
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Last checked: {formatDate(backend.lastHealthCheck)}
+              </p>
+            </div>
+            <div>
+              <TestConnectionButton
+                backendId={backendId}
+                onTestComplete={load}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="flex gap-4">
+          <Button type="submit" disabled={saving}>
+            <Save className="mr-2 h-4 w-4" />
+            {saving ? "Saving..." : "Save Changes"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.back()}
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/admin-portal/src/app/(dashboard)/infrastructure/dms/new/page.tsx
+++ b/web/admin-portal/src/app/(dashboard)/infrastructure/dms/new/page.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, Save } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { DynamicForm } from "@/components/backends/dynamic-form";
+import { CardSkeleton } from "@/components/shared/loading-skeleton";
+import { listBackendTypes, createBackend } from "@/lib/api/backends";
+import { getDisplayError } from "@/lib/utils/sanitize-error";
+import { backendSchema } from "@/lib/validation/schemas";
+import type { AdapterTypeSchema } from "@/types/backends";
+
+export default function NewDMSPage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [types, setTypes] = useState<AdapterTypeSchema[]>([]);
+  const [selectedType, setSelectedType] = useState<AdapterTypeSchema | null>(
+    null
+  );
+  const [form, setForm] = useState({
+    name: "",
+    description: "",
+  });
+  const [configValues, setConfigValues] = useState<Record<string, string>>({});
+  const [credentialValues, setCredentialValues] = useState<
+    Record<string, string>
+  >({});
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    loadTypes();
+  }, []);
+
+  async function loadTypes() {
+    try {
+      setLoading(true);
+      const data = await listBackendTypes("dms");
+      setTypes(data);
+    } catch (err) {
+      setError(getDisplayError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleTypeChange(typeValue: string) {
+    const type = types.find((t) => t.type === typeValue);
+    setSelectedType(type || null);
+    setConfigValues({});
+    setCredentialValues({});
+    setFieldErrors({});
+  }
+
+  function validateDynamicFields(): boolean {
+    const errors: Record<string, string> = {};
+
+    if (!selectedType) {
+      return false;
+    }
+
+    for (const field of selectedType.configSchema) {
+      const value = configValues[field.name] || "";
+      if (field.required && !value) {
+        errors[field.name] = `${field.label} is required`;
+      } else if (field.regex && value) {
+        const regex = new RegExp(field.regex);
+        if (!regex.test(value)) {
+          errors[field.name] = `Invalid format for ${field.label}`;
+        }
+      }
+    }
+
+    for (const field of selectedType.credentialSchema) {
+      const value = credentialValues[field.name] || "";
+      if (field.required && !value) {
+        errors[field.name] = `${field.label} is required`;
+      } else if (field.regex && value) {
+        const regex = new RegExp(field.regex);
+        if (!regex.test(value)) {
+          errors[field.name] = `Invalid format for ${field.label}`;
+        }
+      }
+    }
+
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+
+    const result = backendSchema.safeParse({
+      name: form.name,
+      description: form.description,
+      category: "dms",
+      adapterType: selectedType?.type,
+    });
+
+    if (!result.success) {
+      const firstError = result.error.errors[0];
+      setError(firstError.message);
+      setSaving(false);
+      return;
+    }
+
+    if (!validateDynamicFields()) {
+      setError("Please fix the field errors");
+      setSaving(false);
+      return;
+    }
+
+    try {
+      const backend = await createBackend({
+        name: form.name,
+        description: form.description,
+        category: "dms",
+        adapterType: selectedType!.type,
+        config: configValues,
+        credentials: credentialValues,
+      });
+      router.push(`/infrastructure/dms/${backend.id}`);
+    } catch (err) {
+      setError(getDisplayError(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="max-w-2xl space-y-6">
+        <CardSkeleton />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <h1 className="text-3xl font-bold">Add DMS</h1>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Basic Information</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label className="text-sm font-medium" htmlFor="name">
+                Name <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="name"
+                value={form.name}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, name: e.target.value }))
+                }
+                required
+                maxLength={128}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium" htmlFor="description">
+                Description
+              </label>
+              <Input
+                id="description"
+                value={form.description}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, description: e.target.value }))
+                }
+                maxLength={512}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium" htmlFor="type">
+                Adapter Type <span className="text-destructive">*</span>
+              </label>
+              <select
+                id="type"
+                value={selectedType?.type || ""}
+                onChange={(e) => handleTypeChange(e.target.value)}
+                required
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <option value="">Select adapter type...</option>
+                {types.map((type) => (
+                  <option key={type.type} value={type.type}>
+                    {type.displayName}
+                  </option>
+                ))}
+              </select>
+              {selectedType && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  {selectedType.description}
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {selectedType && selectedType.configSchema.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Configuration</CardTitle>
+              <CardDescription>
+                Configure connection parameters for this backend
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <DynamicForm
+                fields={selectedType.configSchema}
+                values={configValues}
+                onChange={(name, value) =>
+                  setConfigValues((v) => ({ ...v, [name]: value }))
+                }
+                errors={fieldErrors}
+              />
+            </CardContent>
+          </Card>
+        )}
+
+        {selectedType && selectedType.credentialSchema.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Credentials</CardTitle>
+              <CardDescription>
+                Provide authentication credentials for this backend
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <DynamicForm
+                fields={selectedType.credentialSchema}
+                values={credentialValues}
+                onChange={(name, value) =>
+                  setCredentialValues((v) => ({ ...v, [name]: value }))
+                }
+                errors={fieldErrors}
+              />
+            </CardContent>
+          </Card>
+        )}
+
+        <div className="flex gap-4">
+          <Button type="submit" disabled={saving || !selectedType}>
+            <Save className="mr-2 h-4 w-4" />
+            {saving ? "Creating..." : "Create DMS"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.back()}
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/admin-portal/src/app/(dashboard)/infrastructure/dms/page.tsx
+++ b/web/admin-portal/src/app/(dashboard)/infrastructure/dms/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Package, Plus, Trash2, Pencil } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { TableSkeleton } from "@/components/shared/loading-skeleton";
+import { EmptyState } from "@/components/shared/empty-state";
+import { BackendStatusBadge } from "@/components/backends/backend-status-badge";
+import { listBackends, deleteBackend } from "@/lib/api/backends";
+import { getDisplayError } from "@/lib/utils/sanitize-error";
+import type { BackendResponse } from "@/types/backends";
+import { formatDate } from "@/lib/utils";
+
+export default function DMSPage() {
+  const router = useRouter();
+  const [backends, setBackends] = useState<BackendResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadBackends();
+  }, []);
+
+  async function loadBackends() {
+    try {
+      setLoading(true);
+      const data = await listBackends("dms");
+      setBackends(data);
+    } catch (err) {
+      setError(getDisplayError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDelete(backendId: string, name: string) {
+    if (!confirm(`Delete DMS "${name}"? This action cannot be undone.`)) {
+      return;
+    }
+    try {
+      await deleteBackend(backendId);
+      setBackends((prev) => prev.filter((b) => b.id !== backendId));
+    } catch (err) {
+      setError(getDisplayError(err));
+    }
+  }
+
+  const filtered = backends.filter(
+    (b) =>
+      b.name.toLowerCase().includes(search.toLowerCase()) ||
+      b.id.toLowerCase().includes(search.toLowerCase()) ||
+      b.adapterType.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">DMS</h1>
+        <Button onClick={() => router.push("/infrastructure/dms/new")}>
+          <Plus className="mr-2 h-4 w-4" />
+          Add DMS
+        </Button>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+
+      <Input
+        placeholder="Search DMS..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="max-w-sm"
+      />
+
+      {loading ? (
+        <TableSkeleton />
+      ) : filtered.length === 0 ? (
+        <EmptyState
+          icon={Package}
+          title="No DMS found"
+          description={
+            search
+              ? "No DMS match your search"
+              : "Add your first DMS to get started"
+          }
+          actionLabel={!search ? "Add DMS" : undefined}
+          onAction={
+            !search ? () => router.push("/infrastructure/dms/new") : undefined
+          }
+        />
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead className="w-24">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.map((backend) => (
+              <TableRow key={backend.id}>
+                <TableCell>
+                  <Link
+                    href={`/infrastructure/dms/${backend.id}`}
+                    className="font-medium hover:underline"
+                  >
+                    {backend.name}
+                  </Link>
+                  <div className="text-xs text-muted-foreground">
+                    {backend.id}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline">{backend.adapterType}</Badge>
+                </TableCell>
+                <TableCell>
+                  <BackendStatusBadge status={backend.status} />
+                </TableCell>
+                <TableCell className="text-sm max-w-xs truncate">
+                  {backend.description || "-"}
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {formatDate(backend.createdAt)}
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() =>
+                        router.push(`/infrastructure/dms/${backend.id}`)
+                      }
+                      aria-label="Edit DMS"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleDelete(backend.id, backend.name)}
+                      aria-label="Delete DMS"
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/web/admin-portal/src/app/(dashboard)/infrastructure/links/page.tsx
+++ b/web/admin-portal/src/app/(dashboard)/infrastructure/links/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Link2 } from "lucide-react";
+import { CardSkeleton } from "@/components/shared/loading-skeleton";
+import { EmptyState } from "@/components/shared/empty-state";
+import {
+  listBackends,
+  listDMSLinks,
+  createDMSLink,
+  deleteDMSLink,
+} from "@/lib/api/backends";
+import { getDisplayError } from "@/lib/utils/sanitize-error";
+import type { BackendResponse } from "@/types/backends";
+
+export default function LinksPage() {
+  const [imsBackends, setImsBackends] = useState<BackendResponse[]>([]);
+  const [dmsBackends, setDmsBackends] = useState<BackendResponse[]>([]);
+  const [links, setLinks] = useState<Record<string, Set<string>>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toggling, setToggling] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  async function loadData() {
+    try {
+      setLoading(true);
+      const [imsData, dmsData] = await Promise.all([
+        listBackends("ims"),
+        listBackends("dms"),
+      ]);
+      setImsBackends(imsData);
+      setDmsBackends(dmsData);
+
+      const linksMap: Record<string, Set<string>> = {};
+      await Promise.all(
+        imsData.map(async (ims) => {
+          const dmsLinks = await listDMSLinks(ims.id);
+          linksMap[ims.id] = new Set(dmsLinks.map((d) => d.id));
+        })
+      );
+      setLinks(linksMap);
+    } catch (err) {
+      setError(getDisplayError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function toggleLink(imsId: string, dmsId: string, isLinked: boolean) {
+    const key = `${imsId}-${dmsId}`;
+    setToggling(key);
+    try {
+      if (isLinked) {
+        await deleteDMSLink(imsId, dmsId);
+        setLinks((prev) => {
+          const newLinks = { ...prev };
+          newLinks[imsId] = new Set(newLinks[imsId]);
+          newLinks[imsId].delete(dmsId);
+          return newLinks;
+        });
+      } else {
+        await createDMSLink(imsId, dmsId);
+        setLinks((prev) => {
+          const newLinks = { ...prev };
+          if (!newLinks[imsId]) {
+            newLinks[imsId] = new Set();
+          } else {
+            newLinks[imsId] = new Set(newLinks[imsId]);
+          }
+          newLinks[imsId].add(dmsId);
+          return newLinks;
+        });
+      }
+    } catch (err) {
+      setError(getDisplayError(err));
+    } finally {
+      setToggling(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold">IMS-DMS Links</h1>
+        <CardSkeleton />
+      </div>
+    );
+  }
+
+  if (imsBackends.length === 0 || dmsBackends.length === 0) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold">IMS-DMS Links</h1>
+        <EmptyState
+          icon={Link2}
+          title="No backends available"
+          description="Create at least one O-Cloud and one DMS to manage links"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">IMS-DMS Links</h1>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+
+      <div className="rounded-lg border bg-card overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              <th className="p-4 text-left font-medium sticky left-0 bg-muted/50 z-10">
+                O-Cloud / DMS
+              </th>
+              {dmsBackends.map((dms) => (
+                <th
+                  key={dms.id}
+                  className="p-4 text-center font-medium min-w-32"
+                >
+                  <div className="text-sm">{dms.name}</div>
+                  <div className="text-xs text-muted-foreground font-normal">
+                    {dms.adapterType}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {imsBackends.map((ims) => (
+              <tr key={ims.id} className="border-b">
+                <td className="p-4 font-medium sticky left-0 bg-card border-r">
+                  <div className="text-sm">{ims.name}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {ims.adapterType}
+                  </div>
+                </td>
+                {dmsBackends.map((dms) => {
+                  const isLinked = links[ims.id]?.has(dms.id) || false;
+                  const key = `${ims.id}-${dms.id}`;
+                  const isToggling = toggling === key;
+                  return (
+                    <td key={dms.id} className="p-4 text-center">
+                      <input
+                        type="checkbox"
+                        checked={isLinked}
+                        disabled={isToggling}
+                        onChange={() => toggleLink(ims.id, dms.id, isLinked)}
+                        className="h-5 w-5 rounded border-gray-300 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+                      />
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="rounded-lg border bg-muted/50 p-4">
+        <p className="text-sm text-muted-foreground">
+          Check a box to link an O-Cloud (IMS) with a DMS. Uncheck to remove
+          the link. Links enable the O-Cloud to deploy packages from the DMS.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/admin-portal/src/app/(dashboard)/infrastructure/o-clouds/[id]/page.tsx
+++ b/web/admin-portal/src/app/(dashboard)/infrastructure/o-clouds/[id]/page.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft, Save, Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { CardSkeleton } from "@/components/shared/loading-skeleton";
+import { BackendStatusBadge } from "@/components/backends/backend-status-badge";
+import { TestConnectionButton } from "@/components/backends/test-connection-button";
+import {
+  getBackend,
+  updateBackend,
+  listDMSLinks,
+  createDMSLink,
+  deleteDMSLink,
+  listBackends,
+} from "@/lib/api/backends";
+import { getDisplayError } from "@/lib/utils/sanitize-error";
+import { formatDate } from "@/lib/utils";
+import type { BackendResponse } from "@/types/backends";
+
+export default function OCloudDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const backendId = params.id as string;
+  const [backend, setBackend] = useState<BackendResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    name: "",
+    description: "",
+  });
+  const [dmsLinks, setDmsLinks] = useState<BackendResponse[]>([]);
+  const [allDms, setAllDms] = useState<BackendResponse[]>([]);
+  const [showAddDms, setShowAddDms] = useState(false);
+  const [selectedDms, setSelectedDms] = useState("");
+
+  async function load() {
+    try {
+      const [backendData, dmsData, allDmsData] = await Promise.all([
+        getBackend(backendId),
+        listDMSLinks(backendId),
+        listBackends("dms"),
+      ]);
+      setBackend(backendData);
+      setForm({
+        name: backendData.name,
+        description: backendData.description,
+      });
+      setDmsLinks(dmsData);
+      setAllDms(allDmsData);
+    } catch (err) {
+      setError(getDisplayError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, [backendId]);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateBackend(backendId, form);
+      setBackend(updated);
+    } catch (err) {
+      setError(getDisplayError(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleAddDms() {
+    if (!selectedDms) return;
+    try {
+      await createDMSLink(backendId, selectedDms);
+      const dmsData = await listDMSLinks(backendId);
+      setDmsLinks(dmsData);
+      setSelectedDms("");
+      setShowAddDms(false);
+    } catch (err) {
+      setError(getDisplayError(err));
+    }
+  }
+
+  async function handleRemoveDms(dmsId: string, dmsName: string) {
+    if (!confirm(`Remove DMS link to "${dmsName}"?`)) {
+      return;
+    }
+    try {
+      await deleteDMSLink(backendId, dmsId);
+      setDmsLinks((prev) => prev.filter((d) => d.id !== dmsId));
+    } catch (err) {
+      setError(getDisplayError(err));
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="max-w-2xl space-y-6">
+        <CardSkeleton />
+        <CardSkeleton />
+      </div>
+    );
+  }
+
+  if (!backend) {
+    return (
+      <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+        <p className="text-sm text-destructive">
+          {error || "O-Cloud not found"}
+        </p>
+      </div>
+    );
+  }
+
+  const availableDms = allDms.filter(
+    (d) => !dmsLinks.some((link) => link.id === d.id)
+  );
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <div>
+          <h1 className="text-3xl font-bold">{backend.name}</h1>
+          <p className="text-sm text-muted-foreground">{backend.id}</p>
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <Badge variant="outline">{backend.adapterType}</Badge>
+          <BackendStatusBadge status={backend.status} />
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+
+      <form onSubmit={handleSave} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>O-Cloud Details</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label className="text-sm font-medium" htmlFor="name">
+                Name
+              </label>
+              <Input
+                id="name"
+                value={form.name}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, name: e.target.value }))
+                }
+                required
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium" htmlFor="desc">
+                Description
+              </label>
+              <Input
+                id="desc"
+                value={form.description}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, description: e.target.value }))
+                }
+              />
+            </div>
+            <div>
+              <p className="text-sm font-medium mb-1">Status</p>
+              <p className="text-sm text-muted-foreground">
+                {backend.statusMessage || "No status message"}
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Last checked: {formatDate(backend.lastHealthCheck)}
+              </p>
+            </div>
+            <div>
+              <TestConnectionButton
+                backendId={backendId}
+                onTestComplete={load}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Linked DMS</CardTitle>
+            <CardDescription>
+              Deployment management services linked to this O-Cloud
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {dmsLinks.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No DMS linked to this O-Cloud
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {dmsLinks.map((dms) => (
+                  <div
+                    key={dms.id}
+                    className="flex items-center justify-between rounded-lg border p-3"
+                  >
+                    <div>
+                      <p className="font-medium">{dms.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        <Badge variant="outline" className="text-xs">
+                          {dms.adapterType}
+                        </Badge>
+                      </p>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleRemoveDms(dms.id, dms.name)}
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+            {!showAddDms && availableDms.length > 0 && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setShowAddDms(true)}
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                Link DMS
+              </Button>
+            )}
+            {showAddDms && (
+              <div className="flex gap-2">
+                <select
+                  value={selectedDms}
+                  onChange={(e) => setSelectedDms(e.target.value)}
+                  className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                >
+                  <option value="">Select DMS...</option>
+                  {availableDms.map((dms) => (
+                    <option key={dms.id} value={dms.id}>
+                      {dms.name} ({dms.adapterType})
+                    </option>
+                  ))}
+                </select>
+                <Button type="button" onClick={handleAddDms}>
+                  Add
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setShowAddDms(false);
+                    setSelectedDms("");
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <div className="flex gap-4">
+          <Button type="submit" disabled={saving}>
+            <Save className="mr-2 h-4 w-4" />
+            {saving ? "Saving..." : "Save Changes"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.back()}
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/admin-portal/src/app/(dashboard)/infrastructure/o-clouds/new/page.tsx
+++ b/web/admin-portal/src/app/(dashboard)/infrastructure/o-clouds/new/page.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, Save } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { DynamicForm } from "@/components/backends/dynamic-form";
+import { CardSkeleton } from "@/components/shared/loading-skeleton";
+import { listBackendTypes, createBackend } from "@/lib/api/backends";
+import { getDisplayError } from "@/lib/utils/sanitize-error";
+import { backendSchema } from "@/lib/validation/schemas";
+import type { AdapterTypeSchema } from "@/types/backends";
+
+export default function NewOCloudPage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [types, setTypes] = useState<AdapterTypeSchema[]>([]);
+  const [selectedType, setSelectedType] = useState<AdapterTypeSchema | null>(
+    null
+  );
+  const [form, setForm] = useState({
+    name: "",
+    description: "",
+  });
+  const [configValues, setConfigValues] = useState<Record<string, string>>({});
+  const [credentialValues, setCredentialValues] = useState<
+    Record<string, string>
+  >({});
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    loadTypes();
+  }, []);
+
+  async function loadTypes() {
+    try {
+      setLoading(true);
+      const data = await listBackendTypes("ims");
+      setTypes(data);
+    } catch (err) {
+      setError(getDisplayError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleTypeChange(typeValue: string) {
+    const type = types.find((t) => t.type === typeValue);
+    setSelectedType(type || null);
+    setConfigValues({});
+    setCredentialValues({});
+    setFieldErrors({});
+  }
+
+  function validateDynamicFields(): boolean {
+    const errors: Record<string, string> = {};
+
+    if (!selectedType) {
+      return false;
+    }
+
+    for (const field of selectedType.configSchema) {
+      const value = configValues[field.name] || "";
+      if (field.required && !value) {
+        errors[field.name] = `${field.label} is required`;
+      } else if (field.regex && value) {
+        const regex = new RegExp(field.regex);
+        if (!regex.test(value)) {
+          errors[field.name] = `Invalid format for ${field.label}`;
+        }
+      }
+    }
+
+    for (const field of selectedType.credentialSchema) {
+      const value = credentialValues[field.name] || "";
+      if (field.required && !value) {
+        errors[field.name] = `${field.label} is required`;
+      } else if (field.regex && value) {
+        const regex = new RegExp(field.regex);
+        if (!regex.test(value)) {
+          errors[field.name] = `Invalid format for ${field.label}`;
+        }
+      }
+    }
+
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+
+    const result = backendSchema.safeParse({
+      name: form.name,
+      description: form.description,
+      category: "ims",
+      adapterType: selectedType?.type,
+    });
+
+    if (!result.success) {
+      const firstError = result.error.errors[0];
+      setError(firstError.message);
+      setSaving(false);
+      return;
+    }
+
+    if (!validateDynamicFields()) {
+      setError("Please fix the field errors");
+      setSaving(false);
+      return;
+    }
+
+    try {
+      const backend = await createBackend({
+        name: form.name,
+        description: form.description,
+        category: "ims",
+        adapterType: selectedType!.type,
+        config: configValues,
+        credentials: credentialValues,
+      });
+      router.push(`/infrastructure/o-clouds/${backend.id}`);
+    } catch (err) {
+      setError(getDisplayError(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="max-w-2xl space-y-6">
+        <CardSkeleton />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <h1 className="text-3xl font-bold">Add O-Cloud</h1>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Basic Information</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label className="text-sm font-medium" htmlFor="name">
+                Name <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="name"
+                value={form.name}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, name: e.target.value }))
+                }
+                required
+                maxLength={128}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium" htmlFor="description">
+                Description
+              </label>
+              <Input
+                id="description"
+                value={form.description}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, description: e.target.value }))
+                }
+                maxLength={512}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium" htmlFor="type">
+                Adapter Type <span className="text-destructive">*</span>
+              </label>
+              <select
+                id="type"
+                value={selectedType?.type || ""}
+                onChange={(e) => handleTypeChange(e.target.value)}
+                required
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <option value="">Select adapter type...</option>
+                {types.map((type) => (
+                  <option key={type.type} value={type.type}>
+                    {type.displayName}
+                  </option>
+                ))}
+              </select>
+              {selectedType && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  {selectedType.description}
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {selectedType && selectedType.configSchema.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Configuration</CardTitle>
+              <CardDescription>
+                Configure connection parameters for this backend
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <DynamicForm
+                fields={selectedType.configSchema}
+                values={configValues}
+                onChange={(name, value) =>
+                  setConfigValues((v) => ({ ...v, [name]: value }))
+                }
+                errors={fieldErrors}
+              />
+            </CardContent>
+          </Card>
+        )}
+
+        {selectedType && selectedType.credentialSchema.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Credentials</CardTitle>
+              <CardDescription>
+                Provide authentication credentials for this backend
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <DynamicForm
+                fields={selectedType.credentialSchema}
+                values={credentialValues}
+                onChange={(name, value) =>
+                  setCredentialValues((v) => ({ ...v, [name]: value }))
+                }
+                errors={fieldErrors}
+              />
+            </CardContent>
+          </Card>
+        )}
+
+        <div className="flex gap-4">
+          <Button type="submit" disabled={saving || !selectedType}>
+            <Save className="mr-2 h-4 w-4" />
+            {saving ? "Creating..." : "Create O-Cloud"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.back()}
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/admin-portal/src/app/(dashboard)/infrastructure/o-clouds/page.tsx
+++ b/web/admin-portal/src/app/(dashboard)/infrastructure/o-clouds/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Cloud, Plus, Trash2, Pencil } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { TableSkeleton } from "@/components/shared/loading-skeleton";
+import { EmptyState } from "@/components/shared/empty-state";
+import { BackendStatusBadge } from "@/components/backends/backend-status-badge";
+import { listBackends, deleteBackend } from "@/lib/api/backends";
+import { getDisplayError } from "@/lib/utils/sanitize-error";
+import type { BackendResponse } from "@/types/backends";
+import { formatDate } from "@/lib/utils";
+
+export default function OCloudsPage() {
+  const router = useRouter();
+  const [backends, setBackends] = useState<BackendResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadBackends();
+  }, []);
+
+  async function loadBackends() {
+    try {
+      setLoading(true);
+      const data = await listBackends("ims");
+      setBackends(data);
+    } catch (err) {
+      setError(getDisplayError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDelete(backendId: string, name: string) {
+    if (!confirm(`Delete O-Cloud "${name}"? This action cannot be undone.`)) {
+      return;
+    }
+    try {
+      await deleteBackend(backendId);
+      setBackends((prev) => prev.filter((b) => b.id !== backendId));
+    } catch (err) {
+      setError(getDisplayError(err));
+    }
+  }
+
+  const filtered = backends.filter(
+    (b) =>
+      b.name.toLowerCase().includes(search.toLowerCase()) ||
+      b.id.toLowerCase().includes(search.toLowerCase()) ||
+      b.adapterType.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">O-Clouds</h1>
+        <Button onClick={() => router.push("/infrastructure/o-clouds/new")}>
+          <Plus className="mr-2 h-4 w-4" />
+          Add O-Cloud
+        </Button>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+
+      <Input
+        placeholder="Search O-Clouds..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="max-w-sm"
+      />
+
+      {loading ? (
+        <TableSkeleton />
+      ) : filtered.length === 0 ? (
+        <EmptyState
+          icon={Cloud}
+          title="No O-Clouds found"
+          description={
+            search
+              ? "No O-Clouds match your search"
+              : "Add your first O-Cloud to get started"
+          }
+          actionLabel={!search ? "Add O-Cloud" : undefined}
+          onAction={
+            !search
+              ? () => router.push("/infrastructure/o-clouds/new")
+              : undefined
+          }
+        />
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead className="w-24">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.map((backend) => (
+              <TableRow key={backend.id}>
+                <TableCell>
+                  <Link
+                    href={`/infrastructure/o-clouds/${backend.id}`}
+                    className="font-medium hover:underline"
+                  >
+                    {backend.name}
+                  </Link>
+                  <div className="text-xs text-muted-foreground">
+                    {backend.id}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline">{backend.adapterType}</Badge>
+                </TableCell>
+                <TableCell>
+                  <BackendStatusBadge status={backend.status} />
+                </TableCell>
+                <TableCell className="text-sm max-w-xs truncate">
+                  {backend.description || "-"}
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {formatDate(backend.createdAt)}
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() =>
+                        router.push(`/infrastructure/o-clouds/${backend.id}`)
+                      }
+                      aria-label="Edit O-Cloud"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleDelete(backend.id, backend.name)}
+                      aria-label="Delete O-Cloud"
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/web/admin-portal/src/app/(dashboard)/tenants/[id]/page.tsx
+++ b/web/admin-portal/src/app/(dashboard)/tenants/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { ArrowLeft, Save } from "lucide-react";
+import { ArrowLeft, Save, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -15,8 +15,16 @@ import {
 } from "@/components/ui/card";
 import { CardSkeleton } from "@/components/shared/loading-skeleton";
 import { getTenant, updateTenant } from "@/lib/api/tenants";
+import {
+  listBackendAccess,
+  createBackendAccess,
+  deleteBackendAccess,
+  listBackends,
+} from "@/lib/api/backends";
 import { getDisplayError } from "@/lib/utils/sanitize-error";
+import { formatDate } from "@/lib/utils";
 import type { Tenant } from "@/types/api";
+import type { BackendAccess, BackendResponse } from "@/types/backends";
 
 export default function TenantDetailPage() {
   const params = useParams();
@@ -31,17 +39,32 @@ export default function TenantDetailPage() {
     description: "",
     contactEmail: "",
   });
+  const [backendAccess, setBackendAccess] = useState<BackendAccess[]>([]);
+  const [allBackends, setAllBackends] = useState<BackendResponse[]>([]);
+  const [showGrantAccess, setShowGrantAccess] = useState(false);
+  const [grantForm, setGrantForm] = useState({
+    backendId: "",
+    permissions: "read",
+  });
 
   useEffect(() => {
     async function load() {
       try {
-        const data = await getTenant(tenantId);
-        setTenant(data);
+        const [tenantData, accessData, backendsData] = await Promise.all([
+          getTenant(tenantId),
+          listBackendAccess(tenantId),
+          Promise.all([listBackends("ims"), listBackends("dms")]).then(
+            ([ims, dms]) => [...ims, ...dms]
+          ),
+        ]);
+        setTenant(tenantData);
         setForm({
-          name: data.name,
-          description: data.description,
-          contactEmail: data.contactEmail,
+          name: tenantData.name,
+          description: tenantData.description,
+          contactEmail: tenantData.contactEmail,
         });
+        setBackendAccess(accessData);
+        setAllBackends(backendsData);
       } catch (err) {
         setError(getDisplayError(err));
       } finally {
@@ -62,6 +85,34 @@ export default function TenantDetailPage() {
       setError(getDisplayError(err));
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleGrantAccess() {
+    if (!grantForm.backendId) return;
+    try {
+      const permissions = grantForm.permissions.split(",").map((p) => p.trim());
+      const access = await createBackendAccess(tenantId, {
+        backendId: grantForm.backendId,
+        permissions,
+      });
+      setBackendAccess((prev) => [...prev, access]);
+      setGrantForm({ backendId: "", permissions: "read" });
+      setShowGrantAccess(false);
+    } catch (err) {
+      setError(getDisplayError(err));
+    }
+  }
+
+  async function handleRevokeAccess(accessId: string, backendName: string) {
+    if (!confirm(`Revoke access to "${backendName}"?`)) {
+      return;
+    }
+    try {
+      await deleteBackendAccess(tenantId, accessId);
+      setBackendAccess((prev) => prev.filter((a) => a.id !== accessId));
+    } catch (err) {
+      setError(getDisplayError(err));
     }
   }
 
@@ -183,6 +234,127 @@ export default function TenantDetailPage() {
                 max={tenant.quota.maxUsers}
               />
             </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Backend Access</CardTitle>
+            <CardDescription>
+              Infrastructure backends this tenant can access
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {backendAccess.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No backend access granted
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {backendAccess.map((access) => {
+                  const backend = allBackends.find(
+                    (b) => b.id === access.backendId
+                  );
+                  return (
+                    <div
+                      key={access.id}
+                      className="flex items-center justify-between rounded-lg border p-3"
+                    >
+                      <div>
+                        <p className="font-medium">
+                          {backend?.name || access.backendId}
+                        </p>
+                        <div className="flex gap-2 mt-1">
+                          {access.permissions.map((perm) => (
+                            <Badge key={perm} variant="secondary" className="text-xs">
+                              {perm}
+                            </Badge>
+                          ))}
+                        </div>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Granted {formatDate(access.grantedAt)}
+                        </p>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() =>
+                          handleRevokeAccess(
+                            access.id,
+                            backend?.name || access.backendId
+                          )
+                        }
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            {!showGrantAccess && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setShowGrantAccess(true)}
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                Grant Access
+              </Button>
+            )}
+            {showGrantAccess && (
+              <div className="space-y-3 p-4 border rounded-lg">
+                <div>
+                  <label className="text-sm font-medium">Backend</label>
+                  <select
+                    value={grantForm.backendId}
+                    onChange={(e) =>
+                      setGrantForm((f) => ({ ...f, backendId: e.target.value }))
+                    }
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm mt-1"
+                  >
+                    <option value="">Select backend...</option>
+                    {allBackends.map((backend) => (
+                      <option key={backend.id} value={backend.id}>
+                        {backend.name} ({backend.category})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="text-sm font-medium">Permissions</label>
+                  <Input
+                    value={grantForm.permissions}
+                    onChange={(e) =>
+                      setGrantForm((f) => ({
+                        ...f,
+                        permissions: e.target.value,
+                      }))
+                    }
+                    placeholder="read, write, delete"
+                    className="mt-1"
+                  />
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Comma-separated list of permissions
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <Button type="button" onClick={handleGrantAccess}>
+                    Grant
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setShowGrantAccess(false);
+                      setGrantForm({ backendId: "", permissions: "read" });
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            )}
           </CardContent>
         </Card>
 

--- a/web/admin-portal/src/components/backends/backend-status-badge.tsx
+++ b/web/admin-portal/src/components/backends/backend-status-badge.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+
+interface BackendStatusBadgeProps {
+  status: string;
+}
+
+export function BackendStatusBadge({ status }: BackendStatusBadgeProps) {
+  const variant = getStatusVariant(status);
+  return <Badge variant={variant}>{status}</Badge>;
+}
+
+function getStatusVariant(
+  status: string
+): "success" | "destructive" | "secondary" {
+  switch (status.toLowerCase()) {
+    case "healthy":
+      return "success";
+    case "unhealthy":
+      return "destructive";
+    case "unknown":
+    default:
+      return "secondary";
+  }
+}

--- a/web/admin-portal/src/components/backends/dynamic-form.tsx
+++ b/web/admin-portal/src/components/backends/dynamic-form.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { FieldSpec } from "@/types/backends";
+
+interface DynamicFormProps {
+  fields: FieldSpec[];
+  values: Record<string, string>;
+  onChange: (name: string, value: string) => void;
+  errors: Record<string, string>;
+}
+
+export function DynamicForm({
+  fields,
+  values,
+  onChange,
+  errors,
+}: DynamicFormProps) {
+  const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
+
+  const toggleSecret = (name: string) => {
+    setShowSecrets((prev) => ({ ...prev, [name]: !prev[name] }));
+  };
+
+  const renderField = (field: FieldSpec) => {
+    const value = values[field.name] || field.default || "";
+    const error = errors[field.name];
+    const isSecret = field.secret;
+    const showSecret = showSecrets[field.name];
+
+    switch (field.type) {
+      case "boolean":
+        return (
+          <div key={field.name} className="space-y-2">
+            <label className="flex items-center gap-2 text-sm font-medium">
+              <input
+                type="checkbox"
+                checked={value === "true"}
+                onChange={(e) =>
+                  onChange(field.name, e.target.checked ? "true" : "false")
+                }
+                className="h-4 w-4 rounded border-gray-300"
+              />
+              {field.label}
+              {field.required && (
+                <span className="text-destructive">*</span>
+              )}
+            </label>
+            {field.description && (
+              <p className="text-xs text-muted-foreground">
+                {field.description}
+              </p>
+            )}
+            {error && (
+              <p className="text-xs text-destructive">{error}</p>
+            )}
+          </div>
+        );
+
+      case "number":
+        return (
+          <div key={field.name} className="space-y-2">
+            <label className="text-sm font-medium" htmlFor={field.name}>
+              {field.label}
+              {field.required && (
+                <span className="text-destructive">*</span>
+              )}
+            </label>
+            <Input
+              id={field.name}
+              type="number"
+              value={value}
+              onChange={(e) => onChange(field.name, e.target.value)}
+              placeholder={field.placeholder}
+              required={field.required}
+            />
+            {field.description && (
+              <p className="text-xs text-muted-foreground">
+                {field.description}
+              </p>
+            )}
+            {error && (
+              <p className="text-xs text-destructive">{error}</p>
+            )}
+          </div>
+        );
+
+      case "text":
+        return (
+          <div key={field.name} className="space-y-2">
+            <label className="text-sm font-medium" htmlFor={field.name}>
+              {field.label}
+              {field.required && (
+                <span className="text-destructive">*</span>
+              )}
+            </label>
+            {isSecret ? (
+              <div className="relative">
+                <textarea
+                  id={field.name}
+                  value={value}
+                  onChange={(e) => onChange(field.name, e.target.value)}
+                  placeholder={field.placeholder}
+                  required={field.required}
+                  rows={4}
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                  style={
+                    {
+                      fontFamily: showSecret ? "monospace" : "inherit",
+                      WebkitTextSecurity: showSecret ? "none" : "disc",
+                    } as React.CSSProperties
+                  }
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-2 top-2 h-6 w-6"
+                  onClick={() => toggleSecret(field.name)}
+                >
+                  {showSecret ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            ) : (
+              <textarea
+                id={field.name}
+                value={value}
+                onChange={(e) => onChange(field.name, e.target.value)}
+                placeholder={field.placeholder}
+                required={field.required}
+                rows={4}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              />
+            )}
+            {field.description && (
+              <p className="text-xs text-muted-foreground">
+                {field.description}
+              </p>
+            )}
+            {error && (
+              <p className="text-xs text-destructive">{error}</p>
+            )}
+          </div>
+        );
+
+      default:
+        return (
+          <div key={field.name} className="space-y-2">
+            <label className="text-sm font-medium" htmlFor={field.name}>
+              {field.label}
+              {field.required && (
+                <span className="text-destructive">*</span>
+              )}
+            </label>
+            {isSecret ? (
+              <div className="relative">
+                <Input
+                  id={field.name}
+                  type={showSecret ? "text" : "password"}
+                  value={value}
+                  onChange={(e) => onChange(field.name, e.target.value)}
+                  placeholder={field.placeholder}
+                  required={field.required}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-0 top-0 h-full"
+                  onClick={() => toggleSecret(field.name)}
+                >
+                  {showSecret ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            ) : (
+              <Input
+                id={field.name}
+                type="text"
+                value={value}
+                onChange={(e) => onChange(field.name, e.target.value)}
+                placeholder={field.placeholder}
+                required={field.required}
+              />
+            )}
+            {field.description && (
+              <p className="text-xs text-muted-foreground">
+                {field.description}
+              </p>
+            )}
+            {error && (
+              <p className="text-xs text-destructive">{error}</p>
+            )}
+          </div>
+        );
+    }
+  };
+
+  return <div className="space-y-4">{fields.map(renderField)}</div>;
+}

--- a/web/admin-portal/src/components/backends/test-connection-button.tsx
+++ b/web/admin-portal/src/components/backends/test-connection-button.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { CheckCircle2, XCircle, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { testBackend } from "@/lib/api/backends";
+import { getDisplayError } from "@/lib/utils/sanitize-error";
+
+interface TestConnectionButtonProps {
+  backendId: string;
+  onTestComplete?: () => void;
+}
+
+export function TestConnectionButton({
+  backendId,
+  onTestComplete,
+}: TestConnectionButtonProps) {
+  const [testing, setTesting] = useState(false);
+  const [result, setResult] = useState<{
+    status: string;
+    message: string;
+  } | null>(null);
+
+  async function handleTest() {
+    setTesting(true);
+    setResult(null);
+    try {
+      const res = await testBackend(backendId);
+      setResult({ status: res.status, message: res.message });
+      if (onTestComplete) {
+        onTestComplete();
+      }
+    } catch (err) {
+      setResult({ status: "error", message: getDisplayError(err) });
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Button
+        type="button"
+        variant="outline"
+        onClick={handleTest}
+        disabled={testing}
+      >
+        {testing ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Testing...
+          </>
+        ) : (
+          "Test Connection"
+        )}
+      </Button>
+
+      {result && (
+        <div
+          className={`flex items-start gap-2 rounded-md border p-3 text-sm ${
+            result.status === "healthy"
+              ? "border-green-500/50 bg-green-500/10 text-green-700"
+              : "border-destructive/50 bg-destructive/10 text-destructive"
+          }`}
+        >
+          {result.status === "healthy" ? (
+            <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" />
+          ) : (
+            <XCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          )}
+          <div>
+            <p className="font-medium">
+              {result.status === "healthy" ? "Connection successful" : "Connection failed"}
+            </p>
+            <p className="text-xs opacity-90">{result.message}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/admin-portal/src/components/layout/sidebar.tsx
+++ b/web/admin-portal/src/components/layout/sidebar.tsx
@@ -9,16 +9,25 @@ import {
   ShieldCheck,
   FileKey,
   ScrollText,
+  Cloud,
+  Package,
+  Link2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-const navigation = [
+const mainNavigation = [
   { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { name: "Tenants", href: "/tenants", icon: Building2 },
   { name: "Users", href: "/users", icon: Users },
   { name: "Roles", href: "/roles", icon: ShieldCheck },
   { name: "Certificates", href: "/certificates", icon: FileKey },
   { name: "Audit Log", href: "/audit", icon: ScrollText },
+];
+
+const infrastructureNavigation = [
+  { name: "O-Clouds", href: "/infrastructure/o-clouds", icon: Cloud },
+  { name: "DMS", href: "/infrastructure/dms", icon: Package },
+  { name: "Links", href: "/infrastructure/links", icon: Link2 },
 ];
 
 export function Sidebar() {
@@ -35,7 +44,29 @@ export function Sidebar() {
         </Link>
       </div>
       <nav className="flex flex-col gap-1 p-4">
-        {navigation.map((item) => {
+        {mainNavigation.map((item) => {
+          const isActive = pathname.startsWith(item.href);
+          return (
+            <Link
+              key={item.name}
+              href={item.href}
+              className={cn(
+                "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              )}
+            >
+              <item.icon className="h-4 w-4" />
+              {item.name}
+            </Link>
+          );
+        })}
+        <div className="my-2 border-t" />
+        <p className="px-3 py-2 text-xs font-semibold text-muted-foreground uppercase">
+          Infrastructure
+        </p>
+        {infrastructureNavigation.map((item) => {
           const isActive = pathname.startsWith(item.href);
           return (
             <Link

--- a/web/admin-portal/src/lib/api/admin-client.ts
+++ b/web/admin-portal/src/lib/api/admin-client.ts
@@ -1,0 +1,8 @@
+import { ApiClient } from "./client";
+
+const ADMIN_API_BASE_URL =
+  process.env.NEXT_PUBLIC_ADMIN_API_BASE_URL ||
+  "http://localhost:8080/api/v1/admin";
+
+export const adminApiClient = new ApiClient(ADMIN_API_BASE_URL);
+export default adminApiClient;

--- a/web/admin-portal/src/lib/api/backends.ts
+++ b/web/admin-portal/src/lib/api/backends.ts
@@ -1,0 +1,129 @@
+import adminApiClient from "./admin-client";
+import type {
+  BackendResponse,
+  BackendsListResponse,
+  CreateBackendRequest,
+  UpdateBackendRequest,
+  TestBackendResult,
+  BackendAccess,
+  BackendAccessListResponse,
+  CreateBackendAccessRequest,
+  UpdateBackendAccessRequest,
+  AdapterTypeSchema,
+  AdapterTypesListResponse,
+  CreateDMSLinkRequest,
+} from "@/types/backends";
+
+export async function listBackends(
+  category?: string
+): Promise<BackendResponse[]> {
+  const params = category ? { category } : undefined;
+  const response = await adminApiClient.get<BackendsListResponse>(
+    "/backends",
+    params
+  );
+  return response.backends;
+}
+
+export async function getBackend(id: string): Promise<BackendResponse> {
+  return adminApiClient.get<BackendResponse>(`/backends/${id}`);
+}
+
+export async function createBackend(
+  data: CreateBackendRequest
+): Promise<BackendResponse> {
+  return adminApiClient.post<BackendResponse>("/backends", data);
+}
+
+export async function updateBackend(
+  id: string,
+  data: UpdateBackendRequest
+): Promise<BackendResponse> {
+  return adminApiClient.put<BackendResponse>(`/backends/${id}`, data);
+}
+
+export async function deleteBackend(id: string): Promise<void> {
+  await adminApiClient.delete<void>(`/backends/${id}`);
+}
+
+export async function testBackend(id: string): Promise<TestBackendResult> {
+  return adminApiClient.post<TestBackendResult>(`/backends/${id}/test`, {});
+}
+
+export async function listDMSLinks(imsId: string): Promise<BackendResponse[]> {
+  const response = await adminApiClient.get<BackendsListResponse>(
+    `/backends/${imsId}/dms-links`
+  );
+  return response.backends;
+}
+
+export async function createDMSLink(
+  imsId: string,
+  dmsId: string
+): Promise<void> {
+  const data: CreateDMSLinkRequest = { imsId, dmsId };
+  await adminApiClient.post<void>(`/backends/${imsId}/dms-links`, data);
+}
+
+export async function deleteDMSLink(
+  imsId: string,
+  dmsId: string
+): Promise<void> {
+  await adminApiClient.delete<void>(`/backends/${imsId}/dms-links/${dmsId}`);
+}
+
+export async function listBackendAccess(
+  tenantId: string
+): Promise<BackendAccess[]> {
+  const response = await adminApiClient.get<BackendAccessListResponse>(
+    `/tenants/${tenantId}/backend-access`
+  );
+  return response.access;
+}
+
+export async function createBackendAccess(
+  tenantId: string,
+  data: CreateBackendAccessRequest
+): Promise<BackendAccess> {
+  return adminApiClient.post<BackendAccess>(
+    `/tenants/${tenantId}/backend-access`,
+    data
+  );
+}
+
+export async function updateBackendAccess(
+  tenantId: string,
+  accessId: string,
+  data: UpdateBackendAccessRequest
+): Promise<BackendAccess> {
+  return adminApiClient.put<BackendAccess>(
+    `/tenants/${tenantId}/backend-access/${accessId}`,
+    data
+  );
+}
+
+export async function deleteBackendAccess(
+  tenantId: string,
+  accessId: string
+): Promise<void> {
+  await adminApiClient.delete<void>(
+    `/tenants/${tenantId}/backend-access/${accessId}`
+  );
+}
+
+export async function listBackendTypes(
+  category?: string
+): Promise<AdapterTypeSchema[]> {
+  const params = category ? { category } : undefined;
+  const response = await adminApiClient.get<AdapterTypesListResponse>(
+    "/backend-types",
+    params
+  );
+  return response.types;
+}
+
+export async function getBackendTypeSchema(
+  type: string
+): Promise<AdapterTypeSchema> {
+  return adminApiClient.get<AdapterTypeSchema>(`/backend-types/${type}/schema`);
+}

--- a/web/admin-portal/src/lib/api/client.ts
+++ b/web/admin-portal/src/lib/api/client.ts
@@ -16,7 +16,7 @@ function validateBaseUrl(url: string): string {
   return url;
 }
 
-class ApiClient {
+export class ApiClient {
   private baseUrl: string;
   private getToken: (() => Promise<string | null>) | null = null;
 

--- a/web/admin-portal/src/lib/validation/schemas.ts
+++ b/web/admin-portal/src/lib/validation/schemas.ts
@@ -71,6 +71,21 @@ export const userSchema = z.object({
   roleId: z.string().min(1, "Role is required"),
 });
 
+export const backendSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .max(128, "Name must be at most 128 characters"),
+  description: z
+    .string()
+    .max(512, "Description must be at most 512 characters")
+    .optional()
+    .default(""),
+  category: z.enum(["ims", "dms"], { required_error: "Category is required" }),
+  adapterType: z.string().min(1, "Adapter type is required"),
+});
+
 export type CertificateFormData = z.infer<typeof certificateSchema>;
 export type TenantFormData = z.infer<typeof tenantSchema>;
 export type UserFormData = z.infer<typeof userSchema>;
+export type BackendFormData = z.infer<typeof backendSchema>;

--- a/web/admin-portal/src/types/backends.ts
+++ b/web/admin-portal/src/types/backends.ts
@@ -1,0 +1,96 @@
+export interface BackendResponse {
+  id: string;
+  name: string;
+  category: string;
+  adapterType: string;
+  description: string;
+  status: string;
+  statusMessage: string;
+  hasCredentials: boolean;
+  lastHealthCheck: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BackendAccess {
+  id: string;
+  tenantId: string;
+  backendId: string;
+  permissions: string[];
+  constraints: Record<string, unknown>;
+  grantedAt: string;
+  grantedBy: string;
+}
+
+export interface FieldSpec {
+  name: string;
+  label: string;
+  type: "string" | "number" | "boolean" | "text";
+  required: boolean;
+  secret: boolean;
+  default: string;
+  placeholder: string;
+  regex: string;
+  description: string;
+}
+
+export interface AdapterTypeSchema {
+  type: string;
+  category: string;
+  displayName: string;
+  description: string;
+  configSchema: FieldSpec[];
+  credentialSchema: FieldSpec[];
+}
+
+export interface CreateBackendRequest {
+  name: string;
+  category: string;
+  adapterType: string;
+  description?: string;
+  config?: Record<string, string>;
+  credentials?: Record<string, string>;
+}
+
+export interface UpdateBackendRequest {
+  name?: string;
+  description?: string;
+  config?: Record<string, string>;
+  credentials?: Record<string, string>;
+}
+
+export interface TestBackendResult {
+  backendId: string;
+  status: string;
+  message: string;
+}
+
+export interface BackendsListResponse {
+  backends: BackendResponse[];
+  total: number;
+}
+
+export interface BackendAccessListResponse {
+  access: BackendAccess[];
+  total: number;
+}
+
+export interface AdapterTypesListResponse {
+  types: AdapterTypeSchema[];
+}
+
+export interface CreateDMSLinkRequest {
+  imsId: string;
+  dmsId: string;
+}
+
+export interface CreateBackendAccessRequest {
+  backendId: string;
+  permissions: string[];
+  constraints?: Record<string, unknown>;
+}
+
+export interface UpdateBackendAccessRequest {
+  permissions?: string[];
+  constraints?: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary

- Add O-Cloud (IMS) and DMS backend management pages with CRUD operations
- Implement dynamic form component driven by adapter type schemas from the backend API
- Create IMS-DMS link matrix page for managing backend relationships
- Add backend access management to tenant detail pages
- Create separate admin API client (`NEXT_PUBLIC_ADMIN_API_BASE_URL`) for backend management endpoints
- Add status badges, test connection button, and loading/empty state components

## New Pages

| Page | Description |
|------|-------------|
| `/infrastructure/o-clouds` | List IMS backends (Kubernetes, AWS, Azure, OpenStack) |
| `/infrastructure/o-clouds/new` | Create IMS backend with dynamic config/credential form |
| `/infrastructure/o-clouds/[id]` | Edit IMS backend, manage DMS links, test connection |
| `/infrastructure/dms` | List DMS backends (Helm, ArgoCD, Flux) |
| `/infrastructure/dms/new` | Create DMS backend with dynamic config/credential form |
| `/infrastructure/dms/[id]` | Edit DMS backend, test connection |
| `/infrastructure/links` | IMS-DMS link matrix with checkbox toggles |

## New Components

| Component | Purpose |
|-----------|---------|
| `dynamic-form.tsx` | Schema-driven form: string/number/boolean/text fields, secret toggle, validation |
| `backend-status-badge.tsx` | Color-coded status (healthy/unhealthy/unknown) |
| `test-connection-button.tsx` | Async test with loading/result display |

## Modified Files

- **sidebar.tsx**: Added Infrastructure section (O-Clouds, DMS, Links)
- **tenants/[id]/page.tsx**: Added Backend Access card with grant/revoke
- **client.ts**: Exported `ApiClient` class for reuse
- **schemas.ts**: Added `backendSchema` + `BackendFormData`

## API Separation

The admin API uses a **separate client** from the O2-IMS API:
- O2-IMS: `NEXT_PUBLIC_API_BASE_URL` (default: `http://localhost:8080/o2ims-infrastructureInventory/v1`)
- Admin: `NEXT_PUBLIC_ADMIN_API_BASE_URL` (default: `http://localhost:8080/api/v1/admin`)

## Test plan

- [x] `npm run build` passes (24 routes, 0 errors)
- [x] TypeScript compilation clean
- [x] All new pages follow existing patterns (loading, empty, error states)
- [x] Dynamic forms render correctly based on adapter type schemas

Resolves #363 (part 5/5)