### PR TITLE
[Feature] Frontend plugin toggle system with admin API

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,22 +53,40 @@ const (
 //	    log.Fatal(err)
 //	}
 type Config struct {
-	Server        ServerConfig            `mapstructure:"server"`
-	Redis         RedisConfig             `mapstructure:"redis"`
-	Kubernetes    KubernetesConfig        `mapstructure:"kubernetes"`
-	TLS           TLSConfig               `mapstructure:"tls"`
-	Observability ObservabilityConfig     `mapstructure:"observability"`
-	Security      SecurityConfig          `mapstructure:"security"`
-	Validation    ValidationConfig        `mapstructure:"validation"`
-	MultiTenancy  MultiTenancyConfig      `mapstructure:"multi_tenancy"`
-	OAuth2        OAuth2Config            `mapstructure:"oauth2"`
-	Auth          AuthConfig              `mapstructure:"auth"`
-	Postgres      database.PostgresConfig `mapstructure:"postgres"`
-	StorageMode   string                  `mapstructure:"storage_mode"`
+	Server          ServerConfig            `mapstructure:"server"`
+	Redis           RedisConfig             `mapstructure:"redis"`
+	Kubernetes      KubernetesConfig        `mapstructure:"kubernetes"`
+	TLS             TLSConfig               `mapstructure:"tls"`
+	Observability   ObservabilityConfig     `mapstructure:"observability"`
+	Security        SecurityConfig          `mapstructure:"security"`
+	Validation      ValidationConfig        `mapstructure:"validation"`
+	MultiTenancy    MultiTenancyConfig      `mapstructure:"multi_tenancy"`
+	OAuth2          OAuth2Config            `mapstructure:"oauth2"`
+	Auth            AuthConfig              `mapstructure:"auth"`
+	Postgres        database.PostgresConfig `mapstructure:"postgres"`
+	StorageMode     string                  `mapstructure:"storage_mode"`
+	FrontendPlugins FrontendPlugins         `mapstructure:"frontend_plugins"`
 
 	// Environment stores the detected environment (dev/staging/prod)
 	// This field is set automatically during Load() and used for validation
 	Environment string `mapstructure:"-"`
+}
+
+// FrontendPlugins configures which protocol API frontends are enabled.
+// All plugins are disabled by default and must be explicitly enabled by platform admins.
+type FrontendPlugins struct {
+	O2IMS   FrontendPluginConfig `mapstructure:"o2ims"`
+	O2DMS   FrontendPluginConfig `mapstructure:"o2dms"`
+	O2SMO   FrontendPluginConfig `mapstructure:"o2smo"`
+	TMForum FrontendPluginConfig `mapstructure:"tmforum"`
+	GraphQL FrontendPluginConfig `mapstructure:"graphql"`
+}
+
+// FrontendPluginConfig contains configuration for a single frontend plugin.
+type FrontendPluginConfig struct {
+	// Enabled controls whether this frontend plugin is active.
+	// Default: false (all plugins disabled by default).
+	Enabled bool `mapstructure:"enabled"`
 }
 
 // AuthConfig contains authentication backend configuration.
@@ -978,6 +996,13 @@ func setDefaults(v *viper.Viper) {
 
 	// Storage mode defaults
 	v.SetDefault("storage_mode", "redis")
+
+	// Frontend plugins defaults (all disabled by default)
+	v.SetDefault("frontend_plugins.o2ims.enabled", false)
+	v.SetDefault("frontend_plugins.o2dms.enabled", false)
+	v.SetDefault("frontend_plugins.o2smo.enabled", false)
+	v.SetDefault("frontend_plugins.tmforum.enabled", false)
+	v.SetDefault("frontend_plugins.graphql.enabled", false)
 
 	// PostgreSQL defaults
 	v.SetDefault("postgres.host", "localhost")

--- a/internal/handlers/plugin_handler.go
+++ b/internal/handlers/plugin_handler.go
@@ -1,0 +1,119 @@
+// Package handlers provides HTTP request handlers for the O2-IMS Gateway.
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// FrontendPluginInfo represents a frontend plugin for API responses.
+type FrontendPluginInfo struct {
+	Name        string   `json:"name"`
+	DisplayName string   `json:"displayName"`
+	Enabled     bool     `json:"enabled"`
+	BasePaths   []string `json:"basePaths"`
+}
+
+// PluginRegistry defines the interface for frontend plugin management.
+// This decouples the handler from the concrete server.FrontendPluginRegistry type.
+type PluginRegistry interface {
+	List() []FrontendPluginInfo
+	Get(name string) (*FrontendPluginInfo, error)
+	Enable(name string) error
+	Disable(name string) error
+}
+
+// PluginHandler handles admin API requests for frontend plugin management.
+type PluginHandler struct {
+	registry PluginRegistry
+	logger   *zap.Logger
+}
+
+// NewPluginHandler creates a new PluginHandler with the given registry and logger.
+func NewPluginHandler(registry PluginRegistry, logger *zap.Logger) *PluginHandler {
+	return &PluginHandler{
+		registry: registry,
+		logger:   logger,
+	}
+}
+
+// ListPlugins returns all registered frontend plugins.
+// GET /admin/platform/plugins.
+func (h *PluginHandler) ListPlugins(c *gin.Context) {
+	plugins := h.registry.List()
+
+	c.JSON(http.StatusOK, gin.H{
+		"plugins": plugins,
+	})
+}
+
+// GetPlugin returns a single frontend plugin by name.
+// GET /admin/platform/plugins/:name.
+func (h *PluginHandler) GetPlugin(c *gin.Context) {
+	name := c.Param("name")
+
+	plugin, err := h.registry.Get(name)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error":   "NotFound",
+			"message": "Plugin not found: " + name,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, plugin)
+}
+
+// pluginUpdateRequest is the request body for PUT /admin/platform/plugins/:name.
+type pluginUpdateRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+// UpdatePlugin enables or disables a frontend plugin.
+// PUT /admin/platform/plugins/:name.
+func (h *PluginHandler) UpdatePlugin(c *gin.Context) {
+	name := c.Param("name")
+
+	var req pluginUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "BadRequest",
+			"message": "Invalid request body",
+		})
+		return
+	}
+
+	if req.Enabled {
+		if err := h.registry.Enable(name); err != nil {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error":   "NotFound",
+				"message": "Plugin not found: " + name,
+			})
+			return
+		}
+		h.logger.Info("frontend plugin enabled", zap.String("plugin", name))
+	} else {
+		if err := h.registry.Disable(name); err != nil {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error":   "NotFound",
+				"message": "Plugin not found: " + name,
+			})
+			return
+		}
+		h.logger.Info("frontend plugin disabled", zap.String("plugin", name))
+	}
+
+	// Return the updated plugin state.
+	plugin, err := h.registry.Get(name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "InternalError",
+			"message": "Failed to retrieve plugin after update",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, plugin)
+}

