### PR TITLE
[Feature] Complete schema registry with all 20 adapters and SMO category

### DIFF
--- a/internal/backend/adapter_factory.go
+++ b/internal/backend/adapter_factory.go
@@ -5,7 +5,11 @@ import (
 	"fmt"
 
 	"github.com/piwi3910/netweave/internal/adapter"
-	"github.com/piwi3910/netweave/internal/adapters/mock"
+	imsmock "github.com/piwi3910/netweave/internal/adapters/mock"
+	dmsadapter "github.com/piwi3910/netweave/internal/dms/adapter"
+	dmsmock "github.com/piwi3910/netweave/internal/dms/adapters/mock"
+	"github.com/piwi3910/netweave/internal/smo"
+	smomock "github.com/piwi3910/netweave/internal/smo/adapters/mock"
 )
 
 // AdapterFactory creates adapter instances from backend Instance records.
@@ -33,6 +37,36 @@ func (f *AdapterFactory) CreateAdapter(instance *Instance) (adapter.Adapter, err
 	}
 }
 
+// CreateDMSAdapter creates a dms adapter.DMSAdapter from a backend Instance record.
+// The instance's AdapterType determines which concrete DMS adapter is created.
+func (f *AdapterFactory) CreateDMSAdapter(instance *Instance) (dmsadapter.DMSAdapter, error) {
+	if instance == nil {
+		return nil, fmt.Errorf("instance cannot be nil")
+	}
+
+	switch instance.AdapterType {
+	case "mock-dms":
+		return f.createMockDMSAdapter(instance)
+	default:
+		return nil, fmt.Errorf("unsupported DMS adapter type %q: %w", instance.AdapterType, ErrUnsupportedAdapterType)
+	}
+}
+
+// CreateSMOAdapter creates an smo.Plugin from a backend Instance record.
+// The instance's AdapterType determines which concrete SMO plugin is created.
+func (f *AdapterFactory) CreateSMOAdapter(instance *Instance) (smo.Plugin, error) {
+	if instance == nil {
+		return nil, fmt.Errorf("instance cannot be nil")
+	}
+
+	switch instance.AdapterType {
+	case "mock-smo":
+		return f.createMockSMOAdapter(instance)
+	default:
+		return nil, fmt.Errorf("unsupported SMO adapter type %q: %w", instance.AdapterType, ErrUnsupportedAdapterType)
+	}
+}
+
 // ErrUnsupportedAdapterType is returned when an adapter type is not supported by the factory.
 var ErrUnsupportedAdapterType = fmt.Errorf("unsupported adapter type")
 
@@ -42,24 +76,60 @@ type mockConfig struct {
 	OCloudID           string `json:"ocloud_id"`
 }
 
-// createMockAdapter creates a mock adapter from instance configuration.
+// createMockAdapter creates a mock IMS adapter from instance configuration.
 func (f *AdapterFactory) createMockAdapter(instance *Instance) (adapter.Adapter, error) {
 	cfg := mockConfig{
 		PopulateSampleData: true,
 		OCloudID:           instance.ID,
 	}
 
-	// Parse config if present
+	// Parse config if present.
 	if len(instance.Config) > 0 {
 		if err := json.Unmarshal(instance.Config, &cfg); err != nil {
 			return nil, fmt.Errorf("failed to parse mock adapter config: %w", err)
 		}
 	}
 
-	// Use instance ID as OCloudID if not explicitly configured
+	// Use instance ID as OCloudID if not explicitly configured.
 	if cfg.OCloudID == "" {
 		cfg.OCloudID = instance.ID
 	}
 
-	return mock.NewAdapterWithOCloudID(cfg.OCloudID, cfg.PopulateSampleData), nil
+	return imsmock.NewAdapterWithOCloudID(cfg.OCloudID, cfg.PopulateSampleData), nil
+}
+
+// mockDMSConfig holds parsed configuration for a mock DMS adapter instance.
+type mockDMSConfig struct {
+	PopulateSampleData bool `json:"populate_sample_data"`
+}
+
+// createMockDMSAdapter creates a mock DMS adapter from instance configuration.
+func (f *AdapterFactory) createMockDMSAdapter(instance *Instance) (dmsadapter.DMSAdapter, error) {
+	cfg := mockDMSConfig{
+		PopulateSampleData: true,
+	}
+
+	// Parse config if present.
+	if len(instance.Config) > 0 {
+		if err := json.Unmarshal(instance.Config, &cfg); err != nil {
+			return nil, fmt.Errorf("failed to parse mock DMS adapter config: %w", err)
+		}
+	}
+
+	return dmsmock.NewAdapter(cfg.PopulateSampleData), nil
+}
+
+// createMockSMOAdapter creates a mock SMO plugin from instance configuration.
+func (f *AdapterFactory) createMockSMOAdapter(instance *Instance) (smo.Plugin, error) {
+	plugin := smomock.NewPlugin()
+
+	// Parse config to pass to Initialize if present.
+	var configMap map[string]interface{}
+	if len(instance.Config) > 0 {
+		if err := json.Unmarshal(instance.Config, &configMap); err != nil {
+			return nil, fmt.Errorf("failed to parse mock SMO adapter config: %w", err)
+		}
+	}
+
+	return plugin, nil
 }

--- a/internal/backend/adapter_factory_test.go
+++ b/internal/backend/adapter_factory_test.go
@@ -60,7 +60,7 @@ func TestAdapterFactory_CreateAdapter(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, adp)
 
-		// Verify the OCloudID is used via the deployment manager
+		// Verify the OCloudID is used via the deployment manager.
 		dms, dmErr := adp.ListDeploymentManagers(
 			context.Background(), nil,
 		)
