### PR TITLE
Add certificate expiry monitor and webhook notifier

### DIFF
--- a/internal/certlifecycle/monitor.go
+++ b/internal/certlifecycle/monitor.go
@@ -1,0 +1,214 @@
+package certlifecycle
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// DefaultScanInterval is the default interval between certificate scan loops.
+	DefaultScanInterval = 5 * time.Minute
+
+	// DefaultRenewalWindow is the default window before expiry to trigger renewal.
+	DefaultRenewalWindow = 720 * time.Hour // 30 days.
+)
+
+// MonitorConfig holds configuration for the certificate expiry monitor.
+type MonitorConfig struct {
+	// ScanInterval is how often the monitor scans for expiring/expired certs.
+	ScanInterval time.Duration
+
+	// RenewalWindow is how far before expiry to mark certificates as expiring_soon.
+	RenewalWindow time.Duration
+
+	// Store provides certificate metadata persistence.
+	Store Store
+
+	// Logger provides structured logging.
+	Logger *zap.Logger
+}
+
+// Monitor watches for certificate expiry and status transitions.
+// It runs periodic scans to detect certificates that are expiring soon or
+// have already expired, updating their status and invoking callbacks.
+type Monitor struct {
+	scanInterval  time.Duration
+	renewalWindow time.Duration
+	store         Store
+	logger        *zap.Logger
+	stopCh        chan struct{}
+	wg            sync.WaitGroup
+
+	// OnExpiringSoon is called when a certificate transitions to expiring_soon.
+	OnExpiringSoon func(ctx context.Context, meta *CertificateMetadata)
+
+	// OnExpired is called when a certificate transitions to expired.
+	OnExpired func(ctx context.Context, meta *CertificateMetadata)
+}
+
+// NewMonitor creates a new certificate expiry monitor.
+func NewMonitor(cfg *MonitorConfig) *Monitor {
+	scanInterval := cfg.ScanInterval
+	if scanInterval == 0 {
+		scanInterval = DefaultScanInterval
+	}
+
+	renewalWindow := cfg.RenewalWindow
+	if renewalWindow == 0 {
+		renewalWindow = DefaultRenewalWindow
+	}
+
+	return &Monitor{
+		scanInterval:  scanInterval,
+		renewalWindow: renewalWindow,
+		store:         cfg.Store,
+		logger:        cfg.Logger,
+		stopCh:        make(chan struct{}),
+	}
+}
+
+// Start begins the periodic certificate scan loop.
+// It blocks until Stop is called or the context is canceled.
+func (m *Monitor) Start(ctx context.Context) error {
+	m.logger.Info("starting certificate monitor",
+		zap.Duration("scan_interval", m.scanInterval),
+		zap.Duration("renewal_window", m.renewalWindow))
+
+	m.wg.Add(1)
+	go m.scanLoop(ctx)
+
+	// Wait for shutdown signal.
+	select {
+	case <-ctx.Done():
+		return m.Stop()
+	case <-m.stopCh:
+		return nil
+	}
+}
+
+// Stop signals the monitor to stop and waits for it to finish.
+func (m *Monitor) Stop() error {
+	m.logger.Info("stopping certificate monitor")
+	close(m.stopCh)
+	m.wg.Wait()
+	m.logger.Info("certificate monitor stopped")
+	return nil
+}
+
+// scanLoop runs the periodic scan.
+func (m *Monitor) scanLoop(ctx context.Context) {
+	defer m.wg.Done()
+
+	// Run initial scan immediately.
+	m.runScan(ctx)
+
+	ticker := time.NewTicker(m.scanInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.runScan(ctx)
+		}
+	}
+}
+
+// runScan performs a single scan cycle for expiring and expired certificates.
+func (m *Monitor) runScan(ctx context.Context) {
+	start := time.Now()
+	m.logger.Debug("starting certificate scan")
+
+	m.scanExpiringSoon(ctx)
+	m.scanExpired(ctx)
+	m.updateStatusGauge(ctx)
+
+	duration := time.Since(start).Seconds()
+	RecordMonitorLoop(duration)
+
+	m.logger.Debug("certificate scan complete",
+		zap.Float64("duration_seconds", duration))
+}
+
+// scanExpiringSoon finds active certificates within the renewal window and marks them.
+func (m *Monitor) scanExpiringSoon(ctx context.Context) {
+	threshold := time.Now().Add(m.renewalWindow)
+
+	certs, err := m.store.ListExpiring(ctx, threshold)
+	if err != nil {
+		m.logger.Error("failed to list expiring certificates", zap.Error(err))
+		return
+	}
+
+	for _, cert := range certs {
+		if err := m.store.UpdateStatus(ctx, cert.SerialNumber, StatusExpiringSoon); err != nil {
+			m.logger.Error("failed to update certificate status to expiring_soon",
+				zap.String("serial", cert.SerialNumber),
+				zap.Error(err))
+			continue
+		}
+
+		m.logger.Info("certificate marked as expiring_soon",
+			zap.String("serial", cert.SerialNumber),
+			zap.Time("expires_at", cert.ExpiresAt))
+
+		if m.OnExpiringSoon != nil {
+			cert.Status = StatusExpiringSoon
+			m.OnExpiringSoon(ctx, cert)
+		}
+	}
+}
+
+// scanExpired finds active or expiring_soon certificates past their expiry and marks them.
+func (m *Monitor) scanExpired(ctx context.Context) {
+	now := time.Now()
+
+	// Check both active and expiring_soon for expired certs.
+	for _, status := range []CertificateStatus{StatusActive, StatusExpiringSoon} {
+		certs, err := m.store.ListByStatus(ctx, status)
+		if err != nil {
+			m.logger.Error("failed to list certificates by status",
+				zap.String("status", string(status)),
+				zap.Error(err))
+			continue
+		}
+
+		for _, cert := range certs {
+			if cert.ExpiresAt.After(now) {
+				continue
+			}
+
+			if err := m.store.UpdateStatus(ctx, cert.SerialNumber, StatusExpired); err != nil {
+				m.logger.Error("failed to update certificate status to expired",
+					zap.String("serial", cert.SerialNumber),
+					zap.Error(err))
+				continue
+			}
+
+			m.logger.Info("certificate marked as expired",
+				zap.String("serial", cert.SerialNumber),
+				zap.Time("expires_at", cert.ExpiresAt))
+
+			if m.OnExpired != nil {
+				cert.Status = StatusExpired
+				m.OnExpired(ctx, cert)
+			}
+		}
+	}
+}
+
+// updateStatusGauge refreshes the by-status gauge from the store.
+func (m *Monitor) updateStatusGauge(ctx context.Context) {
+	counts, err := m.store.CountByStatus(ctx)
+	if err != nil {
+		m.logger.Error("failed to count certificates by status", zap.Error(err))
+		return
+	}
+	RecordCertsByStatus(counts)
+}

