### PR TITLE
[Feature] Dynamic per-tenant adapter resolution for all API frontends

### DIFF
--- a/internal/dms/handlers/handlers.go
+++ b/internal/dms/handlers/handlers.go
@@ -47,6 +47,22 @@ func NewHandler(reg *registry.Registry, store storage.Store, logger *zap.Logger)
 	}
 }
 
+// ContextKeyDMSRegistry is the gin context key used to store a per-request DMS registry override.
+// When set by server middleware, it takes priority over the handler's static registry.
+const ContextKeyDMSRegistry = "resolved_dms_registry"
+
+// getActiveRegistry returns the DMS registry for the current request.
+// It checks gin context for a per-request override (set by dynamic routing middleware),
+// falling back to the handler's static registry.
+func (h *Handler) getActiveRegistry(c *gin.Context) *registry.Registry {
+	if reg, exists := c.Get(ContextKeyDMSRegistry); exists {
+		if r, ok := reg.(*registry.Registry); ok && r != nil {
+			return r
+		}
+	}
+	return h.registry
+}
+
 // getAdapterFromQuery retrieves a DMS adapter using the adapter query parameter.
 // Returns adapter.DMSAdapter interface (factory/lookup pattern).
 // Note: Returning interface is idiomatic for factory/lookup methods.