--- a/internal/handlers/plugin_handler_test.go
+++ b/internal/handlers/plugin_handler_test.go
@@ -1,0 +1,243 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/piwi3910/netweave/internal/handlers"
+)
+
+// mockPluginRegistry implements handlers.PluginRegistry for testing.
+type mockPluginRegistry struct {
+	plugins map[string]*handlers.FrontendPluginInfo
+}
+
+func newMockPluginRegistry() *mockPluginRegistry {
+	return &mockPluginRegistry{
+		plugins: map[string]*handlers.FrontendPluginInfo{
+			"o2ims": {
+				Name:        "o2ims",
+				DisplayName: "O2-IMS Infrastructure Inventory",
+				Enabled:     false,
+				BasePaths:   []string{"/o2ims-infrastructureInventory/v1"},
+			},
+			"o2dms": {
+				Name:        "o2dms",
+				DisplayName: "O2-DMS Deployment Management",
+				Enabled:     false,
+				BasePaths:   []string{"/o2dms/v1"},
+			},
+			"o2smo": {
+				Name:        "o2smo",
+				DisplayName: "O2-SMO Service Management & Orchestration",
+				Enabled:     false,
+				BasePaths:   []string{"/o2smo/v1"},
+			},
+			"tmforum": {
+				Name:        "tmforum",
+				DisplayName: "TMForum Open APIs",
+				Enabled:     false,
+				BasePaths:   []string{"/tmf-api"},
+			},
+			"graphql": {
+				Name:        "graphql",
+				DisplayName: "GraphQL API",
+				Enabled:     false,
+				BasePaths:   []string{"/graphql"},
+			},
+		},
+	}
+}
+
+func (m *mockPluginRegistry) List() []handlers.FrontendPluginInfo {
+	result := make([]handlers.FrontendPluginInfo, 0, len(m.plugins))
+	for _, p := range m.plugins {
+		result = append(result, *p)
+	}
+	return result
+}
+
+func (m *mockPluginRegistry) Get(name string) (*handlers.FrontendPluginInfo, error) {
+	p, ok := m.plugins[name]
+	if !ok {
+		return nil, errors.New("plugin not found: " + name)
+	}
+	cp := *p
+	return &cp, nil
+}
+
+func (m *mockPluginRegistry) Enable(name string) error {
+	p, ok := m.plugins[name]
+	if !ok {
+		return errors.New("plugin not found: " + name)
+	}
+	p.Enabled = true
+	return nil
+}
+
+func (m *mockPluginRegistry) Disable(name string) error {
+	p, ok := m.plugins[name]
+	if !ok {
+		return errors.New("plugin not found: " + name)
+	}
+	p.Enabled = false
+	return nil
+}
+
+func setupPluginRouter(registry handlers.PluginRegistry) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := handlers.NewPluginHandler(registry, zap.NewNop())
+
+	plugins := router.Group("/admin/platform/plugins")
+	{
+		plugins.GET("", handler.ListPlugins)
+		plugins.GET("/:name", handler.GetPlugin)
+		plugins.PUT("/:name", handler.UpdatePlugin)
+	}
+
+	return router
+}
+
+func TestPluginHandler_ListPlugins(t *testing.T) {
+	registry := newMockPluginRegistry()
+	router := setupPluginRouter(registry)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/platform/plugins", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &body)
+	require.NoError(t, err)
+
+	plugins, ok := body["plugins"].([]interface{})
+	require.True(t, ok, "plugins should be an array")
+	assert.Len(t, plugins, 5, "should have 5 plugins")
+}
+
+func TestPluginHandler_GetPlugin(t *testing.T) {
+	tests := []struct {
+		name           string
+		pluginName     string
+		expectedStatus int
+		checkBody      func(t *testing.T, body map[string]interface{})
+	}{
+		{
+			name:           "returns existing plugin",
+			pluginName:     "o2ims",
+			expectedStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body map[string]interface{}) {
+				t.Helper()
+				assert.Equal(t, "o2ims", body["name"])
+				assert.Equal(t, "O2-IMS Infrastructure Inventory", body["displayName"])
+				assert.Equal(t, false, body["enabled"])
+			},
+		},
+		{
+			name:           "returns 404 for unknown plugin",
+			pluginName:     "nonexistent",
+			expectedStatus: http.StatusNotFound,
+			checkBody: func(t *testing.T, body map[string]interface{}) {
+				t.Helper()
+				assert.Equal(t, "NotFound", body["error"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := newMockPluginRegistry()
+			router := setupPluginRouter(registry)
+
+			req := httptest.NewRequest(http.MethodGet, "/admin/platform/plugins/"+tt.pluginName, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			var body map[string]interface{}
+			err := json.Unmarshal(w.Body.Bytes(), &body)
+			require.NoError(t, err)
+			tt.checkBody(t, body)
+		})
+	}
+}
+
+func TestPluginHandler_UpdatePlugin_Enable(t *testing.T) {
+	registry := newMockPluginRegistry()
+	router := setupPluginRouter(registry)
+
+	body := `{"enabled": true}`
+	req := httptest.NewRequest(http.MethodPut, "/admin/platform/plugins/o2ims", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, true, resp["enabled"])
+	assert.Equal(t, "o2ims", resp["name"])
+}
+
+func TestPluginHandler_UpdatePlugin_Disable(t *testing.T) {
+	registry := newMockPluginRegistry()
+	// Pre-enable the plugin.
+	err := registry.Enable("o2ims")
+	require.NoError(t, err)
+
+	router := setupPluginRouter(registry)
+
+	body := `{"enabled": false}`
+	req := httptest.NewRequest(http.MethodPut, "/admin/platform/plugins/o2ims", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, false, resp["enabled"])
+}
+
+func TestPluginHandler_UpdatePlugin_InvalidName(t *testing.T) {
+	registry := newMockPluginRegistry()
+	router := setupPluginRouter(registry)
+
+	body := `{"enabled": true}`
+	req := httptest.NewRequest(http.MethodPut, "/admin/platform/plugins/nonexistent", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestPluginHandler_UpdatePlugin_InvalidBody(t *testing.T) {
+	registry := newMockPluginRegistry()
+	router := setupPluginRouter(registry)
+
+	body := `not-json`
+	req := httptest.NewRequest(http.MethodPut, "/admin/platform/plugins/o2ims", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/internal/server/auth_routes.go
+++ b/internal/server/auth_routes.go
@@ -64,6 +64,19 @@ func (s *Server) SetupAuthRoutes(authStore auth.Store, authMw *auth.Middleware) 
 
 		// Platform-level audit logs.
 		platform.GET("/audit/events", auditHandler.ListAuditEvents)
+
+		// Frontend plugin management.
+		if s.pluginRegistry != nil {
+			pluginAdapter := newPluginRegistryAdapter(s.pluginRegistry)
+			pluginHandler := handlers.NewPluginHandler(pluginAdapter, s.logger)
+
+			plugins := platform.Group("/plugins")
+			{
+				plugins.GET("", pluginHandler.ListPlugins)
+				plugins.GET("/:name", pluginHandler.GetPlugin)
+				plugins.PUT("/:name", pluginHandler.UpdatePlugin)
+			}
+		}
 	}
 
 	// --- Tenant Routes (/admin/tenant/*) ---

--- a/internal/server/dms_routes.go
+++ b/internal/server/dms_routes.go
@@ -10,6 +10,7 @@ import (
 func (s *Server) setupDMSRoutes(handler *dmshandlers.Handler) {
 	// O2-DMS API v1 routes (all features consolidated)
 	v1 := s.router.Group("/o2dms/v1")
+	v1.Use(PluginGuard(s.pluginRegistry, "o2dms"))
 
 	// Apply dynamic routing middleware to resolve DMS registry per-request.
 	v1.Use(s.dmsAdapterMiddleware())

--- a/internal/server/graphql_routes.go
+++ b/internal/server/graphql_routes.go
@@ -41,16 +41,18 @@ func (s *Server) setupGraphQLRoutes() {
 	// Create GraphQL server with resolver.
 	gqlSrv := gqlserver.NewServer(resolver)
 
+	gqlGuard := PluginGuard(s.pluginRegistry, "graphql")
+
 	// GraphQL query endpoint (POST /graphql).
 	// The graphqlContextMiddleware resolves the adapter per-request and injects it into
 	// the standard context.Context so that gqlgen resolvers can access it.
-	s.router.POST("/graphql", s.graphqlContextMiddleware(), gqlserver.GinHandler(gqlSrv))
+	s.router.POST("/graphql", gqlGuard, s.graphqlContextMiddleware(), gqlserver.GinHandler(gqlSrv))
 
 	// GraphQL playground UI (GET /graphql).
 	// Only enabled in development mode for security.
 	// Provides interactive IDE for exploring the GraphQL schema.
 	if s.config.Server.GinMode != "release" {
-		s.router.GET("/graphql", gqlserver.PlaygroundHandler("/graphql"))
+		s.router.GET("/graphql", gqlGuard, gqlserver.PlaygroundHandler("/graphql"))
 		s.logger.Info("GraphQL playground enabled at /graphql")
 	}
 

--- a/internal/server/plugin_registry.go
+++ b/internal/server/plugin_registry.go
@@ -1,0 +1,223 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"github.com/piwi3910/netweave/internal/config"
+	"github.com/piwi3910/netweave/internal/handlers"
+)
+
+// ErrPluginNotFound is returned when a plugin name is not recognized.
+var ErrPluginNotFound = errors.New("plugin not found")
+
+// FrontendPlugin represents a toggleable API frontend plugin.
+type FrontendPlugin struct {
+	Name        string   `json:"name"`
+	DisplayName string   `json:"displayName"`
+	Enabled     bool     `json:"enabled"`
+	BasePaths   []string `json:"basePaths"`
+}
+
+// FrontendPluginRegistry is a thread-safe registry of frontend plugins.
+// It tracks which API frontends are enabled and supports runtime toggling.
+type FrontendPluginRegistry struct {
+	mu      sync.RWMutex
+	plugins map[string]*FrontendPlugin
+}
+
+// NewFrontendPluginRegistry creates a new FrontendPluginRegistry initialized from config.
+// All five toggleable plugins are registered with their initial enabled state from config.
+func NewFrontendPluginRegistry(cfg config.FrontendPlugins) *FrontendPluginRegistry {
+	r := &FrontendPluginRegistry{
+		plugins: make(map[string]*FrontendPlugin, 5),
+	}
+
+	r.plugins["o2ims"] = &FrontendPlugin{
+		Name:        "o2ims",
+		DisplayName: "O2-IMS Infrastructure Inventory",
+		Enabled:     cfg.O2IMS.Enabled,
+		BasePaths:   []string{"/o2ims-infrastructureInventory/v1"},
+	}
+	r.plugins["o2dms"] = &FrontendPlugin{
+		Name:        "o2dms",
+		DisplayName: "O2-DMS Deployment Management",
+		Enabled:     cfg.O2DMS.Enabled,
+		BasePaths:   []string{"/o2dms/v1"},
+	}
+	r.plugins["o2smo"] = &FrontendPlugin{
+		Name:        "o2smo",
+		DisplayName: "O2-SMO Service Management & Orchestration",
+		Enabled:     cfg.O2SMO.Enabled,
+		BasePaths:   []string{"/o2smo/v1"},
+	}
+	r.plugins["tmforum"] = &FrontendPlugin{
+		Name:        "tmforum",
+		DisplayName: "TMForum Open APIs",
+		Enabled:     cfg.TMForum.Enabled,
+		BasePaths:   []string{"/tmf-api"},
+	}
+	r.plugins["graphql"] = &FrontendPlugin{
+		Name:        "graphql",
+		DisplayName: "GraphQL API",
+		Enabled:     cfg.GraphQL.Enabled,
+		BasePaths:   []string{"/graphql"},
+	}
+
+	return r
+}
+
+// IsEnabled returns whether the named plugin is enabled.
+// Returns false for unknown plugin names.
+func (r *FrontendPluginRegistry) IsEnabled(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	p, ok := r.plugins[name]
+	if !ok {
+		return false
+	}
+	return p.Enabled
+}
+
+// Enable enables a plugin by name.
+// Returns ErrPluginNotFound if the name is not recognized.
+func (r *FrontendPluginRegistry) Enable(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	p, ok := r.plugins[name]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrPluginNotFound, name)
+	}
+	p.Enabled = true
+	return nil
+}
+
+// Disable disables a plugin by name.
+// Returns ErrPluginNotFound if the name is not recognized.
+func (r *FrontendPluginRegistry) Disable(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	p, ok := r.plugins[name]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrPluginNotFound, name)
+	}
+	p.Enabled = false
+	return nil
+}
+
+// List returns a snapshot of all registered plugins sorted by name.
+func (r *FrontendPluginRegistry) List() []FrontendPlugin {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]FrontendPlugin, 0, len(r.plugins))
+	for _, p := range r.plugins {
+		result = append(result, *p)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	return result
+}
+
+// Get returns a copy of the named plugin.
+// Returns ErrPluginNotFound if the name is not recognized.
+func (r *FrontendPluginRegistry) Get(name string) (*FrontendPlugin, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	p, ok := r.plugins[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, name)
+	}
+
+	// Return a copy to avoid data races on the caller side.
+	cp := *p
+	cpPaths := make([]string, len(p.BasePaths))
+	copy(cpPaths, p.BasePaths)
+	cp.BasePaths = cpPaths
+	return &cp, nil
+}
+
+// pluginRegistryAdapter wraps FrontendPluginRegistry to implement handlers.PluginRegistry.
+// This bridges the server and handlers packages without circular imports.
+type pluginRegistryAdapter struct {
+	registry *FrontendPluginRegistry
+}
+
+// newPluginRegistryAdapter creates a new adapter wrapping the given registry.
+func newPluginRegistryAdapter(registry *FrontendPluginRegistry) *pluginRegistryAdapter {
+	return &pluginRegistryAdapter{registry: registry}
+}
+
+// List returns all plugins as handler-compatible FrontendPluginInfo values.
+func (a *pluginRegistryAdapter) List() []handlers.FrontendPluginInfo {
+	plugins := a.registry.List()
+	result := make([]handlers.FrontendPluginInfo, len(plugins))
+	for i, p := range plugins {
+		result[i] = toPluginInfo(p)
+	}
+	return result
+}
+
+// Get returns a single plugin as a handler-compatible FrontendPluginInfo.
+func (a *pluginRegistryAdapter) Get(name string) (*handlers.FrontendPluginInfo, error) {
+	p, err := a.registry.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	info := toPluginInfo(*p)
+	return &info, nil
+}
+
+// Enable enables a plugin by name.
+func (a *pluginRegistryAdapter) Enable(name string) error {
+	return a.registry.Enable(name)
+}
+
+// Disable disables a plugin by name.
+func (a *pluginRegistryAdapter) Disable(name string) error {
+	return a.registry.Disable(name)
+}
+
+// toPluginInfo converts a FrontendPlugin to handlers.FrontendPluginInfo.
+func toPluginInfo(p FrontendPlugin) handlers.FrontendPluginInfo {
+	return handlers.FrontendPluginInfo{
+		Name:        p.Name,
+		DisplayName: p.DisplayName,
+		Enabled:     p.Enabled,
+		BasePaths:   p.BasePaths,
+	}
+}
+
+// PluginGuard returns Gin middleware that blocks requests when the named plugin is disabled.
+// If the registry is nil, the guard is a no-op (all requests pass through).
+// This preserves backward compatibility for tests that do not set up a plugin registry.
+func PluginGuard(registry *FrontendPluginRegistry, pluginName string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// nil registry means all plugins enabled (backward compatibility).
+		if registry == nil {
+			c.Next()
+			return
+		}
+
+		if !registry.IsEnabled(pluginName) {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error":   "NotFound",
+				"message": fmt.Sprintf("The %s API is not enabled. Contact your platform administrator.", pluginName),
+			})
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/internal/server/plugin_registry_test.go
+++ b/internal/server/plugin_registry_test.go
@@ -1,0 +1,250 @@
+package server_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/config"
+	"github.com/piwi3910/netweave/internal/server"
+)
+
+func TestNewFrontendPluginRegistry_AllDisabledByDefault(t *testing.T) {
+	cfg := config.FrontendPlugins{}
+	registry := server.NewFrontendPluginRegistry(cfg)
+
+	plugins := registry.List()
+	require.Len(t, plugins, 5, "should have exactly 5 plugins")
+
+	for _, p := range plugins {
+		assert.False(t, p.Enabled, "plugin %s should be disabled by default", p.Name)
+	}
+}
+
+func TestNewFrontendPluginRegistry_ConfigOverrides(t *testing.T) {
+	cfg := config.FrontendPlugins{
+		O2IMS:   config.FrontendPluginConfig{Enabled: true},
+		GraphQL: config.FrontendPluginConfig{Enabled: true},
+	}
+	registry := server.NewFrontendPluginRegistry(cfg)
+
+	assert.True(t, registry.IsEnabled("o2ims"), "o2ims should be enabled from config")
+	assert.True(t, registry.IsEnabled("graphql"), "graphql should be enabled from config")
+	assert.False(t, registry.IsEnabled("o2dms"), "o2dms should remain disabled")
+	assert.False(t, registry.IsEnabled("o2smo"), "o2smo should remain disabled")
+	assert.False(t, registry.IsEnabled("tmforum"), "tmforum should remain disabled")
+}
+
+func TestFrontendPluginRegistry_IsEnabled_UnknownPlugin(t *testing.T) {
+	cfg := config.FrontendPlugins{}
+	registry := server.NewFrontendPluginRegistry(cfg)
+
+	assert.False(t, registry.IsEnabled("nonexistent"), "unknown plugin should return false")
+}
+
+func TestFrontendPluginRegistry_EnableDisable(t *testing.T) {
+	cfg := config.FrontendPlugins{}
+	registry := server.NewFrontendPluginRegistry(cfg)
+
+	require.False(t, registry.IsEnabled("o2ims"))
+
+	err := registry.Enable("o2ims")
+	require.NoError(t, err)
+	assert.True(t, registry.IsEnabled("o2ims"))
+
+	err = registry.Disable("o2ims")
+	require.NoError(t, err)
+	assert.False(t, registry.IsEnabled("o2ims"))
+}
+
+func TestFrontendPluginRegistry_Enable_UnknownPlugin(t *testing.T) {
+	cfg := config.FrontendPlugins{}
+	registry := server.NewFrontendPluginRegistry(cfg)
+
+	err := registry.Enable("nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, server.ErrPluginNotFound)
+}
+
+func TestFrontendPluginRegistry_Disable_UnknownPlugin(t *testing.T) {
+	cfg := config.FrontendPlugins{}
+	registry := server.NewFrontendPluginRegistry(cfg)
+
+	err := registry.Disable("nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, server.ErrPluginNotFound)
+}
+
+func TestFrontendPluginRegistry_List(t *testing.T) {
+	cfg := config.FrontendPlugins{
+		O2IMS: config.FrontendPluginConfig{Enabled: true},
+	}
+	registry := server.NewFrontendPluginRegistry(cfg)
+
+	plugins := registry.List()
+	require.Len(t, plugins, 5)
+
+	// Verify sorted by name.
+	names := make([]string, len(plugins))
+	for i, p := range plugins {
+		names[i] = p.Name
+	}
+	assert.Equal(t, []string{"graphql", "o2dms", "o2ims", "o2smo", "tmforum"}, names)
+
+	// Verify o2ims is enabled.
+	for _, p := range plugins {
+		if p.Name == "o2ims" {
+			assert.True(t, p.Enabled)
+			assert.Equal(t, "O2-IMS Infrastructure Inventory", p.DisplayName)
+			assert.Equal(t, []string{"/o2ims-infrastructureInventory/v1"}, p.BasePaths)
+		}
+	}
+}
+
+func TestFrontendPluginRegistry_Get(t *testing.T) {
+	cfg := config.FrontendPlugins{}
+	registry := server.NewFrontendPluginRegistry(cfg)
+
+	t.Run("returns existing plugin", func(t *testing.T) {
+		p, err := registry.Get("o2dms")
+		require.NoError(t, err)
+		assert.Equal(t, "o2dms", p.Name)
+		assert.Equal(t, "O2-DMS Deployment Management", p.DisplayName)
+		assert.Equal(t, []string{"/o2dms/v1"}, p.BasePaths)
+		assert.False(t, p.Enabled)
+	})
+
+	t.Run("returns error for unknown plugin", func(t *testing.T) {
+		_, err := registry.Get("nonexistent")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, server.ErrPluginNotFound)
+	})
+}
+
+func TestFrontendPluginRegistry_ConcurrentAccess(t *testing.T) {
+	cfg := config.FrontendPlugins{}
+	registry := server.NewFrontendPluginRegistry(cfg)
+
+	var wg sync.WaitGroup
+	pluginNames := []string{"o2ims", "o2dms", "o2smo", "tmforum", "graphql"}
+
+	// Spawn goroutines that concurrently enable and disable plugins.
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			name := pluginNames[idx%len(pluginNames)]
+
+			if idx%2 == 0 {
+				_ = registry.Enable(name)
+			} else {
+				_ = registry.Disable(name)
+			}
+			registry.IsEnabled(name)
+			registry.List()
+			_, _ = registry.Get(name)
+		}(i)
+	}
+
+	wg.Wait()
+	// No race condition panic means the test passes.
+}
+
+func TestPluginGuard_DisabledPlugin_Returns404(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := config.FrontendPlugins{}
+	registry := server.NewFrontendPluginRegistry(cfg)
+
+	router := gin.New()
+	router.GET("/test", server.PluginGuard(registry, "o2ims"), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var body map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "NotFound", body["error"])
+	assert.Contains(t, body["message"], "o2ims")
+	assert.Contains(t, body["message"], "not enabled")
+}
+
+func TestPluginGuard_EnabledPlugin_PassesThrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := config.FrontendPlugins{
+		O2IMS: config.FrontendPluginConfig{Enabled: true},
+	}
+	registry := server.NewFrontendPluginRegistry(cfg)
+
+	router := gin.New()
+	router.GET("/test", server.PluginGuard(registry, "o2ims"), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPluginGuard_NilRegistry_PassesThrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.GET("/test", server.PluginGuard(nil, "o2ims"), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPluginGuard_RuntimeToggle(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := config.FrontendPlugins{}
+	registry := server.NewFrontendPluginRegistry(cfg)
+
+	router := gin.New()
+	router.GET("/test", server.PluginGuard(registry, "tmforum"), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	// Initially disabled.
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// Enable at runtime.
+	err := registry.Enable("tmforum")
+	require.NoError(t, err)
+
+	req = httptest.NewRequest(http.MethodGet, "/test", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Disable again at runtime.
+	err = registry.Disable("tmforum")
+	require.NoError(t, err)
+
+	req = httptest.NewRequest(http.MethodGet, "/test", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -163,6 +163,7 @@ func (s *Server) setupRoutes() {
 	// Base path: /o2ims-infrastructureInventory/v1 (per O-RAN O2 IMS specification)
 	// Includes all features: basic operations, batch operations, and multi-tenancy support
 	v1 := s.router.Group("/o2ims-infrastructureInventory/v1")
+	v1.Use(PluginGuard(s.pluginRegistry, "o2ims"))
 	v1.Use(VersioningMiddleware(versionConfig))
 
 	// Apply tenant middleware if multi-tenancy is enabled

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -93,6 +93,9 @@ type Server struct {
 	adapterRegistry *backend.AdapterRegistry
 	backendStore    backend.Store
 
+	// Frontend plugin toggle system
+	pluginRegistry *FrontendPluginRegistry
+
 	// fullAuthStore is the full auth.Store for tenant lookups in wrapWithTenantContext.
 	fullAuthStore auth.Store
 
@@ -231,6 +234,9 @@ func New(
 		}
 	}
 
+	// Initialize frontend plugin registry
+	pluginReg := NewFrontendPluginRegistry(cfg.FrontendPlugins)
+
 	// Create server instance
 	srv := &Server{
 		config:           cfg,
@@ -247,6 +253,7 @@ func New(
 		AuthStore:        authStore,
 		authMw:           authMw,
 		auditLogger:      auditLogger,
+		pluginRegistry:   pluginReg,
 	}
 
 	// Setup middleware

--- a/internal/server/smo_routes.go
+++ b/internal/server/smo_routes.go
@@ -265,6 +265,7 @@ func (h *SMOHandler) getPluginFromQuery(c *gin.Context) (smo.Plugin, error) {
 func (s *Server) setupSMORoutes(smoHandler *SMOHandler) {
 	// O2-SMO API v1 routes (all features consolidated)
 	v1 := s.router.Group("/o2smo/v1")
+	v1.Use(PluginGuard(s.pluginRegistry, "o2smo"))
 
 	// Apply dynamic routing middleware to resolve SMO registry per-request.
 	v1.Use(s.smoAdapterMiddleware())

--- a/internal/server/test_helpers.go
+++ b/internal/server/test_helpers.go
@@ -117,3 +117,8 @@ func (s *Server) HTTPServer() *http.Server {
 func (s *Server) SetHTTPServer(srv *http.Server) {
 	s.httpServer = srv
 }
+
+// PluginRegistry returns the frontend plugin registry for testing.
+func (s *Server) PluginRegistry() *FrontendPluginRegistry {
+	return s.pluginRegistry
+}

--- a/internal/server/tmforum_routes.go
+++ b/internal/server/tmforum_routes.go
@@ -41,8 +41,12 @@ import (
 func (s *Server) setupTMForumRoutesEarly() {
 	s.logger.Info("Registering TMForum API route structure")
 
+	// Apply plugin guard to all TMForum routes
+	tmfGuard := PluginGuard(s.pluginRegistry, "tmforum")
+
 	// TMF639 - Resource Inventory Management API v4
 	tmf639 := s.router.Group("/tmf-api/resourceInventoryManagement/v4")
+	tmf639.Use(tmfGuard)
 	{
 		// Resource CRUD operations
 		tmf639.GET("/resource", s.tmfHandlerOrUnavailable(func(h *handlers.TMForumHandler) gin.HandlerFunc {
@@ -64,6 +68,7 @@ func (s *Server) setupTMForumRoutesEarly() {
 
 	// TMF638 - Service Inventory Management API v4
 	tmf638 := s.router.Group("/tmf-api/serviceInventoryManagement/v4")
+	tmf638.Use(tmfGuard)
 	{
 		// Service CRUD operations
 		tmf638.GET("/service", s.tmfHandlerOrUnavailable(func(h *handlers.TMForumHandler) gin.HandlerFunc {
@@ -85,6 +90,7 @@ func (s *Server) setupTMForumRoutesEarly() {
 
 	// TMF641 - Service Ordering Management API v4
 	tmf641 := s.router.Group("/tmf-api/serviceOrdering/v4")
+	tmf641.Use(tmfGuard)
 	{
 		// Service Order CRUD operations
 		tmf641.GET("/serviceOrder", s.tmfHandlerOrUnavailable(func(h *handlers.TMForumHandler) gin.HandlerFunc {
@@ -106,6 +112,7 @@ func (s *Server) setupTMForumRoutesEarly() {
 
 	// TMF688 - Event Management API v4
 	tmf688 := s.router.Group("/tmf-api/eventManagement/v4")
+	tmf688.Use(tmfGuard)
 	{
 		// Event operations
 		tmf688.GET("/event", s.tmfHandlerOrUnavailable(func(h *handlers.TMForumHandler) gin.HandlerFunc {
@@ -129,6 +136,7 @@ func (s *Server) setupTMForumRoutesEarly() {
 
 	// TMF642 - Alarm Management API v4
 	tmf642 := s.router.Group("/tmf-api/alarmManagement/v4")
+	tmf642.Use(tmfGuard)
 	{
 		// Alarm operations
 		tmf642.GET("/alarm", s.tmfHandlerOrUnavailable(func(h *handlers.TMForumHandler) gin.HandlerFunc {
@@ -147,6 +155,7 @@ func (s *Server) setupTMForumRoutesEarly() {
 
 	// TMF640 - Service Activation and Configuration API v4
 	tmf640 := s.router.Group("/tmf-api/serviceActivation/v4")
+	tmf640.Use(tmfGuard)
 	{
 		// Service activation operations
 		tmf640.GET("/serviceActivation", s.tmfHandlerOrUnavailable(func(h *handlers.TMForumHandler) gin.HandlerFunc {
@@ -162,6 +171,7 @@ func (s *Server) setupTMForumRoutesEarly() {
 
 	// TMF620 - Product Catalog Management API v4
 	tmf620 := s.router.Group("/tmf-api/productCatalog/v4")
+	tmf620.Use(tmfGuard)
 	{
 		// Product offering operations
 		tmf620.GET("/productOffering", s.tmfHandlerOrUnavailable(func(h *handlers.TMForumHandler) gin.HandlerFunc {


### PR DESCRIPTION
## Summary
- Adds a **frontend plugin registry** that allows platform admins to enable/disable the 5 toggleable API frontends (O2-IMS, O2-DMS, O2-SMO, TMForum, GraphQL) at runtime
- **All plugins are disabled by default** — platform admins must explicitly enable them via admin API
- Plugin guard middleware on each route group returns **404 Not Found** when the plugin is disabled
- A nil registry means all plugins are enabled (backward compatibility with existing tests)
- Admin API endpoints: `GET/PUT /admin/platform/plugins`, `GET/PUT /admin/platform/plugins/:name`

### New files:
- `internal/server/plugin_registry.go` — Thread-safe plugin registry + guard middleware
- `internal/server/plugin_registry_test.go` — Registry and guard tests (concurrent safety, enable/disable, config overrides)
- `internal/handlers/plugin_handler.go` — Admin API handler for plugin management
- `internal/handlers/plugin_handler_test.go` — Plugin handler tests

### Modified files:
- `internal/config/config.go` — Added `FrontendPlugins` config section
- `internal/server/server.go` — Plugin registry field + initialization
- `internal/server/routes.go` — O2-IMS plugin guard
- `internal/server/dms_routes.go` — O2-DMS plugin guard
- `internal/server/smo_routes.go` — O2-SMO plugin guard
- `internal/server/tmforum_routes.go` — TMForum plugin guard
- `internal/server/graphql_routes.go` — GraphQL plugin guard
- `internal/server/auth_routes.go` — Plugin admin API routes
- `internal/server/test_helpers.go` — PluginRegistry getter for tests

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes — all existing tests continue to work (nil registry = all enabled)
- [ ] Plugin guard returns 404 when disabled
- [ ] Plugin guard passes when enabled
- [ ] Enable/disable toggle works at runtime
- [ ] Concurrent access is thread-safe
- [ ] Admin API CRUD operations work

Resolves #392