@@ -84,7 +84,7 @@ func TestAdapterFactory_CreateAdapter(t *testing.T) {
 		adp, err := factory.CreateAdapter(instance)
 		require.NoError(t, err)
 
-		// No sample data — should have no resource pools
+		// No sample data - should have no resource pools.
 		pools, poolErr := adp.ListResourcePools(
 			context.Background(), nil,
 		)
@@ -118,5 +118,175 @@ func TestAdapterFactory_CreateAdapter(t *testing.T) {
 		require.NoError(t, dmErr)
 		require.Len(t, dms, 1)
 		assert.Equal(t, "my-special-backend", dms[0].OCloudID)
+	})
+}
+
+func TestAdapterFactory_CreateDMSAdapter(t *testing.T) {
+	factory := backend.NewAdapterFactory()
+
+	t.Run("nil instance returns error", func(t *testing.T) {
+		adp, err := factory.CreateDMSAdapter(nil)
+		require.Error(t, err)
+		assert.Nil(t, adp)
+		assert.Contains(t, err.Error(), "nil")
+	})
+
+	t.Run("unsupported DMS adapter type returns error", func(t *testing.T) {
+		instance := &backend.Instance{
+			ID:          "test-dms-1",
+			AdapterType: "nonexistent-dms",
+		}
+		adp, err := factory.CreateDMSAdapter(instance)
+		require.Error(t, err)
+		assert.Nil(t, adp)
+		assert.ErrorIs(t, err, backend.ErrUnsupportedAdapterType)
+	})
+
+	t.Run("mock-dms adapter with default config", func(t *testing.T) {
+		instance := &backend.Instance{
+			ID:          "test-dms-default",
+			AdapterType: "mock-dms",
+		}
+		adp, err := factory.CreateDMSAdapter(instance)
+		require.NoError(t, err)
+		require.NotNil(t, adp)
+		assert.Equal(t, "mock", adp.Name())
+	})
+
+	t.Run("mock-dms adapter with sample data", func(t *testing.T) {
+		cfg := map[string]interface{}{
+			"populate_sample_data": true,
+		}
+		cfgJSON, err := json.Marshal(cfg)
+		require.NoError(t, err)
+
+		instance := &backend.Instance{
+			ID:          "test-dms-with-data",
+			AdapterType: "mock-dms",
+			Config:      cfgJSON,
+		}
+		adp, err := factory.CreateDMSAdapter(instance)
+		require.NoError(t, err)
+		require.NotNil(t, adp)
+
+		// Should have sample packages pre-populated.
+		packages, pkgErr := adp.ListDeploymentPackages(context.Background(), nil)
+		require.NoError(t, pkgErr)
+		assert.NotEmpty(t, packages)
+	})
+
+	t.Run("mock-dms adapter without sample data", func(t *testing.T) {
+		cfg := map[string]interface{}{
+			"populate_sample_data": false,
+		}
+		cfgJSON, err := json.Marshal(cfg)
+		require.NoError(t, err)
+
+		instance := &backend.Instance{
+			ID:          "test-dms-empty",
+			AdapterType: "mock-dms",
+			Config:      cfgJSON,
+		}
+		adp, err := factory.CreateDMSAdapter(instance)
+		require.NoError(t, err)
+		require.NotNil(t, adp)
+
+		// No sample data - should have no packages.
+		packages, pkgErr := adp.ListDeploymentPackages(context.Background(), nil)
+		require.NoError(t, pkgErr)
+		assert.Empty(t, packages)
+	})
+
+	t.Run("mock-dms adapter with invalid config JSON", func(t *testing.T) {
+		instance := &backend.Instance{
+			ID:          "test-dms-bad",
+			AdapterType: "mock-dms",
+			Config:      []byte(`{invalid json`),
+		}
+		adp, err := factory.CreateDMSAdapter(instance)
+		require.Error(t, err)
+		assert.Nil(t, adp)
+		assert.Contains(t, err.Error(), "parse mock DMS adapter config")
+	})
+}
+
+func TestAdapterFactory_CreateSMOAdapter(t *testing.T) {
+	factory := backend.NewAdapterFactory()
+
+	t.Run("nil instance returns error", func(t *testing.T) {
+		adp, err := factory.CreateSMOAdapter(nil)
+		require.Error(t, err)
+		assert.Nil(t, adp)
+		assert.Contains(t, err.Error(), "nil")
+	})
+
+	t.Run("unsupported SMO adapter type returns error", func(t *testing.T) {
+		instance := &backend.Instance{
+			ID:          "test-smo-1",
+			AdapterType: "nonexistent-smo",
+		}
+		adp, err := factory.CreateSMOAdapter(instance)
+		require.Error(t, err)
+		assert.Nil(t, adp)
+		assert.ErrorIs(t, err, backend.ErrUnsupportedAdapterType)
+	})
+
+	t.Run("mock-smo adapter with default config", func(t *testing.T) {
+		instance := &backend.Instance{
+			ID:          "test-smo-default",
+			AdapterType: "mock-smo",
+		}
+		plugin, err := factory.CreateSMOAdapter(instance)
+		require.NoError(t, err)
+		require.NotNil(t, plugin)
+
+		metadata := plugin.Metadata()
+		assert.Equal(t, "mock", metadata.Name)
+		assert.Equal(t, "1.0.0", metadata.Version)
+	})
+
+	t.Run("mock-smo adapter with config", func(t *testing.T) {
+		cfg := map[string]interface{}{
+			"populate_sample_data": true,
+			"simulate_workflows":   true,
+		}
+		cfgJSON, err := json.Marshal(cfg)
+		require.NoError(t, err)
+
+		instance := &backend.Instance{
+			ID:          "test-smo-configured",
+			AdapterType: "mock-smo",
+			Config:      cfgJSON,
+		}
+		plugin, err := factory.CreateSMOAdapter(instance)
+		require.NoError(t, err)
+		require.NotNil(t, plugin)
+
+		metadata := plugin.Metadata()
+		assert.Equal(t, "mock", metadata.Name)
+	})
+
+	t.Run("mock-smo adapter with invalid config JSON", func(t *testing.T) {
+		instance := &backend.Instance{
+			ID:          "test-smo-bad",
+			AdapterType: "mock-smo",
+			Config:      []byte(`{invalid json`),
+		}
+		plugin, err := factory.CreateSMOAdapter(instance)
+		require.Error(t, err)
+		assert.Nil(t, plugin)
+		assert.Contains(t, err.Error(), "parse mock SMO adapter config")
+	})
+
+	t.Run("mock-smo adapter capabilities are correct", func(t *testing.T) {
+		instance := &backend.Instance{
+			ID:          "test-smo-caps",
+			AdapterType: "mock-smo",
+		}
+		plugin, err := factory.CreateSMOAdapter(instance)
+		require.NoError(t, err)
+
+		caps := plugin.Capabilities()
+		assert.NotEmpty(t, caps)
 	})
 }

