### PR TITLE
Rewrite getting-started docs for Kubernetes deployment

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -23,19 +23,19 @@ netweave is a production-grade O-RAN O2 Gateway that implements:
 Start here if you want to see netweave in action immediately:
 
 - [**Quickstart Guide →**](quickstart.md)
-  - Deploy with Docker Compose
-  - Make your first API call
-  - See webhook notifications
+  - Deploy to Kubernetes with `netweave-cli setup all`
+  - Make your first O2-IMS API call with mTLS
+  - Explore the admin portal
 
 ### 2. Installation (30 minutes)
 
 Choose your installation method:
 
 - [**Installation Guide →**](installation.md)
-  - Kubernetes with Helm
-  - Kubernetes with Operator
-  - Docker Compose for development
-  - Local development setup
+  - Automated setup with `netweave-cli` (recommended)
+  - Manual Kubernetes deployment
+  - Production deployment with Helm
+  - Multi-cluster deployment
 
 ### 3. First Steps (1 hour)
 
@@ -54,8 +54,9 @@ Before you begin, ensure you have:
 
 ### For Quickstart
 
-- Docker and Docker Compose installed
-- `curl` or similar HTTP client
+- Kubernetes cluster (Docker Desktop, Kind, or minikube)
+- kubectl, Helm, and Go 1.25.0+ installed
+- NGINX Ingress Controller
 - 5 minutes of your time
 
 ### For Production Installation
@@ -145,7 +146,10 @@ kubectl logs -n netweave -l app.kubernetes.io/component=gateway
 
 # Access via NGINX Ingress (recommended, see Installation Guide)
 # Requires /etc/hosts: 127.0.0.1 api.netweave.local admin.netweave.local auth.netweave.local
-curl -X GET http://api.netweave.local/o2ims-infrastructureInventory/v1/resourcePools
+# O2-IMS API uses mTLS authentication
+curl --cert ~/.netweave/client.crt --key ~/.netweave/client.key \
+  --cacert ~/.netweave/ca.crt \
+  https://api.netweave.local/o2ims-infrastructureInventory/v1/resourceTypes
 ```
 
 </details>

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -242,12 +242,12 @@ kubectl get pods -n netweave
 kubectl get ingress -n netweave
 
 # Check gateway logs
-kubectl logs -n netweave deployment/netweave-netweave -f
+kubectl logs -n netweave deployment/netweave -f
 
 # Test Gateway API via mTLS passthrough
 curl --cert ~/.netweave/client.crt --key ~/.netweave/client.key \
   --cacert ~/.netweave/ca.crt \
-  https://api.netweave.local/o2ims-infrastructureInventory/v1/api_versions
+  https://api.netweave.local/o2ims-infrastructureInventory/v1/resourceTypes
 
 # Test Keycloak OIDC discovery (NGINX TLS termination)
 curl -sk https://auth.netweave.local/realms/netweave/.well-known/openid-configuration | jq .issuer

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,130 +1,137 @@
 # 5-Minute Quickstart
 
-Get netweave running locally in under 5 minutes using Docker Compose.
+Get netweave running on a local Kubernetes cluster in under 5 minutes using the `netweave-cli`.
 
 ## What You'll Get
 
 By the end of this quickstart, you'll have:
 
-- Complete O2-IMS gateway running locally
-- Redis backend for subscriptions and caching
-- Working API endpoints at `http://localhost:8080`
-- Sample Kubernetes backend adapter
+- Complete O2-IMS gateway running on Kubernetes
+- Vault PKI with Root CA, Intermediate CA, and mTLS certificates
+- PostgreSQL, Redis, and Keycloak deployed and configured
+- Admin Portal with Keycloak OIDC authentication
+- NGINX Ingress with TLS for all services
+- Working API endpoints at `https://api.netweave.local`
 
 ## Prerequisites
 
