### PR TITLE
OIDC fixes: CA trust, confidential client, roles mapping

### DIFF
--- a/deployments/helm/netweave/templates/admin-portal-deployment.yaml
+++ b/deployments/helm/netweave/templates/admin-portal-deployment.yaml
@@ -53,6 +53,16 @@ spec:
               value: {{ .Values.adminPortal.authUrl | quote }}
             - name: NEXT_PUBLIC_API_BASE_URL
               value: {{ .Values.adminPortal.apiBaseUrl | quote }}
+            {{- if .Values.adminPortal.trustCA }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: /etc/netweave/tls/ca.crt
+            {{- end }}
+          {{- if .Values.adminPortal.trustCA }}
+          volumeMounts:
+            - name: ca-cert
+              mountPath: /etc/netweave/tls
+              readOnly: true
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /
@@ -67,6 +77,12 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml (.Values.adminPortal.resources | default (dict "requests" (dict "cpu" "100m" "memory" "128Mi") "limits" (dict "cpu" "500m" "memory" "256Mi"))) | nindent 12 }}
+      {{- if .Values.adminPortal.trustCA }}
+      volumes:
+        - name: ca-cert
+          configMap:
+            name: {{ .Values.adminPortal.trustCA }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/deployments/helm/netweave/templates/init-job-keycloak-config.yaml
+++ b/deployments/helm/netweave/templates/init-job-keycloak-config.yaml
@@ -52,6 +52,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "netweave.fullname" . }}-secret
                   key: keycloak-client-secret
+            - name: ADMIN_PORTAL_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "netweave.fullname" . }}-admin-portal
+                  key: keycloak-client-secret
           command:
             - sh
             - -c
@@ -115,19 +120,41 @@ spec:
 
               echo "Found client with UUID: ${CLIENT_UUID}"
 
-              # Update client secret via PUT on the client representation
-              echo "Updating client secret..."
-              curl -sf -X PUT "${KEYCLOAK_URL}/admin/realms/netweave/clients/${CLIENT_UUID}" \
+              # Fetch full client representation, merge updates, and PUT back.
+              # This preserves all existing fields (protocolMappers, attributes, etc.)
+              echo "Updating netweave-gateway client..."
+              FULL_CLIENT=$(curl -sf -X GET "${KEYCLOAK_URL}/admin/realms/netweave/clients/${CLIENT_UUID}" \
                 -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-                -H "Content-Type: application/json" \
-                -d "{\"clientId\":\"netweave-gateway\",\"secret\":\"${GATEWAY_CLIENT_SECRET}\",\"serviceAccountsEnabled\":true,\"directAccessGrantsEnabled\":true}"
+                -H "Content-Type: application/json")
 
-              if [ $? -ne 0 ]; then
-                echo "ERROR: Failed to update client secret"
+              if [ $? -ne 0 ] || [ -z "$FULL_CLIENT" ]; then
+                echo "ERROR: Failed to fetch full client representation"
                 exit 1
               fi
 