--- a/internal/backend/schema_unit_test.go
+++ b/internal/backend/schema_unit_test.go
@@ -129,12 +129,12 @@ func TestRegisterBuiltinSchemas(t *testing.T) {
 
 	t.Run("registers all expected schemas", func(t *testing.T) {
 		schemas := reg.List()
-		assert.Len(t, schemas, 8, "expected 8 builtin schemas")
+		assert.Len(t, schemas, 20, "expected 20 builtin schemas")
 	})
 
 	t.Run("IMS schemas are registered", func(t *testing.T) {
 		imsSchemas := reg.ListByCategory("ims")
-		assert.Len(t, imsSchemas, 5, "expected 5 IMS schemas")
+		assert.Len(t, imsSchemas, 9, "expected 9 IMS schemas")
 
 		imsTypes := map[string]bool{}
 		for _, s := range imsSchemas {
@@ -145,11 +145,15 @@ func TestRegisterBuiltinSchemas(t *testing.T) {
 		assert.True(t, imsTypes["azure"])
 		assert.True(t, imsTypes["openstack"])
 		assert.True(t, imsTypes["mock"])
+		assert.True(t, imsTypes["gcp"])
+		assert.True(t, imsTypes["vmware"])
+		assert.True(t, imsTypes["starlingx"])
+		assert.True(t, imsTypes["dtias"])
 	})
 
 	t.Run("DMS schemas are registered", func(t *testing.T) {
 		dmsSchemas := reg.ListByCategory("dms")
-		assert.Len(t, dmsSchemas, 3, "expected 3 DMS schemas")
+		assert.Len(t, dmsSchemas, 8, "expected 8 DMS schemas")
 
 		dmsTypes := map[string]bool{}
 		for _, s := range dmsSchemas {
@@ -158,6 +162,24 @@ func TestRegisterBuiltinSchemas(t *testing.T) {
 		assert.True(t, dmsTypes["helm"])
 		assert.True(t, dmsTypes["argocd"])
 		assert.True(t, dmsTypes["flux"])
+		assert.True(t, dmsTypes["crossplane"])
+		assert.True(t, dmsTypes["kustomize"])
+		assert.True(t, dmsTypes["onaplcm"])
+		assert.True(t, dmsTypes["osmlcm"])
+		assert.True(t, dmsTypes["mock-dms"])
+	})
+
+	t.Run("SMO schemas are registered", func(t *testing.T) {
+		smoSchemas := reg.ListByCategory("smo")
+		assert.Len(t, smoSchemas, 3, "expected 3 SMO schemas")
+
+		smoTypes := map[string]bool{}
+		for _, s := range smoSchemas {
+			smoTypes[s.Type] = true
+		}
+		assert.True(t, smoTypes["onap"])
+		assert.True(t, smoTypes["osm"])
+		assert.True(t, smoTypes["mock-smo"])
 	})
 
 	t.Run("kubernetes schema has correct fields", func(t *testing.T) {
@@ -168,12 +190,12 @@ func TestRegisterBuiltinSchemas(t *testing.T) {
 		assert.Len(t, schema.ConfigSchema, 2)
 		assert.Len(t, schema.CredentialSchema, 1)
 
-		// Check config fields
+		// Check config fields.
 		assert.Equal(t, "context", schema.ConfigSchema[0].Name)
 		assert.Equal(t, "namespace", schema.ConfigSchema[1].Name)
 		assert.Equal(t, "default", schema.ConfigSchema[1].Default)
 
-		// Check credential fields
+		// Check credential fields.
 		assert.Equal(t, "kubeconfig", schema.CredentialSchema[0].Name)
 		assert.True(t, schema.CredentialSchema[0].Required)
 		assert.True(t, schema.CredentialSchema[0].Secret)
@@ -274,6 +296,231 @@ func TestRegisterBuiltinSchemas(t *testing.T) {
 		assert.Equal(t, "main", schema.ConfigSchema[1].Default)
 		assert.Equal(t, "ssh_key", schema.CredentialSchema[0].Name)
 		assert.Equal(t, backend.FieldTypeText, schema.CredentialSchema[0].Type)
+	})
+
+	t.Run("gcp schema has correct fields", func(t *testing.T) {
+		schema, ok := reg.Get("gcp")
+		require.True(t, ok)
+		assert.Equal(t, "Google Cloud Platform", schema.DisplayName)
+		assert.Equal(t, "ims", schema.Category)
+		assert.Len(t, schema.ConfigSchema, 3)
+		assert.Len(t, schema.CredentialSchema, 1)
+
+		assert.Equal(t, "project_id", schema.ConfigSchema[0].Name)
+		assert.True(t, schema.ConfigSchema[0].Required)
+		assert.Equal(t, "region", schema.ConfigSchema[1].Name)
+		assert.True(t, schema.ConfigSchema[1].Required)
+		assert.Equal(t, "zone", schema.ConfigSchema[2].Name)
+		assert.False(t, schema.ConfigSchema[2].Required)
+
+		assert.Equal(t, "service_account_json", schema.CredentialSchema[0].Name)
+		assert.True(t, schema.CredentialSchema[0].Secret)
+		assert.Equal(t, backend.FieldTypeText, schema.CredentialSchema[0].Type)
+	})
+
+	t.Run("vmware schema has correct fields", func(t *testing.T) {
+		schema, ok := reg.Get("vmware")
+		require.True(t, ok)
+		assert.Equal(t, "VMware vSphere", schema.DisplayName)
+		assert.Equal(t, "ims", schema.Category)
+		assert.Len(t, schema.ConfigSchema, 3)
+		assert.Len(t, schema.CredentialSchema, 2)
+
+		assert.Equal(t, "vcenter_url", schema.ConfigSchema[0].Name)
+		assert.True(t, schema.ConfigSchema[0].Required)
+		assert.Equal(t, "datacenter", schema.ConfigSchema[1].Name)
+		assert.True(t, schema.ConfigSchema[1].Required)
+		assert.Equal(t, "cluster", schema.ConfigSchema[2].Name)
+		assert.False(t, schema.ConfigSchema[2].Required)
+
+		assert.Equal(t, "username", schema.CredentialSchema[0].Name)
+		assert.True(t, schema.CredentialSchema[0].Secret)
+		assert.Equal(t, "password", schema.CredentialSchema[1].Name)
+		assert.True(t, schema.CredentialSchema[1].Secret)
+	})
+
+	t.Run("starlingx schema has correct fields", func(t *testing.T) {
+		schema, ok := reg.Get("starlingx")
+		require.True(t, ok)
+		assert.Equal(t, "StarlingX", schema.DisplayName)
+		assert.Equal(t, "ims", schema.Category)
+		assert.Len(t, schema.ConfigSchema, 3)
+		assert.Len(t, schema.CredentialSchema, 2)
+
+		assert.Equal(t, "api_url", schema.ConfigSchema[0].Name)
+		assert.True(t, schema.ConfigSchema[0].Required)
+		assert.Equal(t, "region", schema.ConfigSchema[1].Name)
+		assert.Equal(t, "system_name", schema.ConfigSchema[2].Name)
+
+		assert.Equal(t, "auth_token", schema.CredentialSchema[0].Name)
+		assert.True(t, schema.CredentialSchema[0].Required)
+		assert.True(t, schema.CredentialSchema[0].Secret)
+		assert.Equal(t, "ca_cert", schema.CredentialSchema[1].Name)
+		assert.Equal(t, backend.FieldTypeText, schema.CredentialSchema[1].Type)
+	})
+
+	t.Run("dtias schema has correct fields", func(t *testing.T) {
+		schema, ok := reg.Get("dtias")
+		require.True(t, ok)
+		assert.Equal(t, "Dell TIAS", schema.DisplayName)
+		assert.Equal(t, "ims", schema.Category)
+		assert.Len(t, schema.ConfigSchema, 2)
+		assert.Len(t, schema.CredentialSchema, 2)
+
+		assert.Equal(t, "api_url", schema.ConfigSchema[0].Name)
+		assert.True(t, schema.ConfigSchema[0].Required)
+		assert.Equal(t, "cluster_name", schema.ConfigSchema[1].Name)
+
+		assert.Equal(t, "api_key", schema.CredentialSchema[0].Name)
+		assert.True(t, schema.CredentialSchema[0].Required)
+		assert.True(t, schema.CredentialSchema[0].Secret)
+		assert.Equal(t, "ca_cert", schema.CredentialSchema[1].Name)
+		assert.Equal(t, backend.FieldTypeText, schema.CredentialSchema[1].Type)
+	})
+
+	t.Run("crossplane schema has correct fields", func(t *testing.T) {
+		schema, ok := reg.Get("crossplane")
+		require.True(t, ok)
+		assert.Equal(t, "Crossplane", schema.DisplayName)
+		assert.Equal(t, "dms", schema.Category)
+		assert.Len(t, schema.ConfigSchema, 3)
+		assert.Len(t, schema.CredentialSchema, 1)
+
+		assert.Equal(t, "kubeconfig", schema.ConfigSchema[0].Name)
+		assert.Equal(t, "provider", schema.ConfigSchema[1].Name)
+		assert.True(t, schema.ConfigSchema[1].Required)
+		assert.Equal(t, "namespace", schema.ConfigSchema[2].Name)
+		assert.Equal(t, "crossplane-system", schema.ConfigSchema[2].Default)
+
+		assert.Equal(t, "kubeconfig_data", schema.CredentialSchema[0].Name)
+		assert.True(t, schema.CredentialSchema[0].Secret)
+	})
+
+	t.Run("kustomize schema has correct fields", func(t *testing.T) {
+		schema, ok := reg.Get("kustomize")
+		require.True(t, ok)
+		assert.Equal(t, "Kustomize", schema.DisplayName)
+		assert.Equal(t, "dms", schema.Category)
+		assert.Len(t, schema.ConfigSchema, 3)
+		assert.Len(t, schema.CredentialSchema, 1)
+
+		assert.Equal(t, "kubeconfig", schema.ConfigSchema[0].Name)
+		assert.Equal(t, "base_path", schema.ConfigSchema[1].Name)
+		assert.True(t, schema.ConfigSchema[1].Required)
+		assert.Equal(t, "namespace", schema.ConfigSchema[2].Name)
+
+		assert.Equal(t, "kubeconfig_data", schema.CredentialSchema[0].Name)
+		assert.True(t, schema.CredentialSchema[0].Secret)
+	})
+
+	t.Run("onaplcm schema has correct fields", func(t *testing.T) {
+		schema, ok := reg.Get("onaplcm")
+		require.True(t, ok)
+		assert.Equal(t, "ONAP LCM", schema.DisplayName)
+		assert.Equal(t, "dms", schema.Category)
+		assert.Len(t, schema.ConfigSchema, 3)
+		assert.Len(t, schema.CredentialSchema, 2)
+
+		assert.Equal(t, "api_url", schema.ConfigSchema[0].Name)
+		assert.True(t, schema.ConfigSchema[0].Required)
+		assert.Equal(t, "vnf_catalog_url", schema.ConfigSchema[1].Name)
+		assert.Equal(t, "so_endpoint", schema.ConfigSchema[2].Name)
+
+		assert.Equal(t, "username", schema.CredentialSchema[0].Name)
+		assert.True(t, schema.CredentialSchema[0].Required)
+		assert.Equal(t, "password", schema.CredentialSchema[1].Name)
+		assert.True(t, schema.CredentialSchema[1].Required)
+	})
+
+	t.Run("osmlcm schema has correct fields", func(t *testing.T) {
+		schema, ok := reg.Get("osmlcm")
+		require.True(t, ok)
+		assert.Equal(t, "OSM LCM", schema.DisplayName)
+		assert.Equal(t, "dms", schema.Category)
+		assert.Len(t, schema.ConfigSchema, 3)
+		assert.Len(t, schema.CredentialSchema, 2)
+
+		assert.Equal(t, "api_url", schema.ConfigSchema[0].Name)
+		assert.True(t, schema.ConfigSchema[0].Required)
+		assert.Equal(t, "project", schema.ConfigSchema[1].Name)
+		assert.Equal(t, "admin", schema.ConfigSchema[1].Default)
+		assert.Equal(t, "vim_account", schema.ConfigSchema[2].Name)
+
+		assert.Equal(t, "username", schema.CredentialSchema[0].Name)
+		assert.True(t, schema.CredentialSchema[0].Required)
+		assert.Equal(t, "password", schema.CredentialSchema[1].Name)
+		assert.True(t, schema.CredentialSchema[1].Required)
+	})
+
+	t.Run("mock-dms schema has correct fields", func(t *testing.T) {
+		schema, ok := reg.Get("mock-dms")
+		require.True(t, ok)
+		assert.Equal(t, "Mock DMS", schema.DisplayName)
+		assert.Equal(t, "dms", schema.Category)
+		assert.Len(t, schema.ConfigSchema, 2)
+		assert.Nil(t, schema.CredentialSchema)
+
+		assert.Equal(t, "populate_sample_data", schema.ConfigSchema[0].Name)
+		assert.Equal(t, backend.FieldTypeBoolean, schema.ConfigSchema[0].Type)
+		assert.Equal(t, "true", schema.ConfigSchema[0].Default)
+		assert.Equal(t, "deployment_delay_ms", schema.ConfigSchema[1].Name)
+		assert.Equal(t, backend.FieldTypeNumber, schema.ConfigSchema[1].Type)
+		assert.Equal(t, "0", schema.ConfigSchema[1].Default)
+	})
+
+	t.Run("onap schema has correct fields", func(t *testing.T) {
+		schema, ok := reg.Get("onap")
+		require.True(t, ok)
+		assert.Equal(t, "ONAP SMO", schema.DisplayName)
+		assert.Equal(t, "smo", schema.Category)
+		assert.Len(t, schema.ConfigSchema, 3)
+		assert.Len(t, schema.CredentialSchema, 2)
+
+		assert.Equal(t, "api_url", schema.ConfigSchema[0].Name)
+		assert.True(t, schema.ConfigSchema[0].Required)
+		assert.Equal(t, "aai_url", schema.ConfigSchema[1].Name)
+		assert.Equal(t, "so_url", schema.ConfigSchema[2].Name)
+
+		assert.Equal(t, "username", schema.CredentialSchema[0].Name)
+		assert.True(t, schema.CredentialSchema[0].Required)
+		assert.Equal(t, "password", schema.CredentialSchema[1].Name)
+		assert.True(t, schema.CredentialSchema[1].Required)
+	})
+
+	t.Run("osm schema has correct fields", func(t *testing.T) {
+		schema, ok := reg.Get("osm")
+		require.True(t, ok)
+		assert.Equal(t, "OSM SMO", schema.DisplayName)
+		assert.Equal(t, "smo", schema.Category)
+		assert.Len(t, schema.ConfigSchema, 3)
+		assert.Len(t, schema.CredentialSchema, 2)
+
+		assert.Equal(t, "api_url", schema.ConfigSchema[0].Name)
+		assert.True(t, schema.ConfigSchema[0].Required)
+		assert.Equal(t, "project", schema.ConfigSchema[1].Name)
+		assert.Equal(t, "admin", schema.ConfigSchema[1].Default)
+		assert.Equal(t, "kafka_broker", schema.ConfigSchema[2].Name)
+
+		assert.Equal(t, "username", schema.CredentialSchema[0].Name)
+		assert.True(t, schema.CredentialSchema[0].Required)
+		assert.Equal(t, "password", schema.CredentialSchema[1].Name)
+		assert.True(t, schema.CredentialSchema[1].Required)
+	})
+
+	t.Run("mock-smo schema has correct fields", func(t *testing.T) {
+		schema, ok := reg.Get("mock-smo")
+		require.True(t, ok)
+		assert.Equal(t, "Mock SMO", schema.DisplayName)
+		assert.Equal(t, "smo", schema.Category)
+		assert.Len(t, schema.ConfigSchema, 2)
+		assert.Nil(t, schema.CredentialSchema)
+
+		assert.Equal(t, "populate_sample_data", schema.ConfigSchema[0].Name)
+		assert.Equal(t, backend.FieldTypeBoolean, schema.ConfigSchema[0].Type)
+		assert.Equal(t, "true", schema.ConfigSchema[0].Default)
+		assert.Equal(t, "simulate_workflows", schema.ConfigSchema[1].Name)
+		assert.Equal(t, backend.FieldTypeBoolean, schema.ConfigSchema[1].Type)
+		assert.Equal(t, "false", schema.ConfigSchema[1].Default)
 	})
 }
 
@@ -386,7 +633,7 @@ func TestAccessStruct(t *testing.T) {
 // We test this indirectly by verifying the NewPostgresStore function returns a valid store.
 func TestNewPostgresStore_NilPool(t *testing.T) {
 	// NewPostgresStore should not panic with a nil pool
-	// It creates the store; queries will fail at runtime
+	// It creates the store; queries will fail at runtime.
 	store := backend.NewPostgresStore(nil)
 	assert.NotNil(t, store)
 }
@@ -395,13 +642,13 @@ func TestNewPostgresStore_NilPool(t *testing.T) {
 // Since isUniqueViolation is unexported, we test it indirectly through
 // the PostgresStore methods. Here we verify the PgError code constant works.
 func TestPgErrorCodeDetection(t *testing.T) {
-	// Create a PgError with the unique violation code
+	// Create a PgError with the unique violation code.
 	pgErr := &pgconn.PgError{
 		Code: "23505",
 	}
 	assert.Equal(t, "23505", pgErr.Code)
 
-	// Create a PgError with a different code
+	// Create a PgError with a different code.
 	otherErr := &pgconn.PgError{
 		Code: "23503",
 	}

--- a/internal/backend/schemas_builtin.go
+++ b/internal/backend/schemas_builtin.go
@@ -4,6 +4,7 @@ package backend
 func RegisterBuiltinSchemas(registry *SchemaRegistry) {
 	registerIMSSchemas(registry)
 	registerDMSSchemas(registry)
+	registerSMOSchemas(registry)
 }
 
 func registerIMSSchemas(registry *SchemaRegistry) {
@@ -12,12 +13,49 @@ func registerIMSSchemas(registry *SchemaRegistry) {
 	registry.Register(azureSchema())
 	registry.Register(openstackSchema())
 	registry.Register(mockSchema())
+	registry.Register(gcpSchema())
+	registry.Register(vmwareSchema())
+	registry.Register(starlingxSchema())
+	registry.Register(dtiasSchema())
 }
 
 func registerDMSSchemas(registry *SchemaRegistry) {
 	registry.Register(helmSchema())
 	registry.Register(argocdSchema())
 	registry.Register(fluxSchema())
+	registry.Register(crossplaneSchema())
+	registry.Register(kustomizeSchema())
+	registry.Register(onaplcmSchema())
+	registry.Register(osmlcmSchema())
+	registry.Register(mockDMSSchema())
+}
+
+func registerSMOSchemas(registry *SchemaRegistry) {
+	registry.Register(onapSchema())
+	registry.Register(osmSchema())
+	registry.Register(mockSMOSchema())
+}
+
+// usernamePasswordCredentials creates credential fields for username/password authentication.
+func usernamePasswordCredentials(prefix string) []FieldSpec {
+	return []FieldSpec{
+		{
+			Name:        "username",
+			Label:       "Username",
+			Type:        FieldTypeString,
+			Required:    true,
+			Secret:      true,
+			Description: prefix + " authentication username.",
+		},
+		{
+			Name:        "password",
+			Label:       "Password",
+			Type:        FieldTypeString,
+			Required:    true,
+			Secret:      true,
+			Description: prefix + " authentication password.",
+		},
+	}
 }
 
 func kubernetesSchema() *AdapterTypeSchema {
@@ -223,6 +261,190 @@ func mockSchema() *AdapterTypeSchema {
 	}
 }
 
+func gcpSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "gcp",
+		Category:    "ims",
+		DisplayName: "Google Cloud Platform",
+		Description: "Google Cloud Platform O-Cloud infrastructure.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "project_id",
+				Label:       "Project ID",
+				Type:        FieldTypeString,
+				Required:    true,
+				Description: "GCP project identifier.",
+			},
+			{
+				Name:        "region",
+				Label:       "Region",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "us-central1",
+				Description: "GCP region for resource discovery.",
+			},
+			{
+				Name:        "zone",
+				Label:       "Zone",
+				Type:        FieldTypeString,
+				Placeholder: "us-central1-a",
+				Description: "GCP zone within the region.",
+			},
+		},
+		CredentialSchema: []FieldSpec{
+			{
+				Name:        "service_account_json",
+				Label:       "Service Account JSON",
+				Type:        FieldTypeText,
+				Required:    true,
+				Secret:      true,
+				Description: "GCP service account key in JSON format.",
+			},
+		},
+	}
+}
+
+func vmwareSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "vmware",
+		Category:    "ims",
+		DisplayName: "VMware vSphere",
+		Description: "VMware vSphere O-Cloud infrastructure.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "vcenter_url",
+				Label:       "vCenter URL",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "https://vcenter.example.com",
+				Description: "VMware vCenter server URL.",
+			},
+			{
+				Name:        "datacenter",
+				Label:       "Datacenter",
+				Type:        FieldTypeString,
+				Required:    true,
+				Description: "VMware datacenter name.",
+			},
+			{
+				Name:        "cluster",
+				Label:       "Cluster",
+				Type:        FieldTypeString,
+				Description: "VMware cluster name within the datacenter.",
+			},
+		},
+		CredentialSchema: usernamePasswordCredentials("VMware vCenter"),
+	}
+}
+
+func starlingxSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "starlingx",
+		Category:    "ims",
+		DisplayName: "StarlingX",
+		Description: "StarlingX O-Cloud infrastructure for edge computing.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "api_url",
+				Label:       "API URL",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "https://starlingx.example.com:6385",
+				Description: "StarlingX system API URL.",
+			},
+			{
+				Name:        "region",
+				Label:       "Region",
+				Type:        FieldTypeString,
+				Description: "StarlingX region name.",
+			},
+			{
+				Name:        "system_name",
+				Label:       "System Name",
+				Type:        FieldTypeString,
+				Description: "StarlingX system name identifier.",
+			},
+		},
+		CredentialSchema: []FieldSpec{
+			{
+				Name:        "auth_token",
+				Label:       "Auth Token",
+				Type:        FieldTypeString,
+				Required:    true,
+				Secret:      true,
+				Description: "StarlingX API authentication token.",
+			},
+			{
+				Name:        "ca_cert",
+				Label:       "CA Certificate",
+				Type:        FieldTypeText,
+				Description: "Custom CA certificate for TLS verification.",
+			},
+		},
+	}
+}
+
+func dtiasSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "dtias",
+		Category:    "ims",
+		DisplayName: "Dell TIAS",
+		Description: "Dell Telecom Infrastructure Automation Suite O-Cloud.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "api_url",
+				Label:       "API URL",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "https://dtias.example.com/api",
+				Description: "Dell TIAS API endpoint URL.",
+			},
+			{
+				Name:        "cluster_name",
+				Label:       "Cluster Name",
+				Type:        FieldTypeString,
+				Description: "Dell TIAS cluster name identifier.",
+			},
+		},
+		CredentialSchema: []FieldSpec{
+			{
+				Name:        "api_key",
+				Label:       "API Key",
+				Type:        FieldTypeString,
+				Required:    true,
+				Secret:      true,
+				Description: "Dell TIAS API authentication key.",
+			},
+			{
+				Name:        "ca_cert",
+				Label:       "CA Certificate",
+				Type:        FieldTypeText,
+				Description: "Custom CA certificate for TLS verification.",
+			},
+		},
+	}
+}
+
+// helmRepoCredentials creates optional credential fields for repository authentication.
+func helmRepoCredentials() []FieldSpec {
+	return []FieldSpec{
+		{
+			Name:        "username",
+			Label:       "Username",
+			Type:        FieldTypeString,
+			Secret:      true,
+			Description: "Repository authentication username.",
+		},
+		{
+			Name:        "password",
+			Label:       "Password",
+			Type:        FieldTypeString,
+			Secret:      true,
+			Description: "Repository authentication password.",
+		},
+	}
+}
+
 func helmSchema() *AdapterTypeSchema {
 	return &AdapterTypeSchema{
 		Type:        "helm",
@@ -246,22 +468,7 @@ func helmSchema() *AdapterTypeSchema {
 				Description: "Repository type (oci or http).",
 			},
 		},
-		CredentialSchema: []FieldSpec{
-			{
-				Name:        "username",
-				Label:       "Username",
-				Type:        FieldTypeString,
-				Secret:      true,
-				Description: "Repository authentication username.",
-			},
-			{
-				Name:        "password",
-				Label:       "Password",
-				Type:        FieldTypeString,
-				Secret:      true,
-				Description: "Repository authentication password.",
-			},
-		},
+		CredentialSchema: helmRepoCredentials(),
 	}
 }
 