-- **Docker Desktop** or **Docker Engine** 20.10+
-- **Docker Compose** v2.0+
-- **netweave-cli** (recommended) or **curl** for API testing
+- **Docker Desktop** with Kubernetes enabled, or a **Kind** cluster
+- **kubectl** configured and connected to your cluster
+- **Helm** 3.x installed
+- **NGINX Ingress Controller** installed (see [Installation Guide](installation.md#step-4-install-nginx-ingress-controller))
+- **Go 1.25.0+** (to build the CLI)
 - **2GB RAM** available
-
-### Install netweave-cli
-
-```bash
-# Build from source
-git clone https://github.com/piwi3910/netweave.git
-cd netweave
-make build-cli
-sudo cp build/netweave-cli /usr/local/bin/
-```
 
 ### Verify Prerequisites
 
 ```bash
-# Check Docker
-docker --version
-# Expected: Docker version 20.10.0+
+# Check Kubernetes cluster
+kubectl cluster-info
+# Expected: Kubernetes control plane is running
 
-# Check Docker Compose
-docker compose version
-# Expected: Docker Compose version v2.0.0+
+# Check Helm
+helm version --short
+# Expected: v3.x.x
 
-# Check available memory
-docker info | grep "Total Memory"
-# Expected: >2GB
+# Check Go
+go version
+# Expected: go1.25.0 or later
+```
+
+### DNS Setup
+
+Add local DNS entries to `/etc/hosts`:
+
+```bash
+echo "127.0.0.1 admin.netweave.local api.netweave.local auth.netweave.local" | sudo tee -a /etc/hosts
 ```
 
 ## Quick Deploy
 
-### Step 1: Clone Repository
+### Step 1: Clone and Build
 
 ```bash
-# Clone the repository
 git clone https://github.com/piwi3910/netweave.git
 cd netweave
+make build-cli
+make docker-build
 ```
 
-### Step 2: Start Services
+Load the gateway image into your cluster nodes (Kind example):
 
 ```bash
-# Start gateway + Redis with Docker Compose
-docker compose up -d
+# For Kind clusters
+kind load docker-image netweave:latest
 
-# Wait for services to be ready (10-30 seconds)
-docker compose ps
+# For Docker Desktop with Kind nodes
+docker save netweave:latest | docker exec -i <worker-node> ctr -n k8s.io images import --all-platforms -
+```
+
+### Step 2: Deploy Everything
+
+```bash
+./build/netweave-cli setup all --verbose
+```
+
+This runs four phases automatically:
+
+1. **Vault** — Deploys Vault with TLS, initializes PKI engine (root CA, intermediate CA, server/client roles)
+2. **Certificates** — Issues gateway server certificate, ingress TLS certificates, and admin client certificate
+3. **Helm** — Installs the netweave Helm chart (PostgreSQL, Redis, Keycloak, Gateway, Admin Portal)
+4. **Keycloak** — Declares user profile attributes, creates default tenant, initializes roles, creates admin user
+
+Credentials are saved to `~/.netweave/`:
+
+- `credentials.json` — Vault root token and unseal keys
+- `client.crt` / `client.key` — Admin client certificate for mTLS API access
+- `ca.crt` — CA certificate chain
+
+### Step 3: Verify Gateway is Running
+
+```bash
+./build/netweave-cli api health
 ```
 
 **Expected output:**
 
 ```text
-NAME                IMAGE                 STATUS
-netweave-gateway    netweave:latest       Up 10 seconds (healthy)
-netweave-redis      redis:7.4-alpine      Up 15 seconds (healthy)
-```
+Status: healthy
 
-### Step 3: Verify Gateway is Running
-
-```bash
-# Check health endpoint
-curl http://localhost:8080/health
-
-# Expected response:
-# {"status":"ok","timestamp":"2026-01-12T21:00:00Z"}
+Gateway is healthy
 ```
 
 ## First API Call
 
-Make your first O2-IMS API call to list resource pools:
+Make your first O2-IMS API call to list resource types:
 
 Using `netweave-cli`:
 
 ```bash
-netweave-cli api resource-pools list --gateway-url http://localhost:8080
+./build/netweave-cli api resource-types list
+```
+
+**Expected output:**
+
+```text
+ID                     NAME                   VENDOR   MODEL  VERSION
+---------------------  ---------------------  -------  -----  -------
+k8s-node-type-generic  k8s-node-type-generic  Unknown  <nil>  v1.33.1
+
+1 item(s)
 ```
 
 <details>
-<summary>Using curl</summary>
+<summary>Using curl with mTLS</summary>
 
 ```bash
-curl -X GET http://localhost:8080/o2ims-infrastructureInventory/v1/resourcePools | jq
+curl --cert ~/.netweave/client.crt --key ~/.netweave/client.key \
+  --cacert ~/.netweave/ca.crt \
+  https://api.netweave.local/o2ims-infrastructureInventory/v1/resourceTypes
 ```
 
 </details>
 
-**Expected response:**
-
-```json
-{
-  "items": [
-    {
-      "resourcePoolId": "pool-default",
-      "name": "Default Compute Pool",
-      "description": "Default Kubernetes node pool",
-      "location": "local",
-      "oCloudId": "ocloud-local-k8s",
-      "extensions": {
-        "backend": "kubernetes",
-        "nodeCount": 1
-      }
-    }
-  ],
-  "metadata": {
-    "totalCount": 1
-  }
-}
-```
-
-**Success!** You've successfully deployed netweave and made your first API call.
+**Success!** You've deployed netweave and made your first API call.
 
 ## What's Running
 
@@ -133,501 +140,249 @@ Your local environment now includes:
 ```mermaid
 graph LR
     Client[Your Terminal]
-    Gateway[netweave Gateway<br/>:8080]
+    Ingress[NGINX Ingress<br/>:443]
+    Gateway[netweave Gateway<br/>mTLS]
     Redis[Redis<br/>:6379]
-    K8s[Local Kubernetes<br/>Docker Desktop]
+    PG[PostgreSQL<br/>:5432]
+    KC[Keycloak<br/>OIDC]
+    Admin[Admin Portal]
+    K8s[Kubernetes API]
 
-    Client -->|HTTP| Gateway
+    Client -->|HTTPS/mTLS| Ingress
+    Ingress --> Gateway
+    Ingress --> Admin
+    Ingress --> KC
     Gateway -->|State/Cache| Redis
+    Gateway -->|Storage| PG
+    Gateway -->|Auth| KC
     Gateway -->|Read Infrastructure| K8s
+    Admin -->|OIDC| KC
 
     style Client fill:#e1f5ff
+    style Ingress fill:#e8f5e9
     style Gateway fill:#fff4e6
     style Redis fill:#ffe6f0
+    style PG fill:#ffe6f0
+    style KC fill:#f3e5f5
+    style Admin fill:#f3e5f5
     style K8s fill:#e8f5e9
 ```
 
 ### Services Overview
 
-| Service | Port | Purpose | Status Check |
-|---------|------|---------|--------------|
-| **netweave Gateway** | 8080 | O2-IMS API | `curl localhost:8080/health` |
-| **Redis** | 6379 | Subscriptions, cache | `docker exec netweave-redis redis-cli ping` |
-| **Kubernetes** | - | Infrastructure backend | `kubectl get nodes` |
+| Service | URL | Auth | Purpose |
+|---------|-----|------|---------|
+| **Gateway API** | `https://api.netweave.local` | mTLS client cert | O2-IMS API endpoints |
+| **Admin Portal** | `https://admin.netweave.local` | OAuth2/OIDC (Keycloak) | Web management UI |
+| **Keycloak** | `https://auth.netweave.local` | Admin credentials | Identity provider |
 
-### Key Configuration
+### Authentication
 
-The development environment uses `config/config.dev.yaml`:
+netweave uses two authentication mechanisms:
 
-```yaml
-server:
-  port: 8080
-  tls:
-    enabled: false  # HTTP only for local testing
-
-redis:
-  address: "redis:6379"
-  password: ""     # No auth for local dev
-
-adapter:
-  backend: "kubernetes"
-  kubernetes:
-    incluster: false
-    kubeconfig: "~/.kube/config"
-
-observability:
-  logging:
-    level: debug
-    development: true
-```
+- **O2-IMS API** — mTLS client certificates (O-RAN spec compliant). Use the client cert from `~/.netweave/`.
+- **Admin Portal** — OAuth2/OIDC via Keycloak. Log in through the browser with your Keycloak credentials.
 
 ## Try More API Calls
 
-### 1. List Resource Types
-
-Using `netweave-cli`:
+### 1. List Deployment Managers
 
 ```bash
-netweave-cli api resource-types list --gateway-url http://localhost:8080
+./build/netweave-cli api deployment-managers list
 ```
-
-<details>
-<summary>Using curl</summary>
-
-```bash
-curl -X GET http://localhost:8080/o2ims-infrastructureInventory/v1/resourceTypes | jq
-```
-
-</details>
 
 **Response:**
 
-```json
-{
-  "items": [
-    {
-      "resourceTypeId": "kubernetes-node",
-      "name": "Kubernetes Node",
-      "vendor": "Kubernetes",
-      "version": "v1.30.0"
-    },
-    {
-      "resourceTypeId": "kubernetes-pod",
-      "name": "Kubernetes Pod",
-      "vendor": "Kubernetes",
-      "version": "v1.30.0"
-    }
-  ]
-}
+```text
+ID               NAME                                 DESCRIPTION
+---------------  -----------------------------------  ------------------------------------------
+netweave-k8s-dm  Kubernetes Cluster: netweave-k8s-dm  Kubernetes-based O2-IMS Deployment Manager
+
+1 item(s)
 ```
 
-### 2. List Resources in a Pool
-
-Using `netweave-cli`:
+### 2. Create a Subscription (Webhooks)
 
 ```bash
-netweave-cli api resources list --pool-id pool-default --gateway-url http://localhost:8080
+./build/netweave-cli api subscriptions create --callback https://example.com/notify
 ```
-
-<details>
-<summary>Using curl</summary>
-
-```bash
-curl -X GET http://localhost:8080/o2ims-infrastructureInventory/v1/resourcePools/pool-default/resources | jq
-```
-
-</details>
 
 **Response:**
 
-```json
-{
-  "items": [
-    {
-      "resourceId": "node-docker-desktop",
-      "resourcePoolId": "pool-default",
-      "resourceTypeId": "kubernetes-node",
-      "description": "Docker Desktop Kubernetes node",
-      "extensions": {
-        "cpu": "8",
-        "memory": "16Gi",
-        "status": "Ready"
-      }
-    }
-  ]
-}
+```text
+Subscription created: sub-<uuid>
+Callback: https://example.com/notify
 ```
 
-### 3. Get Deployment Managers
-
-Using `netweave-cli`:
+### 3. List Subscriptions
 
 ```bash
-netweave-cli api deployment-managers list --gateway-url http://localhost:8080
+./build/netweave-cli api subscriptions list
 ```
 
-<details>
-<summary>Using curl</summary>
+### 4. List Users, Roles, and Tenants
 
 ```bash
-curl -X GET http://localhost:8080/o2ims-infrastructureInventory/v1/deploymentManagers | jq
+./build/netweave-cli users list --tenant=default
+./build/netweave-cli roles list
+./build/netweave-cli tenants list
 ```
 
-</details>
+### 5. Verify Certificates
+
+```bash
+./build/netweave-cli certs verify --cert ~/.netweave/client.crt
+```
 
 **Response:**
 
-```json
-{
-  "items": [
-    {
-      "deploymentManagerId": "dm-kubernetes-local",
-      "name": "Local Kubernetes",
-      "description": "Docker Desktop Kubernetes cluster",
-      "oCloudId": "ocloud-local-k8s",
-      "serviceUri": "https://kubernetes.default.svc",
-      "extensions": {
-        "version": "v1.30.0",
-        "backend": "kubernetes"
-      }
-    }
-  ]
-}
+```text
+Certificate details:
+  Subject:  CN=admin.netweave.local,O=Netweave
+  Issuer:   CN=Netweave Intermediate CA,O=Netweave
+  ...
+
+Certificate is valid and trusted by CA
 ```
 
-### 4. Create a Subscription (Webhooks)
+## Access the Admin Portal
 
-First, set up a webhook receiver (optional):
+Open `https://admin.netweave.local` in your browser.
 
-```bash
-# In a separate terminal, start a simple webhook receiver
-docker run --rm -p 9000:8080 --network netweave_default \
-  mendhak/http-https-echo:31
-```
+> **Browser TLS:** Since certificates are signed by a private Vault CA, import
+> `~/.netweave/ca.crt` into your browser's trusted certificate authorities to
+> avoid security warnings.
 
-Then create a subscription:
+The admin portal provides:
 
-Using `netweave-cli`:
-
-```bash
-netweave-cli api subscriptions create \
-  --callback http://host.docker.internal:9000/webhook \
-  --gateway-url http://localhost:8080
-```
-
-<details>
-<summary>Using curl</summary>
-
-```bash
-curl -X POST http://localhost:8080/o2ims-infrastructureInventory/v1/subscriptions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "callback": "http://host.docker.internal:9000/webhook",
-    "consumerSubscriptionId": "quickstart-sub-1",
-    "filter": {
-      "resourcePoolId": "pool-default"
-    }
-  }' | jq
-```
-
-</details>
-
-**Response:**
-
-```json
-{
-  "subscriptionId": "550e8400-e29b-41d4-a716-446655440000",
-  "consumerSubscriptionId": "quickstart-sub-1",
-  "callback": "http://host.docker.internal:9000/webhook",
-  "filter": {
-    "resourcePoolId": "pool-default"
-  }
-}
-```
-
-Now any changes to resources in `pool-default` will trigger webhook notifications to your receiver.
-
-## Access Swagger UI
-
-The gateway includes interactive API documentation:
-
-```bash
-# Open Swagger UI in your browser
-open http://localhost:8080/docs/
-
-# Or download the OpenAPI spec
-curl http://localhost:8080/openapi.yaml > o2ims-api.yaml
-```
-
-**Swagger UI Features:**
-
-- Interactive API exploration
-- Try out endpoints directly
-- See request/response schemas
-- Generate example payloads
+- Dashboard with infrastructure overview
+- Tenant management
+- User and role management
+- Certificate management
+- Deployment manager configuration
+- Audit log viewer
 
 ## Check Logs
 
 ### View Gateway Logs
 
 ```bash
-# Follow gateway logs
-docker compose logs -f gateway
-
-# Last 100 lines
-docker compose logs --tail=100 gateway
+kubectl logs -n netweave deployment/netweave -f
 ```
 
-**Sample log output:**
-
-```json
-{
-  "level": "info",
-  "ts": "2026-01-12T21:00:00.000Z",
-  "caller": "server/server.go:123",
-  "msg": "Gateway started successfully",
-  "port": 8080,
-  "adapter": "kubernetes"
-}
-```
-
-### View Redis Logs
+### View All Pod Status
 
 ```bash
-# Redis logs
-docker compose logs -f redis
+kubectl get pods -n netweave
 ```
 
-### Monitor Redis State
+**Expected output:**
 
-```bash
-# Connect to Redis CLI
-docker exec -it netweave-redis redis-cli
-
-# List all subscriptions
-KEYS subscription:*
-
-# View subscription details
-GET subscription:550e8400-e29b-41d4-a716-446655440000
-
-# Exit Redis CLI
-exit
+```text
+NAME                                     READY   STATUS      AGE
+netweave-<hash>                          1/1     Running     2m
+netweave-admin-portal-<hash>             1/1     Running     2m
+netweave-keycloak-<hash>                 1/1     Running     2m
+netweave-keycloak-config-<hash>          0/1     Completed   1m
+netweave-keycloak-init-<hash>            0/1     Completed   1m
+netweave-postgresql-0                    1/1     Running     2m
+netweave-redis-master-0                  1/1     Running     2m
+vault-<hash>                             1/1     Running     3m
 ```
 
 ## Stopping and Cleaning Up
 
-### Stop Services
+### Teardown Everything
 
 ```bash
-# Stop containers (keeps data)
-docker compose stop
-
-# Start again
-docker compose start
+./build/netweave-cli setup teardown --force
 ```
 
-### Complete Cleanup
+This removes:
 
-```bash
-# Stop and remove containers + networks
-docker compose down
-
-# Remove volumes (clears all data)
-docker compose down -v
-
-# Remove images
-docker compose down --rmi all -v
-```
+- Helm release (all Kubernetes resources)
+- Vault deployment
+- PersistentVolumeClaims (all data)
+- The `netweave` namespace
 
 ## Troubleshooting
 
 ### Gateway Won't Start
 
-**Symptom:** `docker compose up` fails or gateway container restarts
-
-**Solution:**
-
 ```bash
+# Check pod events
+kubectl describe pod -n netweave -l app.kubernetes.io/component=gateway
+
 # Check logs
-docker compose logs gateway
-
-# Common issues:
-# 1. Port 8080 already in use
-lsof -i :8080  # Find process using port 8080
-docker compose up -d  # Retry
-
-# 2. Cannot connect to Docker Kubernetes
-kubectl cluster-info  # Verify Kubernetes is running
+kubectl logs -n netweave deployment/netweave --tail=50
 ```
 
-### Cannot Reach API
+**Common causes:**
 
-**Symptom:** `curl http://localhost:8080/health` fails
+- Redis not ready yet (wait for StatefulSet)
+- Keycloak not ready (init containers waiting)
+- TLS secrets not created (re-run `netweave-cli setup certs`)
 
-**Solution:**
+### Cannot Reach API via Ingress
 
 ```bash
-# Check gateway is running
-docker compose ps
+# Check ingress
+kubectl get ingress -n netweave
 
-# Check gateway health
-docker exec netweave-gateway wget -qO- http://localhost:8080/health
+# Verify /etc/hosts
+grep netweave /etc/hosts
 
-# Check port forwarding
-docker port netweave-gateway
-# Expected: 8080/tcp -> 0.0.0.0:8080
+# Test health directly (bypasses mTLS)
+curl -sk https://api.netweave.local/healthz
 ```
 
-### Empty Resource Pools
-
-**Symptom:** API returns empty arrays
-
-**Solution:**
+### mTLS Authentication Fails
 
 ```bash
-# Verify Kubernetes backend is accessible
-docker exec netweave-gateway kubectl get nodes
+# Verify client cert exists
+ls -la ~/.netweave/client.crt ~/.netweave/client.key
 
-# If kubectl fails, check kubeconfig mount
-docker inspect netweave-gateway | grep -A5 Mounts
-
-# Restart with correct kubeconfig
-docker compose down
-docker compose up -d
-```
-
-### Redis Connection Failed
-
-**Symptom:** Logs show "failed to connect to Redis"
-
-**Solution:**
-
-```bash
-# Check Redis is running
-docker compose ps redis
-
-# Test Redis connectivity
-docker exec netweave-redis redis-cli ping
-# Expected: PONG
-
-# Restart Redis
-docker compose restart redis
+# Re-issue certificates
+./build/netweave-cli setup certs --verbose
 ```
 
 ## Next Steps
 
 Now that you have netweave running locally, continue with:
 
-1. **[Installation Guide](installation.md)** - Production deployment options
-   - Kubernetes with Helm
-   - Kubernetes with Operator
+1. **[Installation Guide](installation.md)** — Detailed deployment options
+   - Manual Kubernetes setup
+   - Production deployment with Helm
    - Multi-cluster deployment
 
-2. **[First Steps Tutorial](first-steps.md)** - Learn O2-IMS concepts
+2. **[First Steps Tutorial](first-steps.md)** — Learn O2-IMS concepts
    - Understanding resource pools and resources
    - Creating and managing subscriptions
    - Working with webhooks
-   - Common API patterns
 
-3. **[Architecture Documentation](../architecture/README.md)** - Deep dive into design
+3. **[Architecture Documentation](../architecture/README.md)** — Deep dive into design
    - Multi-backend support
    - Subscription controller
    - Security architecture
-   - High availability
 
-4. **[API Mapping Guide](../api-mapping.md)** - O2-IMS to Kubernetes mappings
-   - Resource type mappings
-   - Filter translations
-   - Extension attributes
-
-## Configuration Customization
-
-### Override Default Config
-
-Create a custom configuration file:
-
-```yaml
-# config/custom.yaml
-server:
-  port: 9090  # Change port
-
-redis:
-  address: "localhost:6379"  # External Redis
-
-adapter:
-  backend: "kubernetes"
-  kubernetes:
-    kubeconfig: "/path/to/custom/kubeconfig"
-
-observability:
-  logging:
-    level: info  # Less verbose
-```
-
-Use it with Docker Compose:
-
-```bash
-# Override config file
-docker compose run -v $(pwd)/config/custom.yaml:/app/config/config.yaml \
-  gateway
-```
-
-### Enable TLS for Local Testing
-
-Generate self-signed certificates:
-
-```bash
-# Generate CA and certificates
-make dev-certs
-
-# Update docker-compose.yaml to mount certs
-# Update config/config.dev.yaml to enable TLS
-```
-
-See [Security Documentation](../security/README.md) for certificate management.
-
-## Development vs. Production
-
-This quickstart uses **development configuration** optimized for local testing:
-
-| Feature | Development | Production |
-|---------|-------------|------------|
-| TLS/mTLS | Disabled (HTTP) | Required (HTTPS) |
-| Authentication | None | Required |
-| Rate Limiting | Disabled | Enabled |
-| Logging | Debug, console | Info, JSON |
-| Redis Auth | None | Password + TLS |
-| CORS | Enabled | Restrictive |
-
-**For production deployment**, see:
-
-- [Installation Guide](installation.md) for production deployment
-- [Security Documentation](../security/README.md) for hardening
-- [Operations Guide](../operations.md) for monitoring
-
-## Support and Resources
-
-- **Documentation:** [docs/](../)
-- **API Reference:** Swagger UI at `http://localhost:8080/docs/`
-- **Issues:** [GitHub Issues](https://github.com/piwi3910/netweave/issues)
-- **Discussions:** [GitHub Discussions](https://github.com/piwi3910/netweave/discussions)
+4. **[API Mapping Guide](../api-mapping.md)** — O2-IMS to Kubernetes mappings
 
 ## Summary
 
 You've successfully:
 
-- ✅ Deployed netweave with Docker Compose
-- ✅ Made your first O2-IMS API call
-- ✅ Explored resource pools, resources, and types
-- ✅ Created a subscription for webhook notifications
-- ✅ Accessed interactive API documentation
-
-**Time to complete:** ~5 minutes
+- Deployed netweave on Kubernetes with `netweave-cli setup all`
+- Verified gateway health and API endpoints
+- Made O2-IMS API calls with mTLS authentication
+- Explored resource types, deployment managers, and subscriptions
+- Accessed the admin portal
 
 **What's running:**
 
-- netweave gateway on port 8080
-- Redis on port 6379
-- Connected to local Kubernetes cluster
+- netweave gateway with mTLS at `https://api.netweave.local`
+- Admin portal with OAuth2 at `https://admin.netweave.local`
+- Keycloak identity provider at `https://auth.netweave.local`
+- PostgreSQL, Redis, and Vault backing services
+- All connected to local Kubernetes cluster
 
 **Next:** Follow the [First Steps Tutorial](first-steps.md) to learn O2-IMS concepts and common API patterns.


### PR DESCRIPTION
## Summary

- Rewrote `quickstart.md` from Docker Compose to Kubernetes + `netweave-cli setup all` flow
- Updated `README.md` learning path and prerequisites for Kubernetes-first approach
- Fixed `installation.md` deployment name and replaced non-existent `api_versions` endpoint

### What changed

The getting-started documentation was describing a Docker Compose-based deployment that didn't match reality. The actual deployment uses:

1. `make build-cli && make docker-build` to build
2. `netweave-cli setup all --verbose` to deploy (Vault + certs + Helm + Keycloak)
3. mTLS client certs for O2-IMS API, OAuth2/OIDC for Admin Portal

All documented commands and expected outputs have been verified against a fresh deployment.

## Test plan

- [x] Fresh teardown + redeploy using `netweave-cli setup all` succeeded
- [x] `netweave-cli api health` returns healthy
- [x] `netweave-cli api resource-types list` returns data
- [x] `netweave-cli api deployment-managers list` returns data
- [x] `netweave-cli api subscriptions create` works
- [x] mTLS curl to `https://api.netweave.local` works
- [x] Keycloak OIDC discovery at `https://auth.netweave.local` works
- [x] Admin portal at `https://admin.netweave.local` loads correctly
- [x] All sample CLI outputs in docs match actual output

Resolves #386