-              echo "Successfully configured client secret for netweave-gateway"
+              # Build the redirect URIs and web origins JSON arrays from Helm values
+              GATEWAY_REDIRECT_URIS='["http://localhost:8081/*","https://localhost:8081/*"{{ range .Values.gateway.keycloakClient.additionalRedirectUris }},"{{ . }}"{{ end }}]'
+              GATEWAY_WEB_ORIGINS='["http://localhost:8081","https://localhost:8081"{{ range .Values.gateway.keycloakClient.additionalWebOrigins }},"{{ . }}"{{ end }}]'
+
+              # Merge fields into the full client representation
+              UPDATED_CLIENT=$(echo "$FULL_CLIENT" | sed \
+                -e "s|\"secret\":\"[^\"]*\"|\"secret\":\"${GATEWAY_CLIENT_SECRET}\"|" \
+                -e "s|\"serviceAccountsEnabled\":[a-z]*|\"serviceAccountsEnabled\":true|" \
+                -e "s|\"directAccessGrantsEnabled\":[a-z]*|\"directAccessGrantsEnabled\":true|" \
+                -e "s|\"redirectUris\":\[[^]]*\]|\"redirectUris\":${GATEWAY_REDIRECT_URIS}|" \
+                -e "s|\"webOrigins\":\[[^]]*\]|\"webOrigins\":${GATEWAY_WEB_ORIGINS}|")
+
+              curl -sf -X PUT "${KEYCLOAK_URL}/admin/realms/netweave/clients/${CLIENT_UUID}" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -H "Content-Type: application/json" \
+                -d "$UPDATED_CLIENT"
+
+              if [ $? -ne 0 ]; then
+                echo "ERROR: Failed to update netweave-gateway client"
+                exit 1
+              fi
+
+              echo "Successfully configured netweave-gateway client"
 
               # Verify secret was set correctly
               SECRET_RESPONSE=$(curl -sf -X GET "${KEYCLOAK_URL}/admin/realms/netweave/clients/${CLIENT_UUID}/client-secret" \
@@ -141,6 +168,44 @@ spec:
               else
                 echo "WARNING: Client secret mismatch after update (expected: ${GATEWAY_CLIENT_SECRET:0:5}..., got: ${ACTUAL_SECRET:0:5}...)"
                 exit 1
+              fi
+
+              # Update admin-portal client redirect URIs
+              echo "Fetching admin-portal client..."
+              AP_CLIENT_RESPONSE=$(curl -sf -X GET "${KEYCLOAK_URL}/admin/realms/netweave/clients?clientId=admin-portal" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -H "Content-Type: application/json")
+
+              AP_CLIENT_UUID=$(echo "$AP_CLIENT_RESPONSE" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+              if [ -n "$AP_CLIENT_UUID" ]; then
+                echo "Found admin-portal client: ${AP_CLIENT_UUID}"
+
+                FULL_AP_CLIENT=$(curl -sf -X GET "${KEYCLOAK_URL}/admin/realms/netweave/clients/${AP_CLIENT_UUID}" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                  -H "Content-Type: application/json")
+
+                AP_REDIRECT_URIS='["http://localhost:3000/*","https://localhost:3000/*"{{ range .Values.adminPortal.keycloak.additionalRedirectUris }},"{{ . }}"{{ end }}]'
+                AP_WEB_ORIGINS='["http://localhost:3000","https://localhost:3000"{{ range .Values.adminPortal.keycloak.additionalWebOrigins }},"{{ . }}"{{ end }}]'
+
+                UPDATED_AP_CLIENT=$(echo "$FULL_AP_CLIENT" | sed \
+                  -e "s|\"publicClient\":[a-z]*|\"publicClient\":false|" \
+                  -e "s|\"secret\":\"[^\"]*\"|\"secret\":\"${ADMIN_PORTAL_CLIENT_SECRET}\"|" \
+                  -e "s|\"redirectUris\":\[[^]]*\]|\"redirectUris\":${AP_REDIRECT_URIS}|" \
+                  -e "s|\"webOrigins\":\[[^]]*\]|\"webOrigins\":${AP_WEB_ORIGINS}|")
+
+                curl -sf -X PUT "${KEYCLOAK_URL}/admin/realms/netweave/clients/${AP_CLIENT_UUID}" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                  -H "Content-Type: application/json" \
+                  -d "$UPDATED_AP_CLIENT"
+
+                if [ $? -ne 0 ]; then
+                  echo "WARNING: Failed to update admin-portal redirect URIs"
+                else
+                  echo "Successfully configured admin-portal redirect URIs"
+                fi
+              else
+                echo "INFO: admin-portal client not found, skipping"
               fi
 
               echo "Keycloak configuration complete"

--- a/deployments/helm/netweave/templates/keycloak-realm-configmap.yaml
+++ b/deployments/helm/netweave/templates/keycloak-realm-configmap.yaml
@@ -146,11 +146,28 @@ data:
             {{- end }}
           ],
           "protocol": "openid-connect",
-          "publicClient": true,
+          "publicClient": false,
           "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": false,
           "standardFlowEnabled": true,
           "implicitFlowEnabled": false,
-          "fullScopeAllowed": true
+          "fullScopeAllowed": true,
+          "protocolMappers": [
+            {
+              "name": "roles-mapper",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-realm-role-mapper",
+              "consentRequired": false,
+              "config": {
+                "userinfo.token.claim": "true",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "roles",
+                "jsonType.label": "String",
+                "multivalued": "true"
+              }
+            }
+          ]
         }
       ],
       "roles": {

--- a/deployments/helm/netweave/values-local.yaml
+++ b/deployments/helm/netweave/values-local.yaml
@@ -88,7 +88,7 @@ adminPortal:
     additionalWebOrigins:
       - "https://admin.netweave.local"
   authUrl: "https://admin.netweave.local"
-  apiBaseUrl: "http://netweave-netweave:8080"
+  apiBaseUrl: "https://api.netweave.local"
   ingress:
     enabled: true
     className: "nginx"
@@ -103,6 +103,8 @@ adminPortal:
       - secretName: admin-portal-ingress-tls
         hosts:
           - admin.netweave.local
+  # Trust the Vault CA so Node.js can verify TLS when reaching Keycloak via ingress.
+  trustCA: "netweave-tls-ca"
   # Resolve ingress hostnames from inside the pod for OIDC discovery.
   # Set the IP to the NGINX ingress controller's ClusterIP:
   #   kubectl get svc -n ingress-nginx ingress-nginx-controller -o jsonpath='{.spec.clusterIP}'

--- a/web/admin-portal/Dockerfile
+++ b/web/admin-portal/Dockerfile
@@ -9,6 +9,8 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+ARG NEXT_PUBLIC_API_BASE_URL=""
+ENV NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
 RUN npm run build
 
 FROM base AS runner

--- a/web/admin-portal/src/lib/auth/config.ts
+++ b/web/admin-portal/src/lib/auth/config.ts
@@ -10,11 +10,16 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     }),
   ],
   callbacks: {
-    async jwt({ token, account }) {
+    async jwt({ token, account, profile }) {
       if (account) {
         token.accessToken = account.access_token;
         token.refreshToken = account.refresh_token;
         token.expiresAt = account.expires_at;
+      }
+      if (profile) {
+        token.roles = (profile as Record<string, unknown>).roles as
+          | string[]
+          | undefined;
       }
       return token;
     },
@@ -22,6 +27,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       return {
         ...session,
         accessToken: token.accessToken as string,
+        user: {
+          ...session.user,
+          roles: token.roles as string[] | undefined,
+        },
       };
     },
   },


### PR DESCRIPTION
## Summary

- Mount Vault CA as `NODE_EXTRA_CA_CERTS` in admin-portal pod so Node.js trusts TLS to Keycloak via ingress
- Keycloak init job uses fetch-merge-PUT pattern to preserve protocolMappers/attributes when updating clients; now also configures admin-portal client secret and redirect URIs
- Set admin-portal as confidential Keycloak client (`publicClient: false`) with roles-mapper protocolMapper
- Extract Keycloak realm roles from OIDC profile into NextAuth JWT token and session object
- Accept `NEXT_PUBLIC_API_BASE_URL` as Docker build arg for static inlining at build time
- Set `apiBaseUrl` to `https://api.netweave.local` in local values

## Test plan

- [ ] `helm template` renders correctly with `values-local.yaml`
- [ ] Admin portal pod starts and completes OIDC discovery against Keycloak via ingress
- [ ] Keycloak init job logs show both clients configured successfully
- [ ] Login to admin portal and verify `session.user.roles` contains Keycloak roles
- [ ] Docker build with `--build-arg NEXT_PUBLIC_API_BASE_URL=https://api.netweave.local` inlines the URL

Resolves #373