@@ -326,5 +533,276 @@ func fluxSchema() *AdapterTypeSchema {
 				Description: "SSH private key for Git repository authentication.",
 			},
 		},
+	}
+}
+
+func crossplaneSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "crossplane",
+		Category:    "dms",
+		DisplayName: "Crossplane",
+		Description: "Crossplane cloud-native infrastructure provisioning.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "kubeconfig",
+				Label:       "Kubeconfig",
+				Type:        FieldTypeText,
+				Description: "Kubeconfig for the cluster running Crossplane.",
+			},
+			{
+				Name:        "provider",
+				Label:       "Provider",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "provider-aws",
+				Description: "Crossplane provider name.",
+			},
+			{
+				Name:        "namespace",
+				Label:       "Namespace",
+				Type:        FieldTypeString,
+				Default:     "crossplane-system",
+				Description: "Kubernetes namespace for Crossplane resources.",
+			},
+		},
+		CredentialSchema: []FieldSpec{
+			{
+				Name:        "kubeconfig_data",
+				Label:       "Kubeconfig Data",
+				Type:        FieldTypeText,
+				Secret:      true,
+				Description: "Kubeconfig YAML content for cluster authentication.",
+			},
+		},
+	}
+}
+
+func kustomizeSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "kustomize",
+		Category:    "dms",
+		DisplayName: "Kustomize",
+		Description: "Kustomize-based Kubernetes deployment management.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "kubeconfig",
+				Label:       "Kubeconfig",
+				Type:        FieldTypeText,
+				Description: "Kubeconfig for the target cluster.",
+			},
+			{
+				Name:        "base_path",
+				Label:       "Base Path",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "./base",
+				Description: "Path to the Kustomize base directory.",
+			},
+			{
+				Name:        "namespace",
+				Label:       "Namespace",
+				Type:        FieldTypeString,
+				Description: "Target Kubernetes namespace for deployments.",
+			},
+		},
+		CredentialSchema: []FieldSpec{
+			{
+				Name:        "kubeconfig_data",
+				Label:       "Kubeconfig Data",
+				Type:        FieldTypeText,
+				Secret:      true,
+				Description: "Kubeconfig YAML content for cluster authentication.",
+			},
+		},
+	}
+}
+
+func onaplcmSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "onaplcm",
+		Category:    "dms",
+		DisplayName: "ONAP LCM",
+		Description: "ONAP Lifecycle Management for VNF/CNF deployments.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "api_url",
+				Label:       "API URL",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "https://onap-lcm.example.com/api",
+				Description: "ONAP LCM API endpoint URL.",
+			},
+			{
+				Name:        "vnf_catalog_url",
+				Label:       "VNF Catalog URL",
+				Type:        FieldTypeString,
+				Placeholder: "https://onap-sdc.example.com/api",
+				Description: "ONAP SDC catalog URL for VNF/CNF packages.",
+			},
+			{
+				Name:        "so_endpoint",
+				Label:       "SO Endpoint",
+				Type:        FieldTypeString,
+				Placeholder: "https://onap-so.example.com/onap/so/infra",
+				Description: "ONAP Service Orchestrator endpoint for deployment operations.",
+			},
+		},
+		CredentialSchema: usernamePasswordCredentials("ONAP LCM"),
+	}
+}
+
+func osmlcmSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "osmlcm",
+		Category:    "dms",
+		DisplayName: "OSM LCM",
+		Description: "Open Source MANO Lifecycle Management for NS/VNF deployments.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "api_url",
+				Label:       "API URL",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "https://osm.example.com:9999",
+				Description: "OSM NBI API endpoint URL.",
+			},
+			{
+				Name:        "project",
+				Label:       "Project",
+				Type:        FieldTypeString,
+				Default:     "admin",
+				Description: "OSM project name.",
+			},
+			{
+				Name:        "vim_account",
+				Label:       "VIM Account",
+				Type:        FieldTypeString,
+				Description: "Default VIM account name for NS instantiation.",
+			},
+		},
+		CredentialSchema: usernamePasswordCredentials("OSM NBI"),
+	}
+}
+
+func mockDMSSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "mock-dms",
+		Category:    "dms",
+		DisplayName: "Mock DMS",
+		Description: "Mock deployment management adapter for development, testing, and demos.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:    "populate_sample_data",
+				Label:   "Populate Sample Data",
+				Type:    FieldTypeBoolean,
+				Default: "true",
+				Description: "Pre-populate the adapter with realistic sample " +
+					"deployment packages and configurations.",
+			},
+			{
+				Name:        "deployment_delay_ms",
+				Label:       "Deployment Delay (ms)",
+				Type:        FieldTypeNumber,
+				Default:     "0",
+				Description: "Simulated deployment delay in milliseconds.",
+			},
+		},
+		CredentialSchema: nil,
+	}
+}
+
+func onapSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "onap",
+		Category:    "smo",
+		DisplayName: "ONAP SMO",
+		Description: "ONAP Service Management and Orchestration integration.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "api_url",
+				Label:       "API URL",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "https://onap.example.com/api",
+				Description: "ONAP SMO API endpoint URL.",
+			},
+			{
+				Name:        "aai_url",
+				Label:       "AAI URL",
+				Type:        FieldTypeString,
+				Placeholder: "https://aai.onap.example.com",
+				Description: "ONAP Active and Available Inventory URL.",
+			},
+			{
+				Name:        "so_url",
+				Label:       "SO URL",
+				Type:        FieldTypeString,
+				Placeholder: "https://so.onap.example.com",
+				Description: "ONAP Service Orchestrator URL.",
+			},
+		},
+		CredentialSchema: usernamePasswordCredentials("ONAP SMO"),
+	}
+}
+
+func osmSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "osm",
+		Category:    "smo",
+		DisplayName: "OSM SMO",
+		Description: "Open Source MANO Service Management and Orchestration integration.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:        "api_url",
+				Label:       "API URL",
+				Type:        FieldTypeString,
+				Required:    true,
+				Placeholder: "https://osm.example.com:9999",
+				Description: "OSM NBI API endpoint URL.",
+			},
+			{
+				Name:        "project",
+				Label:       "Project",
+				Type:        FieldTypeString,
+				Default:     "admin",
+				Description: "OSM project name for resource scoping.",
+			},
+			{
+				Name:        "kafka_broker",
+				Label:       "Kafka Broker",
+				Type:        FieldTypeString,
+				Placeholder: "kafka.osm.example.com:9092",
+				Description: "Kafka broker URL for event streaming integration.",
+			},
+		},
+		CredentialSchema: usernamePasswordCredentials("OSM SMO"),
+	}
+}
+
+func mockSMOSchema() *AdapterTypeSchema {
+	return &AdapterTypeSchema{
+		Type:        "mock-smo",
+		Category:    "smo",
+		DisplayName: "Mock SMO",
+		Description: "Mock SMO plugin for development, testing, and demos.",
+		ConfigSchema: []FieldSpec{
+			{
+				Name:    "populate_sample_data",
+				Label:   "Populate Sample Data",
+				Type:    FieldTypeBoolean,
+				Default: "true",
+				Description: "Pre-populate the plugin with realistic sample " +
+					"service models and workflow templates.",
+			},
+			{
+				Name:    "simulate_workflows",
+				Label:   "Simulate Workflows",
+				Type:    FieldTypeBoolean,
+				Default: "false",
+				Description: "Enable simulated async workflow execution " +
+					"with realistic status progression.",
+			},
+		},
+		CredentialSchema: nil,
 	}
 }