@@ -54,10 +70,12 @@ func (h *Handler) getAdapterFromQuery(c *gin.Context) (adapter.DMSAdapter, error
 	adapterName := c.Query("adapter")
 	var adp adapter.DMSAdapter
 
+	reg := h.getActiveRegistry(c)
+
 	if adapterName != "" {
-		h.registry.Mu.RLock()
-		adp = h.registry.Plugins[adapterName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		adp = reg.Plugins[adapterName]
+		reg.Mu.RUnlock()
 
 		if adp == nil {
 			return nil, fmt.Errorf("adapter not found: %s", adapterName)
@@ -66,11 +84,11 @@ func (h *Handler) getAdapterFromQuery(c *gin.Context) (adapter.DMSAdapter, error
 	}
 
 	// Use default adapter
-	h.registry.Mu.RLock()
-	if h.registry.DefaultPlugin != "" {
-		adp = h.registry.Plugins[h.registry.DefaultPlugin]
+	reg.Mu.RLock()
+	if reg.DefaultPlugin != "" {
+		adp = reg.Plugins[reg.DefaultPlugin]
 	}
-	h.registry.Mu.RUnlock()
+	reg.Mu.RUnlock()
 
 	if adp == nil {
 		return nil, fmt.Errorf("no default DMS adapter configured")
@@ -927,7 +945,8 @@ func (h *Handler) DeleteDMSSubscription(c *gin.Context) {
 func (h *Handler) GetDeploymentLifecycleInfo(c *gin.Context) {
 	h.logger.Info("getting deployment lifecycle info")
 
-	adapters := h.registry.ListMetadata()
+	reg := h.getActiveRegistry(c)
+	adapters := reg.ListMetadata()
 
 	adapterInfo := make([]gin.H, 0, len(adapters))
 	for _, meta := range adapters {

--- a/internal/graphql/resolvers/resolver.go
+++ b/internal/graphql/resolvers/resolver.go
@@ -2,6 +2,8 @@
 package resolvers
 
 import (
+	"context"
+
 	"github.com/piwi3910/netweave/internal/adapter"
 	dmshandlers "github.com/piwi3910/netweave/internal/dms/handlers"
 	"github.com/piwi3910/netweave/internal/storage"
@@ -13,8 +15,12 @@ import (
 // It serves as dependency injection for your app, add any dependencies you require
 // here.
 
+// contextKeyIMSAdapter is the context key for storing the resolved IMS adapter per-request.
+type contextKeyIMSAdapter struct{}
+
 // Resolver provides GraphQL resolver implementations.
 // It holds dependencies needed to resolve GraphQL queries, mutations, and subscriptions.
+// The adapter field serves as a fallback when no per-request adapter is available in context.
 type Resolver struct {
 	adapter    adapter.Adapter
 	store      storage.Store
@@ -26,15 +32,31 @@ type Resolver struct {
 // Note: SMO handler is not included to avoid import cycles.
 // SMO resolvers will be implemented in a future iteration.
 func NewResolver(
-	adapter adapter.Adapter,
+	adp adapter.Adapter,
 	store storage.Store,
 	dmsHandler *dmshandlers.Handler,
 	logger *zap.Logger,
 ) *Resolver {
 	return &Resolver{
-		adapter:    adapter,
+		adapter:    adp,
 		store:      store,
 		dmsHandler: dmsHandler,
 		logger:     logger,
 	}
+}
+
+// getActiveAdapter returns the IMS adapter for the current request.
+// It checks the context for a per-request override (set by dynamic routing middleware),
+// falling back to the resolver's static adapter.
+func (r *Resolver) getActiveAdapter(ctx context.Context) adapter.Adapter {
+	if adp, ok := ctx.Value(contextKeyIMSAdapter{}).(adapter.Adapter); ok && adp != nil {
+		return adp
+	}
+	return r.adapter
+}
+
+// WithAdapter returns a new context with the given adapter stored for GraphQL resolution.
+// This is called by the server's GraphQL middleware to inject the per-request adapter.
+func WithAdapter(ctx context.Context, adp adapter.Adapter) context.Context {
+	return context.WithValue(ctx, contextKeyIMSAdapter{}, adp)
 }

--- a/internal/graphql/resolvers/schema.resolvers.go
+++ b/internal/graphql/resolvers/schema.resolvers.go
@@ -211,7 +211,7 @@ func (r *mutationResolver) DeleteTenant(_ context.Context, _ string) (bool, erro
 
 // DeploymentManager is the resolver for the deploymentManager field.
 func (r *queryResolver) DeploymentManager(ctx context.Context, id string) (*adapter.DeploymentManager, error) {
-	dm, err := r.adapter.GetDeploymentManager(ctx, id)
+	dm, err := r.getActiveAdapter(ctx).GetDeploymentManager(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deployment manager: %w", err)
 	}
@@ -222,7 +222,7 @@ func (r *queryResolver) DeploymentManager(ctx context.Context, id string) (*adap
 func (r *queryResolver) DeploymentManagers(ctx context.Context) ([]*adapter.DeploymentManager, error) {
 	// For now, return a single deployment manager representing this gateway
 	// In multi-cluster setups, this could list multiple managers
-	dm, err := r.adapter.GetDeploymentManager(ctx, "default")
+	dm, err := r.getActiveAdapter(ctx).GetDeploymentManager(ctx, "default")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get default deployment manager: %w", err)
 	}
@@ -231,7 +231,7 @@ func (r *queryResolver) DeploymentManagers(ctx context.Context) ([]*adapter.Depl
 
 // ResourcePool is the resolver for the resourcePool field.
 func (r *queryResolver) ResourcePool(ctx context.Context, id string) (*adapter.ResourcePool, error) {
-	pool, err := r.adapter.GetResourcePool(ctx, id)
+	pool, err := r.getActiveAdapter(ctx).GetResourcePool(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resource pool: %w", err)
 	}
@@ -272,7 +272,7 @@ func (r *queryResolver) ResourcePools(
 	}
 
 	// Query resource pools
-	pools, err := r.adapter.ListResourcePools(ctx, adapterFilter)
+	pools, err := r.getActiveAdapter(ctx).ListResourcePools(ctx, adapterFilter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list resource pools: %w", err)
 	}
@@ -311,7 +311,7 @@ func (r *queryResolver) ResourcePools(
 
 // Resource is the resolver for the resource field.
 func (r *queryResolver) Resource(ctx context.Context, id string) (*adapter.Resource, error) {
-	resource, err := r.adapter.GetResource(ctx, id)
+	resource, err := r.getActiveAdapter(ctx).GetResource(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resource: %w", err)
 	}
@@ -356,7 +356,7 @@ func (r *queryResolver) Resources(
 	}
 
 	// Query resources
-	resources, err := r.adapter.ListResources(ctx, adapterFilter)
+	resources, err := r.getActiveAdapter(ctx).ListResources(ctx, adapterFilter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list resources: %w", err)
 	}
@@ -395,7 +395,7 @@ func (r *queryResolver) Resources(
 
 // ResourceType is the resolver for the resourceType field.
 func (r *queryResolver) ResourceType(ctx context.Context, id string) (*adapter.ResourceType, error) {
-	rt, err := r.adapter.GetResourceType(ctx, id)
+	rt, err := r.getActiveAdapter(ctx).GetResourceType(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resource type: %w", err)
 	}
@@ -429,7 +429,7 @@ func (r *queryResolver) ResourceTypes(
 	}
 
 	// Query resource types
-	resourceTypes, err := r.adapter.ListResourceTypes(ctx, adapterFilter)
+	resourceTypes, err := r.getActiveAdapter(ctx).ListResourceTypes(ctx, adapterFilter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list resource types: %w", err)
 	}

--- a/internal/handlers/tmforum_handler.go
+++ b/internal/handlers/tmforum_handler.go
@@ -43,6 +43,40 @@ func NewTMForumHandler(
 	}
 }
 
+// Context keys for per-request dynamic routing.
+// These must match the keys used by server middleware.
+const (
+	// contextKeyIMSAdapter stores the resolved IMS adapter for the current request.
+	contextKeyIMSAdapter = "resolved_ims_adapter"
+
+	// contextKeyDMSRegistry stores the resolved DMS registry for the current request.
+	contextKeyDMSRegistry = "resolved_dms_registry"
+)
+
+// getActiveAdapter returns the IMS adapter for the current request.
+// It checks gin context for a per-request override (set by dynamic routing middleware),
+// falling back to the handler's static adapter.
+func (h *TMForumHandler) getActiveAdapter(c *gin.Context) imsadapter.Adapter {
+	if adp, exists := c.Get(contextKeyIMSAdapter); exists {
+		if a, ok := adp.(imsadapter.Adapter); ok && a != nil {
+			return a
+		}
+	}
+	return h.adapter
+}
+
+// getActiveDMSRegistry returns the DMS registry for the current request.
+// It checks gin context for a per-request override (set by dynamic routing middleware),
+// falling back to the handler's static DMS registry.
+func (h *TMForumHandler) getActiveDMSRegistry(c *gin.Context) *registry.Registry {
+	if reg, exists := c.Get(contextKeyDMSRegistry); exists {
+		if r, ok := reg.(*registry.Registry); ok && r != nil {
+			return r
+		}
+	}
+	return h.dmsRegistry
+}
+
 // ========================================
 // TMF639 - Resource Inventory Management
 // ========================================
@@ -51,6 +85,7 @@ func NewTMForumHandler(
 // GET /tmf-api/resourceInventoryManagement/v4/resource.
 func (h *TMForumHandler) ListTMF639Resources(c *gin.Context) {
 	ctx := c.Request.Context()
+	adp := h.getActiveAdapter(c)
 
 	// Get query parameters
 	category := c.Query("resourceSpecification.category")
@@ -61,7 +96,7 @@ func (h *TMForumHandler) ListTMF639Resources(c *gin.Context) {
 
 	// If category is categoryResourcePool or empty, include resource pools
 	if category == "" || category == categoryResourcePool {
-		pools, err := h.adapter.ListResourcePools(ctx, nil)
+		pools, err := adp.ListResourcePools(ctx, nil)
 		if err != nil {
 			h.logger.Error("failed to list resource pools",
 				zap.Error(err),
@@ -81,7 +116,7 @@ func (h *TMForumHandler) ListTMF639Resources(c *gin.Context) {
 
 	// If category is not categoryResourcePool, include individual resources
 	if category != categoryResourcePool {
-		resourceList, err := h.adapter.ListResources(ctx, nil)
+		resourceList, err := adp.ListResources(ctx, nil)
 		if err != nil {
 			h.logger.Error("failed to list resources",
 				zap.Error(err),
@@ -106,12 +141,13 @@ func (h *TMForumHandler) ListTMF639Resources(c *gin.Context) {
 // GET /tmf-api/resourceInventoryManagement/v4/resource/:id.
 func (h *TMForumHandler) GetTMF639Resource(c *gin.Context) {
 	ctx := c.Request.Context()
+	adp := h.getActiveAdapter(c)
 	resourceID := c.Param("id")
 
 	baseURL := buildBaseURL(c.Request.URL.Scheme, c.Request.Host)
 
 	// Try to get as resource pool first
-	pool, err := h.adapter.GetResourcePool(ctx, resourceID)
+	pool, err := adp.GetResourcePool(ctx, resourceID)
 	if err == nil {
 		tmfResource := TransformResourcePoolToTMF639Resource(pool, baseURL)
 		c.JSON(http.StatusOK, tmfResource)
@@ -119,7 +155,7 @@ func (h *TMForumHandler) GetTMF639Resource(c *gin.Context) {
 	}
 
 	// Try to get as individual resource
-	resource, err := h.adapter.GetResource(ctx, resourceID)
+	resource, err := adp.GetResource(ctx, resourceID)
 	if err != nil {
 		if errors.Is(err, imsadapter.ErrResourceNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{
@@ -148,6 +184,7 @@ func (h *TMForumHandler) GetTMF639Resource(c *gin.Context) {
 // POST /tmf-api/resourceInventoryManagement/v4/resource.
 func (h *TMForumHandler) CreateTMF639Resource(c *gin.Context) {
 	ctx := c.Request.Context()
+	adp := h.getActiveAdapter(c)
 
 	var createReq models.TMF639ResourceCreate
 	if err := c.ShouldBindJSON(&createReq); err != nil {
@@ -184,7 +221,7 @@ func (h *TMForumHandler) CreateTMF639Resource(c *gin.Context) {
 		// Create as resource pool
 		pool := TransformTMF639ResourceToResourcePool(tmfResource)
 
-		createdPool, err := h.adapter.CreateResourcePool(ctx, pool)
+		createdPool, err := adp.CreateResourcePool(ctx, pool)
 		if err != nil {
 			h.logger.Error("failed to create resource pool",
 				zap.Error(err),
@@ -202,7 +239,7 @@ func (h *TMForumHandler) CreateTMF639Resource(c *gin.Context) {
 		// Create as individual resource
 		resource := TransformTMF639ResourceToResource(tmfResource)
 
-		createdResource, err := h.adapter.CreateResource(ctx, resource)
+		createdResource, err := adp.CreateResource(ctx, resource)
 		if err != nil {
 			h.logger.Error("failed to create resource",
 				zap.Error(err),
@@ -223,6 +260,7 @@ func (h *TMForumHandler) CreateTMF639Resource(c *gin.Context) {
 // PATCH /tmf-api/resourceInventoryManagement/v4/resource/:id.
 func (h *TMForumHandler) UpdateTMF639Resource(c *gin.Context) {
 	ctx := c.Request.Context()
+	adp := h.getActiveAdapter(c)
 	resourceID := c.Param("id")
 
 	var updateReq models.TMF639ResourceUpdate
@@ -237,11 +275,11 @@ func (h *TMForumHandler) UpdateTMF639Resource(c *gin.Context) {
 	baseURL := buildBaseURL(c.Request.URL.Scheme, c.Request.Host)
 
 	// Try to update as resource pool first
-	pool, err := h.adapter.GetResourcePool(ctx, resourceID)
+	pool, err := adp.GetResourcePool(ctx, resourceID)
 	if err == nil {
 		applyTMF639ResourceUpdate(pool, &updateReq)
 
-		updatedPool, err := h.adapter.UpdateResourcePool(ctx, resourceID, pool)
+		updatedPool, err := adp.UpdateResourcePool(ctx, resourceID, pool)
 		if err != nil {
 			h.logger.Error("failed to update resource pool",
 				zap.String("categoryResourcePoolId", resourceID),
@@ -270,17 +308,18 @@ func (h *TMForumHandler) UpdateTMF639Resource(c *gin.Context) {
 // DELETE /tmf-api/resourceInventoryManagement/v4/resource/:id.
 func (h *TMForumHandler) DeleteTMF639Resource(c *gin.Context) {
 	ctx := c.Request.Context()
+	adp := h.getActiveAdapter(c)
 	resourceID := c.Param("id")
 
 	// Try to delete as resource pool first
-	err := h.adapter.DeleteResourcePool(ctx, resourceID)
+	err := adp.DeleteResourcePool(ctx, resourceID)
 	if err == nil {
 		c.Status(http.StatusNoContent)
 		return
 	}
 
 	// Try to delete as individual resource
-	err = h.adapter.DeleteResource(ctx, resourceID)
+	err = adp.DeleteResource(ctx, resourceID)
 	if err != nil {
 		if errors.Is(err, imsadapter.ErrResourceNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{
@@ -312,11 +351,12 @@ func (h *TMForumHandler) DeleteTMF639Resource(c *gin.Context) {
 // GET /tmf-api/serviceInventoryManagement/v4/service.
 func (h *TMForumHandler) ListTMF638Services(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 
 	baseURL := buildBaseURL(c.Request.URL.Scheme, c.Request.Host)
 
 	// List all deployments from all adapters
-	adapters := h.dmsRegistry.List()
+	adapters := dmsReg.List()
 	var services []*models.TMF638Service
 
 	for _, dmsAdapter := range adapters {
@@ -342,12 +382,13 @@ func (h *TMForumHandler) ListTMF638Services(c *gin.Context) {
 // GET /tmf-api/serviceInventoryManagement/v4/service/:id.
 func (h *TMForumHandler) GetTMF638Service(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 	serviceID := c.Param("id")
 
 	baseURL := buildBaseURL(c.Request.URL.Scheme, c.Request.Host)
 
 	// Try to find deployment across all adapters
-	adapters := h.dmsRegistry.List()
+	adapters := dmsReg.List()
 	for _, dmsAdapter := range adapters {
 		dep, err := dmsAdapter.GetDeployment(ctx, serviceID)
 		if err == nil {
@@ -367,6 +408,7 @@ func (h *TMForumHandler) GetTMF638Service(c *gin.Context) {
 // POST /tmf-api/serviceInventoryManagement/v4/service.
 func (h *TMForumHandler) CreateTMF638Service(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 
 	var createReq models.TMF638ServiceCreate
 	if err := c.ShouldBindJSON(&createReq); err != nil {
@@ -383,7 +425,7 @@ func (h *TMForumHandler) CreateTMF638Service(c *gin.Context) {
 	deploymentReq := TransformTMF638ServiceToDeployment(&createReq)
 
 	// Create deployment using default DMS adapter
-	dmsAdapter := h.dmsRegistry.GetDefault()
+	dmsAdapter := dmsReg.GetDefault()
 	if dmsAdapter == nil {
 		h.logger.Error("no default DMS adapter available")
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -413,6 +455,7 @@ func (h *TMForumHandler) CreateTMF638Service(c *gin.Context) {
 // PATCH /tmf-api/serviceInventoryManagement/v4/service/:id.
 func (h *TMForumHandler) UpdateTMF638Service(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 	serviceID := c.Param("id")
 
 	var updateReq models.TMF638ServiceUpdate
@@ -427,7 +470,7 @@ func (h *TMForumHandler) UpdateTMF638Service(c *gin.Context) {
 	baseURL := buildBaseURL(c.Request.URL.Scheme, c.Request.Host)
 
 	// Find deployment across all adapters
-	adapters := h.dmsRegistry.List()
+	adapters := dmsReg.List()
 	for _, dmsAdapter := range adapters {
 		dep, err := dmsAdapter.GetDeployment(ctx, serviceID)
 		if err != nil {
@@ -455,10 +498,11 @@ func (h *TMForumHandler) UpdateTMF638Service(c *gin.Context) {
 // DELETE /tmf-api/serviceInventoryManagement/v4/service/:id.
 func (h *TMForumHandler) DeleteTMF638Service(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 	serviceID := c.Param("id")
 
 	// Try to delete deployment from all adapters
-	adapters := h.dmsRegistry.List()
+	adapters := dmsReg.List()
 	for _, dmsAdapter := range adapters {
 		err := dmsAdapter.DeleteDeployment(ctx, serviceID)
 		if err == nil {
@@ -481,6 +525,7 @@ func (h *TMForumHandler) DeleteTMF638Service(c *gin.Context) {
 // GET /tmf-api/serviceOrdering/v4/serviceOrder.
 func (h *TMForumHandler) ListTMF641ServiceOrders(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 
 	baseURL := buildBaseURL(c.Request.URL.Scheme, c.Request.Host)
 
@@ -489,7 +534,7 @@ func (h *TMForumHandler) ListTMF641ServiceOrders(c *gin.Context) {
 	externalID := c.Query("externalId")
 
 	// List all deployments and convert to service orders
-	adapters := h.dmsRegistry.List()
+	adapters := dmsReg.List()
 	var orders []*models.TMF641ServiceOrder
 
 	for _, dmsAdapter := range adapters {
@@ -524,12 +569,13 @@ func (h *TMForumHandler) ListTMF641ServiceOrders(c *gin.Context) {
 // GET /tmf-api/serviceOrdering/v4/serviceOrder/:id.
 func (h *TMForumHandler) GetTMF641ServiceOrder(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 	orderID := c.Param("id")
 
 	baseURL := buildBaseURL(c.Request.URL.Scheme, c.Request.Host)
 
 	// Try to find deployment across all adapters
-	adapters := h.dmsRegistry.List()
+	adapters := dmsReg.List()
 	for _, dmsAdapter := range adapters {
 		dep, err := dmsAdapter.GetDeployment(ctx, orderID)
 		if err == nil {
@@ -549,6 +595,7 @@ func (h *TMForumHandler) GetTMF641ServiceOrder(c *gin.Context) {
 // POST /tmf-api/serviceOrdering/v4/serviceOrder.
 func (h *TMForumHandler) CreateTMF641ServiceOrder(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 
 	var createReq models.TMF641ServiceOrderCreate
 	if err := c.ShouldBindJSON(&createReq); err != nil {
@@ -571,7 +618,7 @@ func (h *TMForumHandler) CreateTMF641ServiceOrder(c *gin.Context) {
 	}
 
 	// Get default DMS adapter
-	dmsAdapter := h.dmsRegistry.GetDefault()
+	dmsAdapter := dmsReg.GetDefault()
 	if dmsAdapter == nil {
 		h.logger.Error("no default DMS adapter available")
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -607,6 +654,7 @@ func (h *TMForumHandler) CreateTMF641ServiceOrder(c *gin.Context) {
 // PATCH /tmf-api/serviceOrdering/v4/serviceOrder/:id.
 func (h *TMForumHandler) UpdateTMF641ServiceOrder(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 	orderID := c.Param("id")
 
 	var updateReq models.TMF641ServiceOrderUpdate
@@ -621,7 +669,7 @@ func (h *TMForumHandler) UpdateTMF641ServiceOrder(c *gin.Context) {
 	baseURL := buildBaseURL(c.Request.URL.Scheme, c.Request.Host)
 
 	// Find deployment across all adapters
-	adapters := h.dmsRegistry.List()
+	adapters := dmsReg.List()
 	for _, dmsAdapter := range adapters {
 		dep, err := dmsAdapter.GetDeployment(ctx, orderID)
 		if err != nil {
@@ -647,10 +695,11 @@ func (h *TMForumHandler) UpdateTMF641ServiceOrder(c *gin.Context) {
 // DELETE /tmf-api/serviceOrdering/v4/serviceOrder/:id.
 func (h *TMForumHandler) DeleteTMF641ServiceOrder(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 	orderID := c.Param("id")
 
 	// Try to delete deployment from all adapters
-	adapters := h.dmsRegistry.List()
+	adapters := dmsReg.List()
 	for _, dmsAdapter := range adapters {
 		err := dmsAdapter.DeleteDeployment(ctx, orderID)
 		if err == nil {
@@ -714,6 +763,7 @@ func (h *TMForumHandler) CreateTMF688Event(c *gin.Context) {
 // POST /tmf-api/eventManagement/v4/hub.
 func (h *TMForumHandler) RegisterTMF688Hub(c *gin.Context) {
 	ctx := c.Request.Context()
+	adp := h.getActiveAdapter(c)
 
 	var hubReq models.TMF688HubCreate
 	if err := c.ShouldBindJSON(&hubReq); err != nil {
@@ -744,7 +794,7 @@ func (h *TMForumHandler) RegisterTMF688Hub(c *gin.Context) {
 		Filter:                 filter,
 	}
 
-	createdSub, err := h.adapter.CreateSubscription(ctx, subscription)
+	createdSub, err := adp.CreateSubscription(ctx, subscription)
 	if err != nil {
 		h.logger.Error("failed to create O2-IMS subscription",
 			zap.String("callback", hubReq.Callback),
@@ -775,7 +825,7 @@ func (h *TMForumHandler) RegisterTMF688Hub(c *gin.Context) {
 			zap.Error(err))
 
 		// Cleanup: Delete O2-IMS subscription
-		if delErr := h.adapter.DeleteSubscription(ctx, createdSub.SubscriptionID); delErr != nil {
+		if delErr := adp.DeleteSubscription(ctx, createdSub.SubscriptionID); delErr != nil {
 			h.logger.Warn("failed to cleanup O2-IMS subscription after hub store error",
 				zap.String("subscriptionId", createdSub.SubscriptionID),
 				zap.Error(delErr))
@@ -809,6 +859,7 @@ func (h *TMForumHandler) RegisterTMF688Hub(c *gin.Context) {
 // DELETE /tmf-api/eventManagement/v4/hub/:id.
 func (h *TMForumHandler) UnregisterTMF688Hub(c *gin.Context) {
 	ctx := c.Request.Context()
+	adp := h.getActiveAdapter(c)
 	hubID := c.Param("id")
 
 	// Get hub registration
@@ -832,7 +883,7 @@ func (h *TMForumHandler) UnregisterTMF688Hub(c *gin.Context) {
 	}
 
 	// Delete O2-IMS subscription
-	if err := h.adapter.DeleteSubscription(ctx, registration.SubscriptionID); err != nil {
+	if err := adp.DeleteSubscription(ctx, registration.SubscriptionID); err != nil {
 		h.logger.Warn("failed to delete O2-IMS subscription",
 			zap.String("hubId", hubID),
 			zap.String("subscriptionId", registration.SubscriptionID),
@@ -940,11 +991,12 @@ func (h *TMForumHandler) ClearTMF642Alarm(c *gin.Context) {
 // GET /tmf-api/serviceActivation/v4/serviceActivation.
 func (h *TMForumHandler) ListTMF640ServiceActivations(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 
 	baseURL := buildBaseURL(c.Request.URL.Scheme, c.Request.Host)
 
 	// Map deployments to service activations
-	adapters := h.dmsRegistry.List()
+	adapters := dmsReg.List()
 	var activations []*models.TMF640ServiceActivation
 
 	for _, dmsAdapter := range adapters {
@@ -970,12 +1022,13 @@ func (h *TMForumHandler) ListTMF640ServiceActivations(c *gin.Context) {
 // GET /tmf-api/serviceActivation/v4/serviceActivation/:id.
 func (h *TMForumHandler) GetTMF640ServiceActivation(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 	activationID := c.Param("id")
 
 	baseURL := buildBaseURL(c.Request.URL.Scheme, c.Request.Host)
 
 	// Find deployment across all adapters
-	adapters := h.dmsRegistry.List()
+	adapters := dmsReg.List()
 	for _, dmsAdapter := range adapters {
 		dep, err := dmsAdapter.GetDeployment(ctx, activationID)
 		if err == nil {
@@ -1008,11 +1061,12 @@ func (h *TMForumHandler) CreateTMF640ServiceActivation(c *gin.Context) {
 // GET /tmf-api/productCatalog/v4/productOffering.
 func (h *TMForumHandler) ListTMF620ProductOfferings(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 
 	baseURL := buildBaseURL(c.Request.URL.Scheme, c.Request.Host)
 
 	// Map DMS packages to product offerings
-	adapters := h.dmsRegistry.List()
+	adapters := dmsReg.List()
 	var offerings []*models.TMF620ProductOffering
 
 	for _, dmsAdapter := range adapters {
@@ -1038,12 +1092,13 @@ func (h *TMForumHandler) ListTMF620ProductOfferings(c *gin.Context) {
 // GET /tmf-api/productCatalog/v4/productOffering/:id.
 func (h *TMForumHandler) GetTMF620ProductOffering(c *gin.Context) {
 	ctx := c.Request.Context()
+	dmsReg := h.getActiveDMSRegistry(c)
 	offeringID := c.Param("id")
 
 	baseURL := buildBaseURL(c.Request.URL.Scheme, c.Request.Host)
 
 	// Find package across all adapters
-	adapters := h.dmsRegistry.List()
+	adapters := dmsReg.List()
 	for _, dmsAdapter := range adapters {
 		pkg, err := dmsAdapter.GetDeploymentPackage(ctx, offeringID)
 		if err == nil {

--- a/internal/server/context_keys.go
+++ b/internal/server/context_keys.go
@@ -1,0 +1,17 @@
+// Package server provides HTTP server infrastructure for the O2-IMS Gateway.
+// This file defines context keys for per-request dynamic adapter/registry resolution.
+package server
+
+// Context keys for per-request dynamic routing.
+// These keys are used with gin.Context.Set/Get to store resolved adapters and registries
+// for the current request, enabling per-tenant backend resolution across all API frontends.
+const (
+	// ctxKeyIMSAdapter stores the resolved IMS adapter (adapter.Adapter) for the current request.
+	ctxKeyIMSAdapter = "resolved_ims_adapter"
+
+	// ctxKeyDMSRegistry stores the resolved DMS registry (*dmsregistry.Registry) for the current request.
+	ctxKeyDMSRegistry = "resolved_dms_registry"
+
+	// ctxKeySMORegistry stores the resolved SMO registry (*smo.Registry) for the current request.
+	ctxKeySMORegistry = "resolved_smo_registry"
+)

--- a/internal/server/dms_routes.go
+++ b/internal/server/dms_routes.go
@@ -10,6 +10,10 @@ import (
 func (s *Server) setupDMSRoutes(handler *dmshandlers.Handler) {
 	// O2-DMS API v1 routes (all features consolidated)
 	v1 := s.router.Group("/o2dms/v1")
+
+	// Apply dynamic routing middleware to resolve DMS registry per-request.
+	v1.Use(s.dmsAdapterMiddleware())
+
 	{
 		s.setupDMSV1Routes(v1, handler)
 	}

--- a/internal/server/dynamic_routing.go
+++ b/internal/server/dynamic_routing.go
@@ -1,0 +1,207 @@
+// Package server provides HTTP server infrastructure for the O2-IMS Gateway.
+// This file implements per-request dynamic routing for DMS, SMO, TMForum, and GraphQL APIs.
+// It provides middleware and resolver methods that resolve the correct adapter/registry
+// for each request based on tenant context, matching the pattern used by O2-IMS resolveAdapter.
+package server
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/piwi3910/netweave/internal/adapter"
+	"github.com/piwi3910/netweave/internal/auth"
+	dmsregistry "github.com/piwi3910/netweave/internal/dms/registry"
+	"github.com/piwi3910/netweave/internal/smo"
+)
+
+// resolveDMSRegistry determines which DMS registry to use for the current request.
+// Resolution order:
+//  1. If a DMS registry override is stored in the gin context (from middleware), use it.
+//  2. Fall back to the server's static DMS registry.
+//  3. Return nil if no DMS registry is available.
+func (s *Server) resolveDMSRegistry(c *gin.Context) *dmsregistry.Registry {
+	// Check for context-override (set by middleware for per-tenant routing).
+	if reg, exists := c.Get(ctxKeyDMSRegistry); exists {
+		if r, ok := reg.(*dmsregistry.Registry); ok && r != nil {
+			return r
+		}
+	}
+
+	// Fall back to the server's static DMS registry.
+	return s.dmsRegistry
+}
+
+// resolveSMORegistry determines which SMO registry to use for the current request.
+// Resolution order:
+//  1. If an SMO registry override is stored in the gin context (from middleware), use it.
+//  2. Fall back to the server's static SMO registry.
+//  3. Return nil if no SMO registry is available.
+func (s *Server) resolveSMORegistry(c *gin.Context) *smo.Registry {
+	// Check for context-override (set by middleware for per-tenant routing).
+	if reg, exists := c.Get(ctxKeySMORegistry); exists {
+		if r, ok := reg.(*smo.Registry); ok && r != nil {
+			return r
+		}
+	}
+
+	// Fall back to the server's static SMO registry.
+	return s.smoRegistry
+}
+
+// dmsAdapterMiddleware is a middleware that resolves the DMS registry and IMS adapter
+// for the current request and stores them in gin context for DMS handlers to use.
+func (s *Server) dmsAdapterMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Resolve and store the DMS registry for this request.
+		reg := s.resolveDMSRegistry(c)
+		if reg != nil {
+			c.Set(ctxKeyDMSRegistry, reg)
+		}
+
+		// Also resolve the IMS adapter so DMS handlers can access O2-IMS resources.
+		adp := s.resolveAdapterSilent(c)
+		if adp != nil {
+			c.Set(ctxKeyIMSAdapter, adp)
+		}
+
+		c.Next()
+	}
+}
+
+// smoAdapterMiddleware is a middleware that resolves the SMO registry for the current request
+// and stores it in gin context for SMO handlers to use.
+func (s *Server) smoAdapterMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Resolve and store the SMO registry for this request.
+		reg := s.resolveSMORegistry(c)
+		if reg != nil {
+			c.Set(ctxKeySMORegistry, reg)
+		}
+
+		c.Next()
+	}
+}
+
+// tmfAdapterMiddleware is a middleware that resolves the IMS adapter and DMS registry
+// for the current request and stores them in gin context for TMForum handlers.
+func (s *Server) tmfAdapterMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Resolve the IMS adapter for TMForum resource operations.
+		adp := s.resolveAdapterSilent(c)
+		if adp != nil {
+			c.Set(ctxKeyIMSAdapter, adp)
+		}
+
+		// Resolve the DMS registry for TMForum service/deployment operations.
+		reg := s.resolveDMSRegistry(c)
+		if reg != nil {
+			c.Set(ctxKeyDMSRegistry, reg)
+		}
+
+		c.Next()
+	}
+}
+
+// graphqlAdapterMiddleware is a middleware that resolves the IMS adapter for the current request
+// and stores it in gin context for GraphQL resolvers to use.
+func (s *Server) graphqlAdapterMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Resolve the IMS adapter for GraphQL queries.
+		adp := s.resolveAdapterSilent(c)
+		if adp != nil {
+			c.Set(ctxKeyIMSAdapter, adp)
+		}
+
+		c.Next()
+	}
+}
+
+// resolveAdapterSilent resolves the IMS adapter for the current request without writing
+// error responses to the gin context. This is used by middleware that runs before handlers,
+// where the handler itself should decide how to handle missing adapters.
+// Returns nil if no adapter can be resolved.
+func (s *Server) resolveAdapterSilent(c *gin.Context) adapter.Adapter {
+	// If no registry is configured, return the static adapter.
+	if s.adapterRegistry == nil || s.backendStore == nil {
+		return s.adapter
+	}
+
+	ctx := c.Request.Context()
+
+	// Platform admin with explicit backend selection.
+	backendID := c.GetHeader("X-Backend-ID")
+	if backendID != "" {
+		adp, err := s.adapterRegistry.GetAdapter(backendID)
+		if err != nil {
+			s.logger.Debug("middleware: backend not found",
+				zap.String("backend_id", backendID),
+				zap.Error(err),
+			)
+			return s.adapter
+		}
+		return adp
+	}
+
+	// Resolve adapter based on tenant.
+	tenantID := auth.TenantIDFromContext(ctx)
+	if tenantID == "" {
+		// No tenant context available - fall back to static adapter.
+		return s.adapter
+	}
+
+	adp, err := s.adapterRegistry.GetAdapterForTenant(ctx, tenantID, s.backendStore)
+	if err != nil {
+		s.logger.Debug("middleware: failed to resolve adapter for tenant",
+			zap.String("tenant_id", tenantID),
+			zap.Error(err),
+		)
+		// Fall back to static adapter rather than failing silently.
+		return s.adapter
+	}
+
+	return adp
+}
+
+// IMSAdapterFromContext extracts the resolved IMS adapter from gin context.
+// Returns nil if no adapter was stored. Used by handlers that support dynamic routing.
+func IMSAdapterFromContext(c *gin.Context) adapter.Adapter {
+	if adp, exists := c.Get(ctxKeyIMSAdapter); exists {
+		if a, ok := adp.(adapter.Adapter); ok {
+			return a
+		}
+	}
+	return nil
+}
+
+// DMSRegistryFromContext extracts the resolved DMS registry from gin context.
+// Returns nil if no registry was stored. Used by DMS and TMForum handlers.
+func DMSRegistryFromContext(c *gin.Context) *dmsregistry.Registry {
+	if reg, exists := c.Get(ctxKeyDMSRegistry); exists {
+		if r, ok := reg.(*dmsregistry.Registry); ok {
+			return r
+		}
+	}
+	return nil
+}
+
+// SMORegistryFromContext extracts the resolved SMO registry from gin context.
+// Returns nil if no registry was stored. Used by SMO handlers.
+func SMORegistryFromContext(c *gin.Context) *smo.Registry {
+	if reg, exists := c.Get(ctxKeySMORegistry); exists {
+		if r, ok := reg.(*smo.Registry); ok {
+			return r
+		}
+	}
+	return nil
+}
+
+// handleAdapterUnavailable sends a 503 response when no adapter could be resolved.
+// Used by handlers that require an adapter and cannot proceed without one.
+func handleAdapterUnavailable(c *gin.Context) {
+	c.JSON(http.StatusServiceUnavailable, gin.H{
+		"error":   "ServiceUnavailable",
+		"message": "No backend adapter available for this request. Ensure backend instances are configured.",
+	})
+}

--- a/internal/server/dynamic_routing_test.go
+++ b/internal/server/dynamic_routing_test.go
@@ -1,0 +1,383 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/piwi3910/netweave/internal/config"
+	dmsregistry "github.com/piwi3910/netweave/internal/dms/registry"
+	"github.com/piwi3910/netweave/internal/server"
+	"github.com/piwi3910/netweave/internal/smo"
+)
+
+// ========================================
+// Context Helper Tests
+// ========================================
+
+func TestIMSAdapterFromContext(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupCtx  func(c *gin.Context)
+		expectNil bool
+	}{
+		{
+			name:      "no adapter in context returns nil",
+			setupCtx:  func(_ *gin.Context) {},
+			expectNil: true,
+		},
+		{
+			name: "valid adapter in context",
+			setupCtx: func(c *gin.Context) {
+				c.Set("resolved_ims_adapter", &mockAdapter{})
+			},
+			expectNil: false,
+		},
+		{
+			name: "wrong type in context returns nil",
+			setupCtx: func(c *gin.Context) {
+				c.Set("resolved_ims_adapter", "not-an-adapter")
+			},
+			expectNil: true,
+		},
+		{
+			name: "nil value in context returns nil",
+			setupCtx: func(c *gin.Context) {
+				c.Set("resolved_ims_adapter", nil)
+			},
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			tt.setupCtx(c)
+
+			adp := server.IMSAdapterFromContext(c)
+			if tt.expectNil {
+				assert.Nil(t, adp)
+			} else {
+				assert.NotNil(t, adp)
+			}
+		})
+	}
+}
+
+func TestDMSRegistryFromContext(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name      string
+		setupCtx  func(c *gin.Context)
+		expectNil bool
+	}{
+		{
+			name:      "no registry in context returns nil",
+			setupCtx:  func(_ *gin.Context) {},
+			expectNil: true,
+		},
+		{
+			name: "valid registry in context",
+			setupCtx: func(c *gin.Context) {
+				reg := dmsregistry.NewRegistry(logger, nil)
+				c.Set("resolved_dms_registry", reg)
+			},
+			expectNil: false,
+		},
+		{
+			name: "wrong type in context returns nil",
+			setupCtx: func(c *gin.Context) {
+				c.Set("resolved_dms_registry", "not-a-registry")
+			},
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			tt.setupCtx(c)
+
+			reg := server.DMSRegistryFromContext(c)
+			if tt.expectNil {
+				assert.Nil(t, reg)
+			} else {
+				assert.NotNil(t, reg)
+			}
+		})
+	}
+}
+
+func TestSMORegistryFromContext(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name      string
+		setupCtx  func(c *gin.Context)
+		expectNil bool
+	}{
+		{
+			name:      "no registry in context returns nil",
+			setupCtx:  func(_ *gin.Context) {},
+			expectNil: true,
+		},
+		{
+			name: "valid registry in context",
+			setupCtx: func(c *gin.Context) {
+				reg := smo.NewRegistry(logger)
+				c.Set("resolved_smo_registry", reg)
+			},
+			expectNil: false,
+		},
+		{
+			name: "wrong type in context returns nil",
+			setupCtx: func(c *gin.Context) {
+				c.Set("resolved_smo_registry", 42)
+			},
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			tt.setupCtx(c)
+
+			reg := server.SMORegistryFromContext(c)
+			if tt.expectNil {
+				assert.Nil(t, reg)
+			} else {
+				assert.NotNil(t, reg)
+			}
+		})
+	}
+}
+
+// ========================================
+// DMS Middleware Integration Tests
+// ========================================
+
+func TestDMSMiddleware_InjectsDMSRegistry(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+	router := gin.New()
+	srv := server.NewTestServerWithRouter(router, logger)
+
+	// Create a DMS registry with a mock adapter.
+	dmsReg := dmsregistry.NewRegistry(logger, nil)
+	mockAdp := newMockDMSAdapter()
+	err := dmsReg.Register(context.Background(), "test-dms-adapter", "mock", mockAdp, nil, true)
+	require.NoError(t, err)
+
+	srv.SetupDMS(dmsReg)
+
+	// The deployment lifecycle endpoint should return adapter info.
+	req := httptest.NewRequest(http.MethodGet, "/o2dms/v1/deploymentLifecycle", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// Verify the adapter was resolved from the registry.
+	adapters, ok := response["adapters"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, adapters, 1)
+
+	firstAdapter, ok := adapters[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "test-dms-adapter", firstAdapter["name"])
+}
+
+func TestDMSMiddleware_ListNFDeployments(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+	router := gin.New()
+	srv := server.NewTestServerWithRouter(router, logger)
+
+	// Create a DMS registry with a mock adapter.
+	dmsReg := dmsregistry.NewRegistry(logger, nil)
+	mockAdp := newMockDMSAdapter()
+	err := dmsReg.Register(context.Background(), "test-adapter", "mock", mockAdp, nil, true)
+	require.NoError(t, err)
+
+	srv.SetupDMS(dmsReg)
+
+	// List NF deployments endpoint.
+	req := httptest.NewRequest(http.MethodGet, "/o2dms/v1/nfDeployments", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// ========================================
+// SMO Middleware Integration Tests
+// ========================================
+
+func TestSMOMiddleware_ListPlugins(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+	router := gin.New()
+	srv := server.NewTestServerWithRouter(router, logger)
+
+	// Create SMO registry.
+	smoReg := smo.NewRegistry(logger)
+	srv.SetSMORegistry(smoReg)
+
+	// List plugins endpoint.
+	req := httptest.NewRequest(http.MethodGet, "/o2smo/v1/plugins", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Contains(t, response, "plugins")
+	assert.Contains(t, response, "total")
+}
+
+func TestSMOMiddleware_HealthEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+	router := gin.New()
+	srv := server.NewTestServerWithRouter(router, logger)
+
+	// Create SMO registry.
+	smoReg := smo.NewRegistry(logger)
+	srv.SetSMORegistry(smoReg)
+
+	// Health endpoint.
+	req := httptest.NewRequest(http.MethodGet, "/o2smo/v1/health", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// ========================================
+// TMForum Middleware Integration Tests
+// ========================================
+
+func TestTMForumMiddleware_Returns503WithoutDMS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Port:    8080,
+			GinMode: gin.TestMode,
+		},
+	}
+
+	// Create a server with a mock adapter but no DMS.
+	srv, _ := server.NewTestServerWithMetrics(cfg, logger, &mockAdapter{}, &mockStore{})
+
+	// Without DMS initialization, TMForum routes should return 503.
+	req := httptest.NewRequest(http.MethodGet, "/tmf-api/resourceInventoryManagement/v4/resource", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestTMForumMiddleware_WorksWithDMS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Port:    8080,
+			GinMode: gin.TestMode,
+		},
+	}
+
+	// Create a server with a mock adapter.
+	srv, _ := server.NewTestServerWithMetrics(cfg, logger, &mockAdapter{}, &mockStore{})
+
+	// Initialize DMS subsystem.
+	dmsReg := dmsregistry.NewRegistry(logger, nil)
+	mockAdp := newMockDMSAdapter()
+	err := dmsReg.Register(context.Background(), "test-adapter", "mock", mockAdp, nil, true)
+	require.NoError(t, err)
+	srv.SetupDMS(dmsReg)
+
+	// With DMS initialized, TMForum routes should work (return 200).
+	req := httptest.NewRequest(http.MethodGet, "/tmf-api/resourceInventoryManagement/v4/resource", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// ========================================
+// GraphQL Integration Tests
+// ========================================
+
+func TestGraphQLRoute_WithStaticAdapter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Port:    8080,
+			GinMode: "debug",
+		},
+	}
+
+	srv, _ := server.NewTestServerWithMetrics(cfg, logger, &mockAdapter{}, &mockStore{})
+
+	// In debug mode, GET /graphql returns the playground HTML.
+	req := httptest.NewRequest(http.MethodGet, "/graphql", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestGraphQLRoute_WithoutAdapter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Port:    8080,
+			GinMode: "debug",
+		},
+	}
+
+	srv, _ := server.NewTestServerWithMetrics(cfg, logger, nil, &mockStore{})
+
+	// Without any adapter source, GraphQL routes should not be registered.
+	req := httptest.NewRequest(http.MethodGet, "/graphql", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	// Should return 404 since GraphQL routes were not registered.
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/server/graphql_routes.go
+++ b/internal/server/graphql_routes.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/gin-gonic/gin"
 	gqlserver "github.com/piwi3910/netweave/internal/graphql"
 	"github.com/piwi3910/netweave/internal/graphql/resolvers"
 )
@@ -19,15 +20,17 @@ import (
 //   - Real-time subscriptions via WebSocket
 //   - Introspection for schema exploration
 func (s *Server) setupGraphQLRoutes() {
-	// GraphQL requires an adapter — skip setup if no static adapter is available.
-	// With dynamic backend routing, GraphQL is deferred until it supports adapter resolution.
-	if s.adapter == nil {
-		s.logger.Info("GraphQL API deferred (no static adapter, uses dynamic routing)")
+	// GraphQL requires at least one source of adapter resolution.
+	// With dynamic routing, the adapter is resolved per-request via middleware.
+	// Without dynamic routing, a static adapter must be present.
+	if s.adapter == nil && s.adapterRegistry == nil {
+		s.logger.Info("GraphQL API deferred (no adapter source available)")
 		return
 	}
 
-	// Create GraphQL resolver with server dependencies
-	// Note: SMO handler not included to avoid import cycles
+	// Create GraphQL resolver with server dependencies.
+	// The static adapter serves as a fallback for when dynamic routing is not configured.
+	// Note: SMO handler not included to avoid import cycles.
 	resolver := resolvers.NewResolver(
 		s.adapter,
 		s.store,
@@ -35,20 +38,36 @@ func (s *Server) setupGraphQLRoutes() {
 		s.logger,
 	)
 
-	// Create GraphQL server with resolver
+	// Create GraphQL server with resolver.
 	gqlSrv := gqlserver.NewServer(resolver)
 
-	// GraphQL query endpoint (POST /graphql)
-	// Handles all GraphQL queries, mutations, and subscriptions
-	s.router.POST("/graphql", gqlserver.GinHandler(gqlSrv))
+	// GraphQL query endpoint (POST /graphql).
+	// The graphqlContextMiddleware resolves the adapter per-request and injects it into
+	// the standard context.Context so that gqlgen resolvers can access it.
+	s.router.POST("/graphql", s.graphqlContextMiddleware(), gqlserver.GinHandler(gqlSrv))
 
-	// GraphQL playground UI (GET /graphql)
-	// Only enabled in development mode for security
-	// Provides interactive IDE for exploring the GraphQL schema
+	// GraphQL playground UI (GET /graphql).
+	// Only enabled in development mode for security.
+	// Provides interactive IDE for exploring the GraphQL schema.
 	if s.config.Server.GinMode != "release" {
 		s.router.GET("/graphql", gqlserver.PlaygroundHandler("/graphql"))
 		s.logger.Info("GraphQL playground enabled at /graphql")
 	}
 
 	s.logger.Info("GraphQL API configured at /graphql")
+}
+
+// graphqlContextMiddleware resolves the IMS adapter per-request and injects it into
+// the standard context.Context so that GraphQL resolvers can access it via context.Value.
+// This is necessary because gqlgen resolvers receive context.Context, not gin.Context.
+func (s *Server) graphqlContextMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		adp := s.resolveAdapterSilent(c)
+		if adp != nil {
+			// Inject adapter into the standard request context for GraphQL resolvers.
+			ctx := resolvers.WithAdapter(c.Request.Context(), adp)
+			c.Request = c.Request.WithContext(ctx)
+		}
+		c.Next()
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -694,15 +694,15 @@ func (s *Server) SetupDMS(reg *dmsregistry.Registry) {
 
 	s.logger.Info("DMS subsystem initialized")
 
-	// Initialize TMForum handler only if a static adapter is available.
-	// With dynamic backend routing, TMForum routes return 503 via tmfHandlerOrUnavailable
-	// until TMForum is updated to support dynamic adapter resolution.
+	// Initialize TMForum handler with the static adapter (may be nil for dynamic routing).
+	// When dynamic routing is active, the handler's getActiveAdapter(c) method resolves
+	// the adapter per-request from gin context, falling back to the static adapter.
+	hubStore := storage.NewInMemoryHubStore()
+	s.tmfHandler = handlers.NewTMForumHandler(s.adapter, s.dmsRegistry, hubStore, s.logger)
 	if s.adapter != nil {
-		hubStore := storage.NewInMemoryHubStore()
-		s.tmfHandler = handlers.NewTMForumHandler(s.adapter, s.dmsRegistry, hubStore, s.logger)
-		s.logger.Info("TMForum API initialized", zap.Int("apis", 2))
+		s.logger.Info("TMForum API initialized with static adapter")
 	} else {
-		s.logger.Info("TMForum API deferred (no static adapter, uses dynamic routing)")
+		s.logger.Info("TMForum API initialized with dynamic routing (adapter resolved per-request)")
 	}
 }
 

--- a/internal/server/smo_routes.go
+++ b/internal/server/smo_routes.go
@@ -153,24 +153,25 @@ func (h *SMOHandler) setEventDefaults(eventID *string, timestamp *time.Time) {
 // publishEvent publishes an event using the provided plugin function.
 func (h *SMOHandler) publishEvent(c *gin.Context, publishFn func(context.Context, smo.Plugin) error) error {
 	pluginName := c.Query("plugin")
+	reg := h.getActiveRegistry(c)
 
 	// Get plugin inline (avoid ireturn linter)
 	var plugin smo.Plugin
 	var err error
 
 	if pluginName != "" {
-		h.registry.Mu.RLock()
-		plugin = h.registry.Plugins[pluginName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		plugin = reg.Plugins[pluginName]
+		reg.Mu.RUnlock()
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", pluginName)
 		}
 	} else {
-		h.registry.Mu.RLock()
-		defaultName := h.registry.DefaultPlugin
-		plugin = h.registry.Plugins[defaultName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		defaultName := reg.DefaultPlugin
+		plugin = reg.Plugins[defaultName]
+		reg.Mu.RUnlock()
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -207,17 +208,34 @@ func NewSMOHandler(registry *smo.Registry, logger *zap.Logger) *SMOHandler {
 	}
 }
 
+// contextKeySMORegistry is the gin context key used to store a per-request SMO registry override.
+// When set by server middleware, it takes priority over the handler's static registry.
+const contextKeySMORegistry = "resolved_smo_registry"
+
+// getActiveRegistry returns the SMO registry for the current request.
+// It checks gin context for a per-request override (set by dynamic routing middleware),
+// falling back to the handler's static registry.
+func (h *SMOHandler) getActiveRegistry(c *gin.Context) *smo.Registry {
+	if reg, exists := c.Get(contextKeySMORegistry); exists {
+		if r, ok := reg.(*smo.Registry); ok && r != nil {
+			return r
+		}
+	}
+	return h.registry
+}
+
 // getPluginFromQuery retrieves a plugin from the registry using the plugin query parameter.
 // Returns smo.Plugin interface (factory/lookup pattern).
 // Note: Returning interface is idiomatic for factory/lookup methods.
 func (h *SMOHandler) getPluginFromQuery(c *gin.Context) (smo.Plugin, error) {
 	pluginName := c.Query("plugin")
+	reg := h.getActiveRegistry(c)
 	var plugin smo.Plugin
 
 	if pluginName != "" {
-		h.registry.Mu.RLock()
-		plugin = h.registry.Plugins[pluginName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		plugin = reg.Plugins[pluginName]
+		reg.Mu.RUnlock()
 
 		if plugin == nil {
 			return nil, fmt.Errorf("plugin %s not found", pluginName)
@@ -226,10 +244,10 @@ func (h *SMOHandler) getPluginFromQuery(c *gin.Context) (smo.Plugin, error) {
 	}
 
 	// Use default plugin
-	h.registry.Mu.RLock()
-	defaultName := h.registry.DefaultPlugin
-	plugin = h.registry.Plugins[defaultName]
-	h.registry.Mu.RUnlock()
+	reg.Mu.RLock()
+	defaultName := reg.DefaultPlugin
+	plugin = reg.Plugins[defaultName]
+	reg.Mu.RUnlock()
 
 	if defaultName == "" {
 		return nil, fmt.Errorf("no default plugin configured")
@@ -247,6 +265,10 @@ func (h *SMOHandler) getPluginFromQuery(c *gin.Context) (smo.Plugin, error) {
 func (s *Server) setupSMORoutes(smoHandler *SMOHandler) {
 	// O2-SMO API v1 routes (all features consolidated)
 	v1 := s.router.Group("/o2smo/v1")
+
+	// Apply dynamic routing middleware to resolve SMO registry per-request.
+	v1.Use(s.smoAdapterMiddleware())
+
 	{
 		s.setupSMOV1Routes(v1, smoHandler)
 	}
@@ -357,8 +379,9 @@ func (s *Server) handleSMOFeatures(c *gin.Context) {
 // GET /o2smo/v1/plugins.
 func (h *SMOHandler) HandleListPlugins(c *gin.Context) {
 	h.logger.Info("listing SMO plugins")
+	reg := h.getActiveRegistry(c)
 
-	plugins := h.registry.List()
+	plugins := reg.List()
 
 	c.JSON(http.StatusOK, gin.H{
 		"plugins": plugins,
@@ -370,12 +393,13 @@ func (h *SMOHandler) HandleListPlugins(c *gin.Context) {
 // GET /o2smo/v1/plugins/:pluginId.
 func (h *SMOHandler) HandleGetPlugin(c *gin.Context) {
 	pluginID := c.Param("pluginId")
+	reg := h.getActiveRegistry(c)
 	h.logger.Info("getting SMO plugin", zap.String("plugin_id", pluginID))
 
-	h.registry.Mu.RLock()
+	reg.Mu.RLock()
 	var exists bool
-	plugin, exists := h.registry.Plugins[pluginID]
-	h.registry.Mu.RUnlock()
+	plugin, exists := reg.Plugins[pluginID]
+	reg.Mu.RUnlock()
 	var err error
 	if !exists {
 		err = fmt.Errorf("plugin %s not found", pluginID)
@@ -412,6 +436,7 @@ type WorkflowRequest struct {
 // POST /o2smo/v1/workflows.
 func (h *SMOHandler) HandleExecuteWorkflow(c *gin.Context) {
 	start := time.Now()
+	reg := h.getActiveRegistry(c)
 	h.logger.Info("executing workflow")
 
 	var req WorkflowRequest
@@ -427,9 +452,9 @@ func (h *SMOHandler) HandleExecuteWorkflow(c *gin.Context) {
 	var err error
 
 	if req.PluginName != "" {
-		h.registry.Mu.RLock()
-		plugin = h.registry.Plugins[req.PluginName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		plugin = reg.Plugins[req.PluginName]
+		reg.Mu.RUnlock()
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", req.PluginName)
 			h.respondWithNotFound(c, err)
@@ -438,10 +463,10 @@ func (h *SMOHandler) HandleExecuteWorkflow(c *gin.Context) {
 		}
 		pluginName = req.PluginName
 	} else {
-		h.registry.Mu.RLock()
-		defaultName := h.registry.DefaultPlugin
-		plugin = h.registry.Plugins[defaultName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		defaultName := reg.DefaultPlugin
+		plugin = reg.Plugins[defaultName]
+		reg.Mu.RUnlock()
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -519,6 +544,7 @@ func (h *SMOHandler) HandleGetWorkflowStatus(c *gin.Context) {
 // DELETE /o2smo/v1/workflows/:executionId.
 func (h *SMOHandler) HandleCancelWorkflow(c *gin.Context) {
 	executionID := c.Param("executionId")
+	reg := h.getActiveRegistry(c)
 	pluginName := c.Query("plugin")
 
 	// Validate execution ID
@@ -534,18 +560,18 @@ func (h *SMOHandler) HandleCancelWorkflow(c *gin.Context) {
 	var err error
 	// Get plugin inline (avoid ireturn linter)
 	if pluginName != "" {
-		h.registry.Mu.RLock()
-		plugin = h.registry.Plugins[pluginName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		plugin = reg.Plugins[pluginName]
+		reg.Mu.RUnlock()
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", pluginName)
 		}
 	} else {
-		h.registry.Mu.RLock()
-		defaultName := h.registry.DefaultPlugin
-		plugin = h.registry.Plugins[defaultName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		defaultName := reg.DefaultPlugin
+		plugin = reg.Plugins[defaultName]
+		reg.Mu.RUnlock()
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -586,6 +612,7 @@ type ServiceModelRequest struct {
 // GET /o2smo/v1/serviceModels.
 func (h *SMOHandler) HandleListServiceModels(c *gin.Context) {
 	pluginName := c.Query("plugin")
+	reg := h.getActiveRegistry(c)
 	h.logger.Info("listing service models")
 
 	// Get plugin
@@ -593,18 +620,18 @@ func (h *SMOHandler) HandleListServiceModels(c *gin.Context) {
 	var err error
 	// Get plugin inline (avoid ireturn linter)
 	if pluginName != "" {
-		h.registry.Mu.RLock()
-		plugin = h.registry.Plugins[pluginName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		plugin = reg.Plugins[pluginName]
+		reg.Mu.RUnlock()
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", pluginName)
 		}
 	} else {
-		h.registry.Mu.RLock()
-		defaultName := h.registry.DefaultPlugin
-		plugin = h.registry.Plugins[defaultName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		defaultName := reg.DefaultPlugin
+		plugin = reg.Plugins[defaultName]
+		reg.Mu.RUnlock()
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -635,6 +662,7 @@ func (h *SMOHandler) HandleListServiceModels(c *gin.Context) {
 // POST /o2smo/v1/serviceModels.
 func (h *SMOHandler) HandleCreateServiceModel(c *gin.Context) {
 	h.logger.Info("creating service model")
+	reg := h.getActiveRegistry(c)
 
 	var req ServiceModelRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -647,18 +675,18 @@ func (h *SMOHandler) HandleCreateServiceModel(c *gin.Context) {
 	var err error
 	// Get plugin inline (avoid ireturn linter)
 	if req.PluginName != "" {
-		h.registry.Mu.RLock()
-		plugin = h.registry.Plugins[req.PluginName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		plugin = reg.Plugins[req.PluginName]
+		reg.Mu.RUnlock()
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", req.PluginName)
 		}
 	} else {
-		h.registry.Mu.RLock()
-		defaultName := h.registry.DefaultPlugin
-		plugin = h.registry.Plugins[defaultName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		defaultName := reg.DefaultPlugin
+		plugin = reg.Plugins[defaultName]
+		reg.Mu.RUnlock()
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -756,6 +784,7 @@ type PolicyRequest struct {
 // POST /o2smo/v1/policies.
 func (h *SMOHandler) HandleApplyPolicy(c *gin.Context) {
 	h.logger.Info("applying policy")
+	reg := h.getActiveRegistry(c)
 
 	var req PolicyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -768,18 +797,18 @@ func (h *SMOHandler) HandleApplyPolicy(c *gin.Context) {
 	var err error
 	// Get plugin inline (avoid ireturn linter)
 	if req.PluginName != "" {
-		h.registry.Mu.RLock()
-		plugin = h.registry.Plugins[req.PluginName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		plugin = reg.Plugins[req.PluginName]
+		reg.Mu.RUnlock()
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", req.PluginName)
 		}
 	} else {
-		h.registry.Mu.RLock()
-		defaultName := h.registry.DefaultPlugin
-		plugin = h.registry.Plugins[defaultName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		defaultName := reg.DefaultPlugin
+		plugin = reg.Plugins[defaultName]
+		reg.Mu.RUnlock()
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -849,6 +878,7 @@ func (h *SMOHandler) HandleGetPolicyStatus(c *gin.Context) {
 // POST /o2smo/v1/sync/infrastructure.
 func (h *SMOHandler) HandleSyncInfrastructure(c *gin.Context) {
 	pluginName := c.Query("plugin")
+	reg := h.getActiveRegistry(c)
 	h.logger.Info("syncing infrastructure inventory")
 
 	var inventory smo.InfrastructureInventory
@@ -862,18 +892,18 @@ func (h *SMOHandler) HandleSyncInfrastructure(c *gin.Context) {
 	var err error
 	// Get plugin inline (avoid ireturn linter)
 	if pluginName != "" {
-		h.registry.Mu.RLock()
-		plugin = h.registry.Plugins[pluginName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		plugin = reg.Plugins[pluginName]
+		reg.Mu.RUnlock()
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", pluginName)
 		}
 	} else {
-		h.registry.Mu.RLock()
-		defaultName := h.registry.DefaultPlugin
-		plugin = h.registry.Plugins[defaultName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		defaultName := reg.DefaultPlugin
+		plugin = reg.Plugins[defaultName]
+		reg.Mu.RUnlock()
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -909,6 +939,7 @@ func (h *SMOHandler) HandleSyncInfrastructure(c *gin.Context) {
 // POST /o2smo/v1/sync/deployments.
 func (h *SMOHandler) HandleSyncDeployments(c *gin.Context) {
 	pluginName := c.Query("plugin")
+	reg := h.getActiveRegistry(c)
 	h.logger.Info("syncing deployment inventory")
 
 	var inventory smo.DeploymentInventory
@@ -922,18 +953,18 @@ func (h *SMOHandler) HandleSyncDeployments(c *gin.Context) {
 	var err error
 	// Get plugin inline (avoid ireturn linter)
 	if pluginName != "" {
-		h.registry.Mu.RLock()
-		plugin = h.registry.Plugins[pluginName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		plugin = reg.Plugins[pluginName]
+		reg.Mu.RUnlock()
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", pluginName)
 		}
 	} else {
-		h.registry.Mu.RLock()
-		defaultName := h.registry.DefaultPlugin
-		plugin = h.registry.Plugins[defaultName]
-		h.registry.Mu.RUnlock()
+		reg.Mu.RLock()
+		defaultName := reg.DefaultPlugin
+		plugin = reg.Plugins[defaultName]
+		reg.Mu.RUnlock()
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -1006,8 +1037,9 @@ func (h *SMOHandler) HandlePublishDeploymentEvent(c *gin.Context) {
 // GET /o2smo/v1/health.
 func (h *SMOHandler) HandleSMOHealth(c *gin.Context) {
 	h.logger.Info("checking SMO health")
+	reg := h.getActiveRegistry(c)
 
-	plugins := h.registry.List()
+	plugins := reg.List()
 	healthy := 0
 	unhealthy := 0
 

--- a/internal/server/tmforum_routes.go
+++ b/internal/server/tmforum_routes.go
@@ -177,6 +177,8 @@ func (s *Server) setupTMForumRoutesEarly() {
 
 // tmfHandlerOrUnavailable returns a handler that delegates to the TMForum handler if available,
 // or returns 503 Service Unavailable if DMS has not been initialized yet.
+// It also injects the per-request resolved IMS adapter and DMS registry into gin context
+// so the TMForum handler can use dynamic per-tenant routing.
 func (s *Server) tmfHandlerOrUnavailable(getHandler func(*handlers.TMForumHandler) gin.HandlerFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if s.tmfHandler == nil {
@@ -186,6 +188,17 @@ func (s *Server) tmfHandlerOrUnavailable(getHandler func(*handlers.TMForumHandle
 			})
 			return
 		}
+
+		// Inject resolved adapter and DMS registry for per-tenant routing.
+		adp := s.resolveAdapterSilent(c)
+		if adp != nil {
+			c.Set(ctxKeyIMSAdapter, adp)
+		}
+		reg := s.resolveDMSRegistry(c)
+		if reg != nil {
+			c.Set(ctxKeyDMSRegistry, reg)
+		}
+
 		handler := getHandler(s.tmfHandler)
 		handler(c)
 	}


### PR DESCRIPTION
## Summary
- Adds per-request dynamic backend routing to all 5 toggleable frontend APIs (O2-DMS, O2-SMO, TMForum, GraphQL), matching the pattern already in O2-IMS via `resolveAdapter()`
- Each API frontend now resolves its adapter/registry per-request from gin context, with fallback to static references for backward compatibility
- Server middleware on each route group resolves adapters per-tenant using the AdapterRegistry and stores them in gin context before handlers run

### Changes by API frontend:
- **DMS**: Handler reads DMS registry from context via `getActiveRegistry(c)`
- **SMO**: Handler reads SMO registry from context via `getActiveRegistry(c)`  
- **TMForum**: Handler reads IMS adapter and DMS registry from context via `getActiveAdapter(c)` and `getActiveDMSRegistry(c)`
- **GraphQL**: Resolver reads IMS adapter from `context.Context` via `getActiveAdapter(ctx)`, injected by `graphqlContextMiddleware`

### New files:
- `internal/server/context_keys.go` — Context keys for dynamic routing
- `internal/server/dynamic_routing.go` — Middleware and resolver methods
- `internal/server/dynamic_routing_test.go` — Tests for dynamic routing

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes — all existing tests continue to work (backward compatible via static fallback)
- [ ] Dynamic routing test file verifies context-based adapter resolution
- [ ] Verify DMS/SMO/TMForum/GraphQL handlers use per-request resolution

Resolves #392