### PR TITLE
[Fix] Fix all lint violations across Go and React code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.7.2
-          args: --timeout=5m --config=.golangci.yml
+          args: --timeout=10m --config=.golangci.yml
 
       - name: Check go mod tidy
         run: |

--- a/internal/middleware/openapi_validation_test.go
+++ b/internal/middleware/openapi_validation_test.go
@@ -619,7 +619,7 @@ func TestOpenAPIValidator_MaxBodySize(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/o2ims/v1/subscriptions", bytes.NewReader([]byte("small")))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Content-Length", "10000") // Claim 10KB size
-		req.ContentLength = 10000                  // Set ContentLength field
+		req.ContentLength = 10000                 // Set ContentLength field
 		w := httptest.NewRecorder()
 
 		router.ServeHTTP(w, req)
@@ -716,7 +716,7 @@ func TestOpenAPIValidator_MaxBodySize(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/o2ims/v1/subscriptions", bytes.NewReader(largeBody))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Content-Length", "50") // Lie about the size
-		req.ContentLength = 50                  // Set ContentLength field to small value
+		req.ContentLength = 50                 // Set ContentLength field to small value
 		w := httptest.NewRecorder()
 
 		router.ServeHTTP(w, req)

--- a/web/admin-portal/src/app/(dashboard)/infrastructure/dms/[id]/page.tsx
+++ b/web/admin-portal/src/app/(dashboard)/infrastructure/dms/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft, Save } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -34,7 +34,7 @@ export default function DMSDetailPage() {
     description: "",
   });
 
-  async function load() {
+  const load = useCallback(async () => {
     try {
       const backendData = await getBackend(backendId);
       setBackend(backendData);
@@ -47,11 +47,11 @@ export default function DMSDetailPage() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [backendId]);
 
   useEffect(() => {
     load();
-  }, [backendId]);
+  }, [load]);
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();

--- a/web/admin-portal/src/app/(dashboard)/infrastructure/o-clouds/[id]/page.tsx
+++ b/web/admin-portal/src/app/(dashboard)/infrastructure/o-clouds/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft, Save, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -45,7 +45,7 @@ export default function OCloudDetailPage() {
   const [showAddDms, setShowAddDms] = useState(false);
   const [selectedDms, setSelectedDms] = useState("");
 
-  async function load() {
+  const load = useCallback(async () => {
     try {
       const [backendData, dmsData, allDmsData] = await Promise.all([
         getBackend(backendId),
@@ -64,11 +64,11 @@ export default function OCloudDetailPage() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [backendId]);
 
   useEffect(() => {
     load();
-  }, [backendId]);
+  }, [load]);
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Fix `gofmt -s` trailing whitespace alignment in `openapi_validation_test.go` (root cause of CI `Lint Code` failure on main)
- Fix `react-hooks/exhaustive-deps` ESLint warnings in DMS and O-Cloud detail pages by wrapping async `load` functions in `useCallback`

## Changes
| File | Fix |
|------|-----|
| `internal/middleware/openapi_validation_test.go` | Remove extra trailing spaces before comments |
| `web/admin-portal/.../dms/[id]/page.tsx` | Wrap `load()` in `useCallback` with `[backendId]` dependency |
| `web/admin-portal/.../o-clouds/[id]/page.tsx` | Wrap `load()` in `useCallback` with `[backendId]` dependency |

## Test plan
- [x] `gofmt -s -l .` returns no output (clean)
- [x] `golangci-lint run ./...` returns 0 issues
- [x] `next lint` returns no warnings or errors
- [x] `go test -short ./internal/middleware/...` passes
- [x] `go mod tidy` produces no changes

Resolves #418