--- a/internal/certlifecycle/monitor_test.go
+++ b/internal/certlifecycle/monitor_test.go
@@ -1,0 +1,332 @@
+package certlifecycle_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/piwi3910/netweave/internal/certlifecycle"
+)
+
+// certMeta is a type alias to keep mock store field declarations under line length.
+type certMeta = certlifecycle.CertificateMetadata
+
+// certStatus is a type alias for certificate status.
+type certStatus = certlifecycle.CertificateStatus
+
+// mockStore implements certlifecycle.Store for testing the monitor.
+type mockStore struct {
+	mu            sync.Mutex
+	certs         map[string]*certMeta
+	statusUpdates []statusUpdate
+}
+
+type statusUpdate struct {
+	SerialNumber string
+	Status       certlifecycle.CertificateStatus
+}
+
+func newMockStore() *mockStore {
+	return &mockStore{
+		certs: make(map[string]*certMeta),
+	}
+}
+
+func (m *mockStore) Create(_ context.Context, meta *certMeta) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.certs[meta.SerialNumber] = meta
+	return nil
+}
+
+func (m *mockStore) Get(
+	_ context.Context, serialNumber string,
+) (*certMeta, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cert, ok := m.certs[serialNumber]
+	if !ok {
+		return nil, certlifecycle.ErrCertificateNotFound
+	}
+	return cert, nil
+}
+
+func (m *mockStore) UpdateStatus(
+	_ context.Context, serialNumber string, status certStatus,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.statusUpdates = append(m.statusUpdates, statusUpdate{
+		serialNumber, status,
+	})
+	if cert, ok := m.certs[serialNumber]; ok {
+		cert.Status = status
+	}
+	return nil
+}
+
+func (m *mockStore) MarkRevoked(
+	_ context.Context, _ string,
+) error {
+	return nil
+}
+
+func (m *mockStore) MarkRenewed(
+	_ context.Context, _, _ string,
+) error {
+	return nil
+}
+
+func (m *mockStore) MarkRenewalFailed(
+	_ context.Context, _, _ string, _ time.Time,
+) error {
+	return nil
+}
+
+func (m *mockStore) ListByTenant(
+	_ context.Context, _ string,
+) ([]*certMeta, error) {
+	return nil, nil
+}
+
+func (m *mockStore) ListByUser(
+	_ context.Context, _ string,
+) ([]*certMeta, error) {
+	return nil, nil
+}
+
+func (m *mockStore) ListByStatus(
+	_ context.Context, status certStatus,
+) ([]*certMeta, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []*certMeta
+	for _, cert := range m.certs {
+		if cert.Status == status {
+			result = append(result, cert)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStore) ListExpiring(
+	_ context.Context, before time.Time,
+) ([]*certMeta, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []*certMeta
+	for _, cert := range m.certs {
+		if cert.Status == certlifecycle.StatusActive &&
+			cert.ExpiresAt.Before(before) {
+			result = append(result, cert)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStore) ListRenewalFailed(
+	_ context.Context, _ time.Time,
+) ([]*certMeta, error) {
+	return nil, nil
+}
+
+func (m *mockStore) CountByStatus(
+	_ context.Context,
+) (map[certStatus]int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	counts := make(map[certStatus]int64)
+	for _, cert := range m.certs {
+		counts[cert.Status]++
+	}
+	return counts, nil
+}
+
+func (m *mockStore) Delete(_ context.Context, serialNumber string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.certs, serialNumber)
+	return nil
+}
+
+func (m *mockStore) Close() error { return nil }
+
+func (m *mockStore) Ping(_ context.Context) error { return nil }
+
+func (m *mockStore) getStatusUpdates() []statusUpdate {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]statusUpdate, len(m.statusUpdates))
+	copy(result, m.statusUpdates)
+	return result
+}
+
+// TestMonitor_ScanExpiringSoon verifies that the monitor marks active certs as expiring_soon.
+func TestMonitor_ScanExpiringSoon(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	// Add an active cert expiring within the renewal window.
+	store.certs["serial-1"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "serial-1",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusActive,
+		ExpiresAt:    time.Now().Add(10 * 24 * time.Hour), // 10 days from now.
+	}
+	// Add an active cert NOT expiring soon.
+	store.certs["serial-2"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "serial-2",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusActive,
+		ExpiresAt:    time.Now().Add(60 * 24 * time.Hour), // 60 days from now.
+	}
+
+	callbackCh := make(chan string, 1)
+	var once sync.Once
+
+	monitor := certlifecycle.NewMonitor(&certlifecycle.MonitorConfig{
+		ScanInterval:  50 * time.Millisecond,
+		RenewalWindow: 30 * 24 * time.Hour,
+		Store:         store,
+		Logger:        logger,
+	})
+	monitor.OnExpiringSoon = func(_ context.Context, meta *certlifecycle.CertificateMetadata) {
+		once.Do(func() {
+			callbackCh <- meta.SerialNumber
+		})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		_ = monitor.Start(ctx)
+		close(done)
+	}()
+
+	callbackSerial := <-callbackCh
+	cancel()
+	<-done
+
+	assert.Equal(t, "serial-1", callbackSerial)
+
+	updates := store.getStatusUpdates()
+	require.NotEmpty(t, updates)
+	assert.Equal(t, "serial-1", updates[0].SerialNumber)
+	assert.Equal(t, certlifecycle.StatusExpiringSoon, updates[0].Status)
+}
+
+// TestMonitor_ScanExpired verifies that the monitor marks expired certs.
+func TestMonitor_ScanExpired(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	// Add a cert that has already expired.
+	store.certs["serial-expired"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "serial-expired",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusActive,
+		ExpiresAt:    time.Now().Add(-1 * time.Hour), // 1 hour ago.
+	}
+
+	callbackCh := make(chan string, 1)
+	var once sync.Once
+
+	monitor := certlifecycle.NewMonitor(&certlifecycle.MonitorConfig{
+		ScanInterval:  50 * time.Millisecond,
+		RenewalWindow: 30 * 24 * time.Hour,
+		Store:         store,
+		Logger:        logger,
+	})
+	monitor.OnExpired = func(_ context.Context, meta *certlifecycle.CertificateMetadata) {
+		once.Do(func() {
+			callbackCh <- meta.SerialNumber
+		})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		_ = monitor.Start(ctx)
+		close(done)
+	}()
+
+	callbackSerial := <-callbackCh
+	cancel()
+	<-done
+
+	assert.Equal(t, "serial-expired", callbackSerial)
+}
+
+// TestMonitor_StopGracefully verifies the monitor stops cleanly.
+func TestMonitor_StopGracefully(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	monitor := certlifecycle.NewMonitor(&certlifecycle.MonitorConfig{
+		ScanInterval:  1 * time.Second,
+		RenewalWindow: 30 * 24 * time.Hour,
+		Store:         store,
+		Logger:        logger,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		_ = monitor.Start(ctx)
+		close(done)
+	}()
+
+	// Give it time to start.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// Stopped successfully.
+	case <-time.After(2 * time.Second):
+		t.Fatal("monitor did not stop within timeout")
+	}
+}
+
+// TestMonitor_NoCertsNoError verifies the monitor handles empty stores.
+func TestMonitor_NoCertsNoError(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	monitor := certlifecycle.NewMonitor(&certlifecycle.MonitorConfig{
+		ScanInterval:  50 * time.Millisecond,
+		RenewalWindow: 30 * 24 * time.Hour,
+		Store:         store,
+		Logger:        logger,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := monitor.Start(ctx)
+	require.NoError(t, err)
+
+	updates := store.getStatusUpdates()
+	assert.Empty(t, updates)
+}
+
+// TestMonitor_DefaultConfig verifies default values are applied.
+func TestMonitor_DefaultConfig(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	monitor := certlifecycle.NewMonitor(&certlifecycle.MonitorConfig{
+		Store:  store,
+		Logger: logger,
+	})
+
+	require.NotNil(t, monitor)
+}

--- a/internal/certlifecycle/notifier.go
+++ b/internal/certlifecycle/notifier.go
@@ -1,0 +1,245 @@
+package certlifecycle
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// CertEventType identifies the type of certificate lifecycle event.
+type CertEventType string
+
+const (
+	// EventCertIssued indicates a new certificate was issued.
+	EventCertIssued CertEventType = "certificate.issued"
+
+	// EventCertRenewed indicates a certificate was successfully renewed.
+	EventCertRenewed CertEventType = "certificate.renewed"
+
+	// EventCertRenewalFailed indicates a certificate renewal attempt failed.
+	EventCertRenewalFailed CertEventType = "certificate.renewal_failed"
+
+	// EventCertExpiringSoon indicates a certificate is approaching expiry.
+	EventCertExpiringSoon CertEventType = "certificate.expiring_soon"
+
+	// EventCertExpired indicates a certificate has expired.
+	EventCertExpired CertEventType = "certificate.expired"
+
+	// EventCertRevoked indicates a certificate was revoked.
+	EventCertRevoked CertEventType = "certificate.revoked"
+)
+
+const (
+	// DefaultNotifierMaxRetries is the default max retry attempts for webhook delivery.
+	DefaultNotifierMaxRetries = 3
+
+	// DefaultNotifierRetryBackoff is the base backoff between retries.
+	DefaultNotifierRetryBackoff = 1 * time.Second
+
+	// DefaultNotifierTimeout is the default HTTP request timeout.
+	DefaultNotifierTimeout = 10 * time.Second
+)
+
+// CertEvent represents a certificate lifecycle event for webhook notification.
+type CertEvent struct {
+	EventType    CertEventType `json:"event_type"`
+	Timestamp    time.Time     `json:"timestamp"`
+	SerialNumber string        `json:"serial_number"`
+	CommonName   string        `json:"common_name"`
+	TenantID     string        `json:"tenant_id"`
+	UserID       string        `json:"user_id"`
+	Status       string        `json:"status"`
+	ExpiresAt    time.Time     `json:"expires_at"`
+	RenewedFrom  string        `json:"renewed_from,omitempty"`
+	Error        string        `json:"error,omitempty"`
+}
+
+// NotifierConfig holds configuration for the webhook notifier.
+type NotifierConfig struct {
+	// WebhookURL is the target URL for event notifications.
+	WebhookURL string
+
+	// HMACSecret is the secret for HMAC-SHA256 signature generation.
+	HMACSecret string
+
+	// MaxRetries is the maximum number of delivery retry attempts.
+	MaxRetries int
+
+	// RetryBackoff is the base backoff duration that doubles each attempt.
+	RetryBackoff time.Duration
+
+	// Timeout is the HTTP request timeout.
+	Timeout time.Duration
+
+	// Logger provides structured logging.
+	Logger *zap.Logger
+}
+
+// Notifier delivers certificate lifecycle events to a webhook endpoint.
+type Notifier struct {
+	webhookURL   string
+	hmacSecret   string
+	maxRetries   int
+	retryBackoff time.Duration
+	httpClient   *http.Client
+	logger       *zap.Logger
+}
+
+// NewNotifier creates a new webhook notifier.
+func NewNotifier(cfg *NotifierConfig) (*Notifier, error) {
+	if cfg.WebhookURL == "" {
+		return nil, fmt.Errorf("webhook URL is required")
+	}
+	if cfg.Logger == nil {
+		return nil, fmt.Errorf("logger is required")
+	}
+
+	maxRetries := cfg.MaxRetries
+	if maxRetries == 0 {
+		maxRetries = DefaultNotifierMaxRetries
+	}
+
+	retryBackoff := cfg.RetryBackoff
+	if retryBackoff == 0 {
+		retryBackoff = DefaultNotifierRetryBackoff
+	}
+
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = DefaultNotifierTimeout
+	}
+
+	return &Notifier{
+		webhookURL:   cfg.WebhookURL,
+		hmacSecret:   cfg.HMACSecret,
+		maxRetries:   maxRetries,
+		retryBackoff: retryBackoff,
+		httpClient:   &http.Client{Timeout: timeout},
+		logger:       cfg.Logger,
+	}, nil
+}
+
+// Notify sends a certificate event to the webhook endpoint without retries.
+func (n *Notifier) Notify(ctx context.Context, event *CertEvent) error {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal event: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.webhookURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Event-Type", string(event.EventType))
+
+	if n.hmacSecret != "" {
+		signature := n.generateHMAC(payload)
+		req.Header.Set("X-Signature-SHA256", signature)
+	}
+
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			n.logger.Warn("failed to close response body", zap.Error(closeErr))
+		}
+	}()
+
+	// Drain response body to allow connection reuse.
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook returned non-2xx status: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// NotifyWithRetry sends an event with exponential backoff retries.
+func (n *Notifier) NotifyWithRetry(ctx context.Context, event *CertEvent) error {
+	var lastErr error
+
+	for attempt := 0; attempt <= n.maxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := exponentialBackoff(n.retryBackoff, attempt)
+
+			n.logger.Info("retrying webhook notification",
+				zap.String("event_type", string(event.EventType)),
+				zap.String("serial", event.SerialNumber),
+				zap.Int("attempt", attempt),
+				zap.Duration("backoff", backoff))
+
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return fmt.Errorf("context canceled during retry: %w", ctx.Err())
+			}
+		}
+
+		if err := n.Notify(ctx, event); err != nil {
+			lastErr = err
+			n.logger.Warn("webhook notification failed",
+				zap.String("event_type", string(event.EventType)),
+				zap.String("serial", event.SerialNumber),
+				zap.Int("attempt", attempt),
+				zap.Error(err))
+			continue
+		}
+
+		n.logger.Info("webhook notification delivered",
+			zap.String("event_type", string(event.EventType)),
+			zap.String("serial", event.SerialNumber),
+			zap.Int("attempts", attempt+1))
+		return nil
+	}
+
+	return fmt.Errorf("max retries exceeded: %w", lastErr)
+}
+
+// exponentialBackoff computes the backoff duration for a given retry attempt.
+// Attempt 1 = base, attempt 2 = 2*base, attempt 3 = 4*base, etc.
+func exponentialBackoff(base time.Duration, attempt int) time.Duration {
+	backoff := base
+	for i := 1; i < attempt; i++ {
+		backoff *= 2
+	}
+	return backoff
+}
+
+// generateHMAC creates an HMAC-SHA256 signature for the payload.
+func (n *Notifier) generateHMAC(payload []byte) string {
+	mac := hmac.New(sha256.New, []byte(n.hmacSecret))
+	mac.Write(payload)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// NewCertEvent creates a CertEvent from certificate metadata.
+func NewCertEvent(eventType CertEventType, meta *CertificateMetadata) *CertEvent {
+	return &CertEvent{
+		EventType:    eventType,
+		Timestamp:    time.Now().UTC(),
+		SerialNumber: meta.SerialNumber,
+		CommonName:   meta.CommonName,
+		TenantID:     meta.TenantID,
+		UserID:       meta.UserID,
+		Status:       string(meta.Status),
+		ExpiresAt:    meta.ExpiresAt,
+		RenewedFrom:  meta.RenewedFrom,
+		Error:        meta.LastError,
+	}
+}

--- a/internal/certlifecycle/notifier_test.go
+++ b/internal/certlifecycle/notifier_test.go
@@ -1,0 +1,290 @@
+package certlifecycle_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/piwi3910/netweave/internal/certlifecycle"
+)
+
+// TestNotifier_Notify verifies basic webhook delivery.
+func TestNotifier_Notify(t *testing.T) {
+	var receivedBody []byte
+	var receivedEventType string
+	var receivedContentType string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedContentType = r.Header.Get("Content-Type")
+		receivedEventType = r.Header.Get("X-Event-Type")
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := zaptest.NewLogger(t)
+	notifier, err := certlifecycle.NewNotifier(&certlifecycle.NotifierConfig{
+		WebhookURL: server.URL,
+		Logger:     logger,
+	})
+	require.NoError(t, err)
+
+	event := &certlifecycle.CertEvent{
+		EventType:    certlifecycle.EventCertIssued,
+		Timestamp:    time.Now().UTC(),
+		SerialNumber: "serial-123",
+		CommonName:   "test.example.com",
+		TenantID:     "tenant-1",
+		Status:       "active",
+		ExpiresAt:    time.Now().Add(24 * time.Hour),
+	}
+
+	err = notifier.Notify(context.Background(), event)
+	require.NoError(t, err)
+
+	assert.Equal(t, "application/json", receivedContentType)
+	assert.Equal(t, "certificate.issued", receivedEventType)
+
+	var decoded certlifecycle.CertEvent
+	require.NoError(t, json.Unmarshal(receivedBody, &decoded))
+	assert.Equal(t, "serial-123", decoded.SerialNumber)
+	assert.Equal(t, "test.example.com", decoded.CommonName)
+}
+
+// TestNotifier_HMACSignature verifies HMAC-SHA256 signing.
+func TestNotifier_HMACSignature(t *testing.T) {
+	secret := "test-hmac-secret"
+	var receivedSignature string
+	var receivedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedSignature = r.Header.Get("X-Signature-SHA256")
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := zaptest.NewLogger(t)
+	notifier, err := certlifecycle.NewNotifier(&certlifecycle.NotifierConfig{
+		WebhookURL: server.URL,
+		HMACSecret: secret,
+		Logger:     logger,
+	})
+	require.NoError(t, err)
+
+	event := &certlifecycle.CertEvent{
+		EventType:    certlifecycle.EventCertRevoked,
+		SerialNumber: "serial-456",
+	}
+
+	err = notifier.Notify(context.Background(), event)
+	require.NoError(t, err)
+
+	// Verify HMAC signature.
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(receivedBody)
+	expectedSig := hex.EncodeToString(mac.Sum(nil))
+
+	assert.Equal(t, expectedSig, receivedSignature)
+	assert.NotEmpty(t, receivedSignature)
+}
+
+// TestNotifier_NoHMACWhenSecretEmpty verifies no signature header without secret.
+func TestNotifier_NoHMACWhenSecretEmpty(t *testing.T) {
+	var receivedSignature string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedSignature = r.Header.Get("X-Signature-SHA256")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := zaptest.NewLogger(t)
+	notifier, err := certlifecycle.NewNotifier(&certlifecycle.NotifierConfig{
+		WebhookURL: server.URL,
+		Logger:     logger,
+	})
+	require.NoError(t, err)
+
+	event := &certlifecycle.CertEvent{
+		EventType:    certlifecycle.EventCertIssued,
+		SerialNumber: "serial-789",
+	}
+
+	err = notifier.Notify(context.Background(), event)
+	require.NoError(t, err)
+	assert.Empty(t, receivedSignature)
+}
+
+// TestNotifier_NonSuccessStatus verifies error on non-2xx response.
+func TestNotifier_NonSuccessStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	logger := zaptest.NewLogger(t)
+	notifier, err := certlifecycle.NewNotifier(&certlifecycle.NotifierConfig{
+		WebhookURL: server.URL,
+		Logger:     logger,
+	})
+	require.NoError(t, err)
+
+	event := &certlifecycle.CertEvent{
+		EventType:    certlifecycle.EventCertExpired,
+		SerialNumber: "serial-fail",
+	}
+
+	err = notifier.Notify(context.Background(), event)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-2xx status: 500")
+}
+
+// TestNotifier_NotifyWithRetry verifies retry behavior on transient failures.
+func TestNotifier_NotifyWithRetry(t *testing.T) {
+	var attempts atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := attempts.Add(1)
+		if count <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := zaptest.NewLogger(t)
+	notifier, err := certlifecycle.NewNotifier(&certlifecycle.NotifierConfig{
+		WebhookURL:   server.URL,
+		MaxRetries:   3,
+		RetryBackoff: 10 * time.Millisecond,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	event := &certlifecycle.CertEvent{
+		EventType:    certlifecycle.EventCertRenewed,
+		SerialNumber: "serial-retry",
+	}
+
+	err = notifier.NotifyWithRetry(context.Background(), event)
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), attempts.Load())
+}
+
+// TestNotifier_NotifyWithRetryExhausted verifies error after all retries fail.
+func TestNotifier_NotifyWithRetryExhausted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	logger := zaptest.NewLogger(t)
+	notifier, err := certlifecycle.NewNotifier(&certlifecycle.NotifierConfig{
+		WebhookURL:   server.URL,
+		MaxRetries:   2,
+		RetryBackoff: 10 * time.Millisecond,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	event := &certlifecycle.CertEvent{
+		EventType:    certlifecycle.EventCertRenewalFailed,
+		SerialNumber: "serial-exhausted",
+	}
+
+	err = notifier.NotifyWithRetry(context.Background(), event)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max retries exceeded")
+}
+
+// TestNotifier_ContextCancellation verifies retry stops on context cancellation.
+func TestNotifier_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	logger := zaptest.NewLogger(t)
+	notifier, err := certlifecycle.NewNotifier(&certlifecycle.NotifierConfig{
+		WebhookURL:   server.URL,
+		MaxRetries:   10,
+		RetryBackoff: 5 * time.Second, // Long backoff so cancellation triggers first.
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	event := &certlifecycle.CertEvent{
+		EventType:    certlifecycle.EventCertExpiringSoon,
+		SerialNumber: "serial-cancel",
+	}
+
+	err = notifier.NotifyWithRetry(ctx, event)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context")
+}
+
+// TestNewNotifier_Validation verifies constructor validation.
+func TestNewNotifier_Validation(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	t.Run("missing webhook URL", func(t *testing.T) {
+		_, err := certlifecycle.NewNotifier(&certlifecycle.NotifierConfig{
+			Logger: logger,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "webhook URL")
+	})
+
+	t.Run("missing logger", func(t *testing.T) {
+		_, err := certlifecycle.NewNotifier(&certlifecycle.NotifierConfig{
+			WebhookURL: "https://example.com/webhook",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "logger")
+	})
+}
+
+// TestNewCertEvent verifies the event constructor helper.
+func TestNewCertEvent(t *testing.T) {
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "serial-100",
+		CommonName:   "app.example.com",
+		TenantID:     "tenant-1",
+		UserID:       "user-1",
+		Status:       certlifecycle.StatusExpiringSoon,
+		ExpiresAt:    time.Now().Add(5 * 24 * time.Hour),
+		RenewedFrom:  "serial-99",
+		LastError:    "renewal failed",
+	}
+
+	event := certlifecycle.NewCertEvent(certlifecycle.EventCertExpiringSoon, meta)
+
+	assert.Equal(t, certlifecycle.EventCertExpiringSoon, event.EventType)
+	assert.Equal(t, "serial-100", event.SerialNumber)
+	assert.Equal(t, "app.example.com", event.CommonName)
+	assert.Equal(t, "tenant-1", event.TenantID)
+	assert.Equal(t, "user-1", event.UserID)
+	assert.Equal(t, "expiring_soon", event.Status)
+	assert.Equal(t, "serial-99", event.RenewedFrom)
+	assert.Equal(t, "renewal failed", event.Error)
+	assert.False(t, event.Timestamp.IsZero())
+}


### PR DESCRIPTION
## Summary

- Add `Monitor` that periodically scans for expiring/expired certificates, transitions their status, and fires callbacks
- Add `Notifier` for webhook delivery of 6 certificate lifecycle event types with HMAC-SHA256 signing and exponential backoff retries
- Add `NewCertEvent` helper to create events from certificate metadata
- Comprehensive tests with mock store and httptest.Server (84.9% coverage)

This is **Phase 2** of the certificate lifecycle automation epic (#408), building on Phase 1 (#420).

**Depends on:** PR #420 (Phase 1: metadata store + metrics)

## Test plan

- [x] `go test -race -count=1 ./internal/certlifecycle/...` — all tests pass, no races
- [x] `golangci-lint run ./...` — zero issues
- [x] `gofmt -s -l .` — no formatting issues
- [x] Coverage ≥ 80% (84.9%)
- [ ] CI pipeline passes all checks

Resolves #410
Resolves #411