### PR TITLE
[Fix] Add UUID generation to CLI user create command

### DIFF
--- a/internal/cli/cmd/users/users.go
+++ b/internal/cli/cmd/users/users.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/piwi3910/netweave/internal/auth"
@@ -168,10 +169,11 @@ func newCreateCmd() *cobra.Command {
 			}
 
 			user := &auth.TenantUser{
+				ID:         uuid.New().String(),
 				TenantID:   tenantID,
 				CommonName: certCN,
 				Email:      email,
-				Subject:    fmt.Sprintf("CN=%s", certCN),
+				Subject:    fmt.Sprintf("CN=%s,O=Netweave", certCN),
 				RoleID:     role.ID,
 				IsActive:   true,
 			}


### PR DESCRIPTION
## Summary

- Fixed CLI `users create` command failing with "invalid user ID" error
- Added `uuid.New().String()` to generate user ID before passing to Keycloak store
- Fixed Subject format from `CN=<name>` to `CN=<name>,O=Netweave` to match the setup command pattern

## Root Cause

The `newCreateCmd()` in `internal/cli/cmd/users/users.go` was constructing a `TenantUser` without setting the `ID` field. The Keycloak store's `CreateUser` validates that `user.ID != ""` and returns `auth.ErrInvalidUserID` when missing.

## Test Plan

- [x] Built CLI with fix and created 5 test users with different roles
- [x] Verified all users created successfully in Keycloak
- [x] Verified RBAC permissions work correctly for each role
- [x] `make lint` passes

Resolves #388