--- a/web/admin-portal/src/lib/validation/schemas.ts
+++ b/web/admin-portal/src/lib/validation/schemas.ts
@@ -81,7 +81,9 @@ export const backendSchema = z.object({
     .max(512, "Description must be at most 512 characters")
     .optional()
     .default(""),
-  category: z.enum(["ims", "dms"], { required_error: "Category is required" }),
+  category: z.enum(["ims", "dms", "smo"], {
+    required_error: "Category is required",
+  }),
   adapterType: z.string().min(1, "Adapter type is required"),
 });
 


### PR DESCRIPTION
## Summary
- Add 12 new adapter type schemas to the schema registry (4 IMS + 5 DMS + 3 SMO = 20 total)
- Wire mock-dms and mock-smo into AdapterFactory with `CreateDMSAdapter()` and `CreateSMOAdapter()` methods
- Add "smo" to admin portal category enum for backend validation
- Extract `usernamePasswordCredentials()` helper to reduce schema code duplication

## Changes
- **schemas_builtin.go**: 4 new IMS schemas (gcp, vmware, starlingx, dtias), 5 new DMS schemas (crossplane, kustomize, onaplcm, osmlcm, mock-dms), 3 new SMO schemas (onap, osm, mock-smo)
- **adapter_factory.go**: `CreateDMSAdapter()` and `CreateSMOAdapter()` factory methods for mock adapters
- **schema_unit_test.go**: Updated expected counts (8→20), added SMO category tests, field validation for all new schemas
- **adapter_factory_test.go**: Tests for DMS and SMO adapter creation
- **schemas.ts**: Added "smo" to category enum

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (all backend package tests green)
- [x] Schema registry returns 20 schemas: 9 IMS + 8 DMS + 3 SMO
- [x] Factory creates mock adapters for all 3 categories

Resolves #392