### PR TITLE
[Feature] Add auto renewal service, manager orchestrator, and admin API (#409)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/piwi3910/netweave/internal/auth"
 	"github.com/piwi3910/netweave/internal/backend"
+	"github.com/piwi3910/netweave/internal/certlifecycle"
 	"github.com/piwi3910/netweave/internal/config"
 	"github.com/piwi3910/netweave/internal/database"
 	"github.com/piwi3910/netweave/internal/dms/adapters/helm"
@@ -53,6 +54,7 @@ import (
 	"github.com/piwi3910/netweave/internal/observability"
 	"github.com/piwi3910/netweave/internal/server"
 	"github.com/piwi3910/netweave/internal/storage"
+	vaultpkg "github.com/piwi3910/netweave/internal/vault"
 )
 
 const (
@@ -141,6 +143,7 @@ type ApplicationComponents struct {
 	healthChecker   *observability.HealthChecker // Health and readiness checks
 	server          *server.Server
 	authStore       server.AuthStore
+	certManager     *certlifecycle.Manager // Certificate lifecycle manager (nil if disabled)
 }
 
 // NewApplicationComponentsForTest creates an ApplicationComponents instance for testing.
@@ -173,6 +176,12 @@ func NewApplicationComponentsForTestFull(
 func (c *ApplicationComponents) Close(logger *zap.Logger) error {
 	var closeErrors []error
 
+	if c.certManager != nil {
+		if err := c.certManager.Stop(); err != nil {
+			logger.Warn("failed to stop certificate lifecycle manager", zap.Error(err))
+			closeErrors = append(closeErrors, fmt.Errorf("cert manager: %w", err))
+		}
+	}
 	if c.adapterRegistry != nil {
 		if err := c.adapterRegistry.Close(); err != nil {
 			logger.Warn("failed to close adapter registry", zap.Error(err))
@@ -473,6 +482,16 @@ func initializeComponents(cfg *config.Config, logger *zap.Logger) (*ApplicationC
 		return nil, fmt.Errorf("failed to initialize DMS: %w", dmsErr)
 	}
 
+	// Initialize certificate lifecycle manager if enabled and PostgreSQL is available
+	if cfg.CertLifecycle.Enabled && pgDB != nil {
+		certMgr, certErr := initializeCertLifecycle(cfg, srv, pgDB, logger)
+		if certErr != nil {
+			logger.Warn("failed to initialize certificate lifecycle manager", zap.Error(certErr))
+		} else {
+			components.certManager = certMgr
+		}
+	}
+
 	return components, nil
 }
 
@@ -522,6 +541,13 @@ func logMultiTenancyStatus(authStore server.AuthStore, logger *zap.Logger) {
 func runServerWithShutdown(cfg *config.Config, logger *zap.Logger, components *ApplicationComponents) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Start certificate lifecycle manager if initialized.
+	if components.certManager != nil {
+		if err := components.certManager.Start(ctx); err != nil {
+			logger.Error("failed to start certificate lifecycle manager", zap.Error(err))
+		}
+	}
 
 	// Setup signal handling
 	shutdown := make(chan os.Signal, 1)
@@ -908,6 +934,70 @@ func registerHelmDMSAdapter(
 		zap.String("adapter", "helm"),
 	)
 	return nil
+}
+
+// initializeCertLifecycle creates and configures the certificate lifecycle manager.
+// It initializes the certificate metadata store, manager, and admin API handler.
+func initializeCertLifecycle(
+	cfg *config.Config,
+	srv *server.Server,
+	pgDB *database.DB,
+	logger *zap.Logger,
+) (*certlifecycle.Manager, error) {
+	// Create certificate metadata store.
+	certStore := certlifecycle.NewPostgresStore(pgDB)
+
+	// Create vault PKI client if vault is configured.
+	var vaultPKI certlifecycle.VaultPKI
+	vaultAddr := os.Getenv("VAULT_ADDR")
+	vaultToken := os.Getenv("VAULT_TOKEN")
+	if vaultAddr != "" && vaultToken != "" {
+		vaultCfg := &vaultpkg.Config{
+			Address: vaultAddr,
+			Token:   vaultToken,
+			PKIPath: cfg.CertLifecycle.VaultPKIPath,
+		}
+		vaultClient, vaultErr := vaultpkg.NewClient(vaultCfg)
+		if vaultErr != nil {
+			return nil, fmt.Errorf("failed to create vault client: %w", vaultErr)
+		}
+		vaultPKI = vaultClient
+	}
+
+	// Resolve HMAC secret from environment.
+	hmacSecret := ""
+	if cfg.CertLifecycle.WebhookHMACSecretEnvVar != "" {
+		hmacSecret = os.Getenv(cfg.CertLifecycle.WebhookHMACSecretEnvVar)
+	}
+
+	// Create lifecycle manager.
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:         certStore,
+		VaultClient:   vaultPKI,
+		Logger:        logger,
+		ScanInterval:  cfg.CertLifecycle.ScanInterval,
+		RenewalWindow: cfg.CertLifecycle.RenewalWindow,
+		MaxRetries:    cfg.CertLifecycle.MaxRenewalRetries,
+		RetryInterval: cfg.CertLifecycle.RenewalRetryInterval,
+		WebhookURL:    cfg.CertLifecycle.WebhookURL,
+		HMACSecret:    hmacSecret,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cert lifecycle manager: %w", err)
+	}
+
+	// Register admin API handler.
+	handler := certlifecycle.NewHandler(certStore, logger)
+	srv.SetupCertLifecycle(handler)
+
+	logger.Info("certificate lifecycle manager initialized",
+		zap.Duration("scan_interval", cfg.CertLifecycle.ScanInterval),
+		zap.Duration("renewal_window", cfg.CertLifecycle.RenewalWindow),
+		zap.Bool("vault_configured", vaultPKI != nil),
+		zap.Bool("webhook_configured", cfg.CertLifecycle.WebhookURL != ""),
+	)
+
+	return mgr, nil
 }
 
 // initializeHealthChecker creates and configures the health checker.

--- a/internal/certlifecycle/handler.go
+++ b/internal/certlifecycle/handler.go
@@ -1,0 +1,113 @@
+package certlifecycle
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// Handler provides HTTP endpoints for certificate lifecycle queries.
+type Handler struct {
+	store  Store
+	logger *zap.Logger
+}
+
+// NewHandler creates a new certificate lifecycle HTTP handler.
+func NewHandler(store Store, logger *zap.Logger) *Handler {
+	return &Handler{
+		store:  store,
+		logger: logger,
+	}
+}
+
+// RegisterRoutes registers certificate lifecycle routes on the given group.
+func (h *Handler) RegisterRoutes(group *gin.RouterGroup) {
+	certs := group.Group("/certificates")
+	certs.GET("", h.listCertificates)
+	certs.GET("/monitoring", h.monitoringStats)
+	certs.GET("/:serial", h.getCertificate)
+}
+
+// listCertificates returns certificates with optional filters.
+func (h *Handler) listCertificates(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	tenantID := c.Query("tenant_id")
+	userID := c.Query("user_id")
+	status := c.Query("status")
+
+	var certs []*CertificateMetadata
+	var err error
+
+	switch {
+	case tenantID != "":
+		certs, err = h.store.ListByTenant(ctx, tenantID)
+	case userID != "":
+		certs, err = h.store.ListByUser(ctx, userID)
+	case status != "":
+		certs, err = h.store.ListByStatus(ctx, CertificateStatus(status))
+	default:
+		// Without a filter, return active certs as a sensible default.
+		certs, err = h.store.ListByStatus(ctx, StatusActive)
+	}
+
+	if err != nil {
+		h.logger.Error("failed to list certificates",
+			zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to list certificates",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"certificates": certs,
+		"count":        len(certs),
+	})
+}
+
+// monitoringStats returns aggregate certificate statistics.
+func (h *Handler) monitoringStats(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	counts, err := h.store.CountByStatus(ctx)
+	if err != nil {
+		h.logger.Error("failed to get monitoring stats",
+			zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to get monitoring stats",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status_counts": counts,
+	})
+}
+
+// getCertificate returns a single certificate by serial number.
+func (h *Handler) getCertificate(c *gin.Context) {
+	ctx := c.Request.Context()
+	serial := c.Param("serial")
+
+	meta, err := h.store.Get(ctx, serial)
+	if err != nil {
+		if errors.Is(err, ErrCertificateNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "certificate not found",
+			})
+			return
+		}
+		h.logger.Error("failed to get certificate",
+			zap.String("serial", serial),
+			zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to get certificate",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, meta)
+}

--- a/internal/certlifecycle/handler_test.go
+++ b/internal/certlifecycle/handler_test.go
@@ -1,0 +1,213 @@
+package certlifecycle_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/piwi3910/netweave/internal/certlifecycle"
+)
+
+func setupHandlerRouter(t *testing.T) (*gin.Engine, *mockStore) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+	handler := certlifecycle.NewHandler(store, logger)
+
+	router := gin.New()
+	group := router.Group("/admin")
+	handler.RegisterRoutes(group)
+
+	return router, store
+}
+
+func TestHandler_ListCertificates_DefaultActive(t *testing.T) {
+	router, store := setupHandlerRouter(t)
+
+	store.certs["active-1"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "active-1",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusActive,
+		ExpiresAt:    time.Now().Add(30 * 24 * time.Hour),
+	}
+	store.certs["expired-1"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "expired-1",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusExpired,
+		ExpiresAt:    time.Now().Add(-1 * time.Hour),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/certificates", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	count := int(resp["count"].(float64))
+	assert.Equal(t, 1, count)
+}
+
+func TestHandler_ListCertificates_ByTenant(t *testing.T) {
+	router, store := setupHandlerRouter(t)
+
+	store.certs["t1-cert"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "t1-cert",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusActive,
+	}
+	store.certs["t2-cert"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "t2-cert",
+		TenantID:     "tenant-2",
+		Status:       certlifecycle.StatusActive,
+	}
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/admin/certificates?tenant_id=tenant-1", nil,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	// mockStore.ListByTenant returns nil (not filtering),
+	// but the endpoint should return 200.
+	assert.Contains(t, resp, "certificates")
+}
+
+func TestHandler_ListCertificates_ByUser(t *testing.T) {
+	router, store := setupHandlerRouter(t)
+
+	store.certs["u1-cert"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "u1-cert",
+		UserID:       "user-1",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusActive,
+	}
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/admin/certificates?user_id=user-1", nil,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	count := int(resp["count"].(float64))
+	assert.Equal(t, 1, count)
+}
+
+func TestHandler_ListCertificates_ByStatus(t *testing.T) {
+	router, store := setupHandlerRouter(t)
+
+	store.certs["cert-a"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "cert-a",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusExpiringSoon,
+	}
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/admin/certificates?status=expiring_soon", nil,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	count := int(resp["count"].(float64))
+	assert.Equal(t, 1, count)
+}
+
+func TestHandler_GetCertificate_Found(t *testing.T) {
+	router, store := setupHandlerRouter(t)
+
+	store.certs["serial-abc"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "serial-abc",
+		CommonName:   "abc.example.com",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusActive,
+		ExpiresAt:    time.Now().Add(30 * 24 * time.Hour),
+	}
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/admin/certificates/serial-abc", nil,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp certlifecycle.CertificateMetadata
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "serial-abc", resp.SerialNumber)
+	assert.Equal(t, "abc.example.com", resp.CommonName)
+}
+
+func TestHandler_GetCertificate_NotFound(t *testing.T) {
+	router, _ := setupHandlerRouter(t)
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/admin/certificates/nonexistent", nil,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "certificate not found", resp["error"])
+}
+
+func TestHandler_MonitoringStats(t *testing.T) {
+	router, store := setupHandlerRouter(t)
+
+	store.certs["active-1"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "active-1",
+		Status:       certlifecycle.StatusActive,
+	}
+	store.certs["active-2"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "active-2",
+		Status:       certlifecycle.StatusActive,
+	}
+	store.certs["expired-1"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "expired-1",
+		Status:       certlifecycle.StatusExpired,
+	}
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/admin/certificates/monitoring", nil,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Contains(t, resp, "status_counts")
+}

--- a/internal/certlifecycle/manager.go
+++ b/internal/certlifecycle/manager.go
@@ -1,0 +1,248 @@
+package certlifecycle
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// ManagerConfig holds configuration for the lifecycle manager.
+type ManagerConfig struct {
+	Store         Store
+	VaultClient   VaultPKI
+	Logger        *zap.Logger
+	ScanInterval  time.Duration
+	RenewalWindow time.Duration
+	MaxRetries    int
+	RetryInterval time.Duration
+	WebhookURL    string
+	HMACSecret    string
+}
+
+// Manager orchestrates certificate lifecycle automation.
+// It ties together the monitor, renewer, and notifier.
+type Manager struct {
+	store    Store
+	monitor  *Monitor
+	renewer  *Renewer
+	notifier *Notifier
+	logger   *zap.Logger
+	stopCh   chan struct{}
+	wg       sync.WaitGroup
+}
+
+// NewManager creates a new lifecycle manager.
+func NewManager(cfg *ManagerConfig) (*Manager, error) {
+	if cfg.Store == nil {
+		return nil, fmt.Errorf("store is required")
+	}
+	if cfg.Logger == nil {
+		return nil, fmt.Errorf("logger is required")
+	}
+
+	m := &Manager{
+		store:  cfg.Store,
+		logger: cfg.Logger,
+		stopCh: make(chan struct{}),
+	}
+
+	// Initialize notifier if webhook URL is configured.
+	if cfg.WebhookURL != "" {
+		notifier, err := NewNotifier(&NotifierConfig{
+			WebhookURL: cfg.WebhookURL,
+			HMACSecret: cfg.HMACSecret,
+			Logger:     cfg.Logger,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create notifier: %w", err)
+		}
+		m.notifier = notifier
+	}
+
+	// Initialize renewer if vault client is provided.
+	if cfg.VaultClient != nil {
+		m.renewer = NewRenewer(&RenewerConfig{
+			MaxRetries:    cfg.MaxRetries,
+			RetryInterval: cfg.RetryInterval,
+			Store:         cfg.Store,
+			VaultClient:   cfg.VaultClient,
+			Notifier:      m.notifier,
+			Logger:        cfg.Logger,
+		})
+	}
+
+	// Initialize monitor.
+	m.monitor = NewMonitor(&MonitorConfig{
+		ScanInterval:  cfg.ScanInterval,
+		RenewalWindow: cfg.RenewalWindow,
+		Store:         cfg.Store,
+		Logger:        cfg.Logger,
+	})
+
+	// Wire monitor callbacks.
+	m.monitor.OnExpiringSoon = m.onExpiringSoon
+	m.monitor.OnExpired = m.onExpired
+
+	return m, nil
+}
+
+// Start begins the lifecycle manager and its background monitor.
+func (m *Manager) Start(ctx context.Context) error {
+	m.logger.Info("starting certificate lifecycle manager")
+
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		if err := m.monitor.Start(ctx); err != nil {
+			m.logger.Error("monitor stopped with error", zap.Error(err))
+		}
+	}()
+
+	// Process failed renewals on each monitor tick.
+	m.wg.Add(1)
+	go m.retryFailedRenewals(ctx)
+
+	return nil
+}
+
+// Stop signals the manager and all workers to shut down.
+func (m *Manager) Stop() error {
+	m.logger.Info("stopping certificate lifecycle manager")
+	close(m.stopCh)
+	if err := m.monitor.Stop(); err != nil {
+		m.logger.Error("monitor stop error", zap.Error(err))
+	}
+	m.wg.Wait()
+	m.logger.Info("certificate lifecycle manager stopped")
+	return nil
+}
+
+// RecordIssuance records a newly issued certificate in the store and metrics.
+func (m *Manager) RecordIssuance(
+	ctx context.Context,
+	cert *CertificateMetadata,
+) error {
+	if err := m.store.Create(ctx, cert); err != nil {
+		return fmt.Errorf("failed to record issuance: %w", err)
+	}
+
+	RecordIssuance(cert.TenantID, cert.RoleName, "success")
+
+	if m.notifier != nil {
+		event := NewCertEvent(EventCertIssued, cert)
+		if err := m.notifier.NotifyWithRetry(ctx, event); err != nil {
+			m.logger.Warn("failed to send issuance notification",
+				zap.String("serial", cert.SerialNumber),
+				zap.Error(err))
+		}
+	}
+
+	return nil
+}
+
+// RecordRevocation records a certificate revocation in the store and metrics.
+func (m *Manager) RecordRevocation(
+	ctx context.Context, serialNumber string,
+) error {
+	meta, err := m.store.Get(ctx, serialNumber)
+	if err != nil {
+		return fmt.Errorf("failed to get certificate for revocation: %w", err)
+	}
+
+	if err := m.store.MarkRevoked(ctx, serialNumber); err != nil {
+		return fmt.Errorf("failed to mark certificate as revoked: %w", err)
+	}
+
+	RecordRevocation(meta.TenantID)
+
+	if m.notifier != nil {
+		meta.Status = StatusRevoked
+		event := NewCertEvent(EventCertRevoked, meta)
+		if err := m.notifier.NotifyWithRetry(ctx, event); err != nil {
+			m.logger.Warn("failed to send revocation notification",
+				zap.String("serial", serialNumber),
+				zap.Error(err))
+		}
+	}
+
+	return nil
+}
+
+// onExpiringSoon handles the monitor's expiring_soon callback.
+func (m *Manager) onExpiringSoon(ctx context.Context, meta *CertificateMetadata) {
+	// Send notification.
+	if m.notifier != nil {
+		event := NewCertEvent(EventCertExpiringSoon, meta)
+		if err := m.notifier.NotifyWithRetry(ctx, event); err != nil {
+			m.logger.Warn("failed to send expiring_soon notification",
+				zap.String("serial", meta.SerialNumber),
+				zap.Error(err))
+		}
+	}
+
+	// Attempt automatic renewal if renewer is available.
+	if m.renewer != nil {
+		if err := m.renewer.RenewCertificate(ctx, meta); err != nil {
+			m.logger.Warn("automatic renewal failed for expiring cert",
+				zap.String("serial", meta.SerialNumber),
+				zap.Error(err))
+		}
+	}
+}
+
+// onExpired handles the monitor's expired callback.
+func (m *Manager) onExpired(ctx context.Context, meta *CertificateMetadata) {
+	if m.notifier != nil {
+		event := NewCertEvent(EventCertExpired, meta)
+		if err := m.notifier.NotifyWithRetry(ctx, event); err != nil {
+			m.logger.Warn("failed to send expired notification",
+				zap.String("serial", meta.SerialNumber),
+				zap.Error(err))
+		}
+	}
+}
+
+// retryFailedRenewals periodically retries certificates that previously
+// failed renewal and are eligible for retry.
+func (m *Manager) retryFailedRenewals(ctx context.Context) {
+	defer m.wg.Done()
+
+	if m.renewer == nil {
+		return
+	}
+
+	ticker := time.NewTicker(DefaultScanInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.processFailedRenewals(ctx)
+		}
+	}
+}
+
+// processFailedRenewals finds and retries eligible failed renewals.
+func (m *Manager) processFailedRenewals(ctx context.Context) {
+	certs, err := m.store.ListRenewalFailed(ctx, time.Now())
+	if err != nil {
+		m.logger.Error("failed to list renewal-failed certificates",
+			zap.Error(err))
+		return
+	}
+
+	for _, cert := range certs {
+		if err := m.renewer.RenewCertificate(ctx, cert); err != nil {
+			m.logger.Warn("retry renewal failed",
+				zap.String("serial", cert.SerialNumber),
+				zap.Error(err))
+		}
+	}
+}

--- a/internal/certlifecycle/manager_test.go
+++ b/internal/certlifecycle/manager_test.go
@@ -1,0 +1,357 @@
+package certlifecycle_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/piwi3910/netweave/internal/certlifecycle"
+)
+
+func TestNewManager_RequiresStore(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	_, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Logger: logger,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "store is required")
+}
+
+func TestNewManager_RequiresLogger(t *testing.T) {
+	store := newMockStore()
+
+	_, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store: store,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "logger is required")
+}
+
+func TestNewManager_MinimalConfig(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:  store,
+		Logger: logger,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mgr)
+}
+
+func TestNewManager_WithVaultClient(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+	vaultPKI := &mockVaultPKI{}
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:       store,
+		VaultClient: vaultPKI,
+		Logger:      logger,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mgr)
+}
+
+func TestManager_StartStop(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:        store,
+		Logger:       logger,
+		ScanInterval: 50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = mgr.Start(ctx)
+	require.NoError(t, err)
+
+	// Give workers time to start.
+	time.Sleep(100 * time.Millisecond)
+
+	err = mgr.Stop()
+	require.NoError(t, err)
+}
+
+func TestManager_RecordIssuance(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:  store,
+		Logger: logger,
+	})
+	require.NoError(t, err)
+
+	cert := &certlifecycle.CertificateMetadata{
+		SerialNumber: "issued-serial-001",
+		UserID:       "user-1",
+		TenantID:     "tenant-1",
+		CommonName:   "test.example.com",
+		RoleName:     "web-server",
+		Status:       certlifecycle.StatusActive,
+		IssuedAt:     time.Now(),
+		ExpiresAt:    time.Now().Add(365 * 24 * time.Hour),
+	}
+
+	err = mgr.RecordIssuance(context.Background(), cert)
+	require.NoError(t, err)
+
+	// Verify cert is in the store.
+	stored, getErr := store.Get(context.Background(), "issued-serial-001")
+	require.NoError(t, getErr)
+	assert.Equal(t, "issued-serial-001", stored.SerialNumber)
+	assert.Equal(t, "user-1", stored.UserID)
+}
+
+func TestManager_RecordRevocation(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	// Pre-populate the cert in the store.
+	store.certs["revoke-serial-001"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "revoke-serial-001",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusActive,
+	}
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:  store,
+		Logger: logger,
+	})
+	require.NoError(t, err)
+
+	err = mgr.RecordRevocation(context.Background(), "revoke-serial-001")
+	require.NoError(t, err)
+}
+
+func TestManager_RecordRevocation_NotFound(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:  store,
+		Logger: logger,
+	})
+	require.NoError(t, err)
+
+	err = mgr.RecordRevocation(context.Background(), "nonexistent-serial")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get certificate")
+}
+
+func TestManager_StartStop_WithVault(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+	vaultPKI := &mockVaultPKI{}
+
+	// Add a failed cert for retry processing.
+	store.certs["failed-serial"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "failed-serial",
+		TenantID:     "tenant-1",
+		CommonName:   "test.example.com",
+		RoleName:     "web-server",
+		Status:       certlifecycle.StatusRenewalFailed,
+		RetryCount:   1,
+		NextRetryAt:  time.Now().Add(-1 * time.Hour),
+	}
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:        store,
+		VaultClient:  vaultPKI,
+		Logger:       logger,
+		ScanInterval: 50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = mgr.Start(ctx)
+	require.NoError(t, err)
+
+	// Give workers time to process.
+	time.Sleep(200 * time.Millisecond)
+
+	err = mgr.Stop()
+	require.NoError(t, err)
+}
+
+func TestManager_OnExpiringSoonCallback(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	// Add an active cert expiring within the renewal window.
+	store.certs["expiring-serial"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "expiring-serial",
+		TenantID:     "tenant-1",
+		CommonName:   "test.example.com",
+		RoleName:     "web-server",
+		Status:       certlifecycle.StatusActive,
+		ExpiresAt:    time.Now().Add(10 * 24 * time.Hour),
+	}
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:         store,
+		Logger:        logger,
+		ScanInterval:  50 * time.Millisecond,
+		RenewalWindow: 30 * 24 * time.Hour,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = mgr.Start(ctx)
+	require.NoError(t, err)
+
+	// Wait for at least one scan cycle.
+	time.Sleep(200 * time.Millisecond)
+
+	err = mgr.Stop()
+	require.NoError(t, err)
+
+	// Cert should have been detected as expiring_soon.
+	updates := store.getStatusUpdates()
+	require.NotEmpty(t, updates)
+	assert.Equal(t, "expiring-serial", updates[0].SerialNumber)
+	assert.Equal(t, certlifecycle.StatusExpiringSoon, updates[0].Status)
+}
+
+func TestManager_OnExpiredCallback(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	// Add an already-expired cert.
+	store.certs["expired-serial"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "expired-serial",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusActive,
+		ExpiresAt:    time.Now().Add(-1 * time.Hour),
+	}
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:         store,
+		Logger:        logger,
+		ScanInterval:  50 * time.Millisecond,
+		RenewalWindow: 30 * 24 * time.Hour,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = mgr.Start(ctx)
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+
+	err = mgr.Stop()
+	require.NoError(t, err)
+
+	// The cert should be marked as expired.
+	found := false
+	for _, u := range store.getStatusUpdates() {
+		if u.SerialNumber == "expired-serial" &&
+			u.Status == certlifecycle.StatusExpired {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected expired-serial to be marked expired")
+}
+
+func TestManager_RecordIssuance_WithWebhook(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	webhookServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+	defer webhookServer.Close()
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:      store,
+		Logger:     logger,
+		WebhookURL: webhookServer.URL,
+		HMACSecret: "test-secret",
+	})
+	require.NoError(t, err)
+
+	cert := &certlifecycle.CertificateMetadata{
+		SerialNumber: "webhook-serial",
+		TenantID:     "tenant-1",
+		RoleName:     "web-server",
+		Status:       certlifecycle.StatusActive,
+		ExpiresAt:    time.Now().Add(365 * 24 * time.Hour),
+	}
+
+	err = mgr.RecordIssuance(context.Background(), cert)
+	require.NoError(t, err)
+}
+
+func TestManager_RecordRevocation_WithWebhook(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	webhookServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+	defer webhookServer.Close()
+
+	store.certs["revoke-wh"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "revoke-wh",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusActive,
+	}
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:      store,
+		Logger:     logger,
+		WebhookURL: webhookServer.URL,
+	})
+	require.NoError(t, err)
+
+	err = mgr.RecordRevocation(context.Background(), "revoke-wh")
+	require.NoError(t, err)
+}
+
+func TestManager_RecordIssuance_DuplicateError(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:  store,
+		Logger: logger,
+	})
+	require.NoError(t, err)
+
+	cert := &certlifecycle.CertificateMetadata{
+		SerialNumber: "dup-serial",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusActive,
+		ExpiresAt:    time.Now().Add(365 * 24 * time.Hour),
+	}
+
+	// First issuance should succeed.
+	err = mgr.RecordIssuance(context.Background(), cert)
+	require.NoError(t, err)
+
+	// Second issuance of same serial should still succeed
+	// (mockStore overwrites on Create, real store would error).
+	err = mgr.RecordIssuance(context.Background(), cert)
+	require.NoError(t, err)
+}

--- a/internal/certlifecycle/monitor_test.go
+++ b/internal/certlifecycle/monitor_test.go
@@ -89,15 +89,31 @@ func (m *mockStore) MarkRenewalFailed(
 }
 
 func (m *mockStore) ListByTenant(
-	_ context.Context, _ string,
+	_ context.Context, tenantID string,
 ) ([]*certMeta, error) {
-	return nil, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []*certMeta
+	for _, cert := range m.certs {
+		if cert.TenantID == tenantID {
+			result = append(result, cert)
+		}
+	}
+	return result, nil
 }
 
 func (m *mockStore) ListByUser(
-	_ context.Context, _ string,
+	_ context.Context, userID string,
 ) ([]*certMeta, error) {
-	return nil, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []*certMeta
+	for _, cert := range m.certs {
+		if cert.UserID == userID {
+			result = append(result, cert)
+		}
+	}
+	return result, nil
 }
 
 func (m *mockStore) ListByStatus(
@@ -130,9 +146,19 @@ func (m *mockStore) ListExpiring(
 }
 
 func (m *mockStore) ListRenewalFailed(
-	_ context.Context, _ time.Time,
+	_ context.Context, now time.Time,
 ) ([]*certMeta, error) {
-	return nil, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []*certMeta
+	for _, cert := range m.certs {
+		if cert.Status == certlifecycle.StatusRenewalFailed &&
+			!cert.NextRetryAt.IsZero() &&
+			cert.NextRetryAt.Before(now) {
+			result = append(result, cert)
+		}
+	}
+	return result, nil
 }
 
 func (m *mockStore) CountByStatus(

--- a/internal/certlifecycle/renewer.go
+++ b/internal/certlifecycle/renewer.go
@@ -1,0 +1,224 @@
+package certlifecycle
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/piwi3910/netweave/internal/vault"
+)
+
+const (
+	// DefaultMaxRenewalRetries is the default max attempts for certificate renewal.
+	DefaultMaxRenewalRetries = 3
+
+	// DefaultRetryInterval is the default wait between renewal retries.
+	DefaultRetryInterval = 1 * time.Hour
+)
+
+// RenewerConfig holds configuration for the certificate renewal service.
+type RenewerConfig struct {
+	// MaxRetries is the maximum number of renewal attempts.
+	MaxRetries int
+
+	// RetryInterval is the base interval between retry attempts.
+	RetryInterval time.Duration
+
+	// Store provides certificate metadata persistence.
+	Store Store
+
+	// VaultClient provides certificate issuance and revocation.
+	VaultClient VaultPKI
+
+	// Notifier sends webhook notifications for renewal events (optional).
+	Notifier *Notifier
+
+	// Logger provides structured logging.
+	Logger *zap.Logger
+}
+
+// VaultPKI defines the vault operations needed for certificate renewal.
+type VaultPKI interface {
+	IssueCertificate(
+		ctx context.Context, roleName string, req *vault.CertificateRequest,
+	) (*vault.Certificate, error)
+	RevokeCertificateBySerial(ctx context.Context, serialNumber string) error
+}
+
+// Renewer handles automatic certificate renewal.
+type Renewer struct {
+	maxRetries    int
+	retryInterval time.Duration
+	store         Store
+	vaultClient   VaultPKI
+	notifier      *Notifier
+	logger        *zap.Logger
+}
+
+// NewRenewer creates a new certificate renewal service.
+func NewRenewer(cfg *RenewerConfig) *Renewer {
+	maxRetries := cfg.MaxRetries
+	if maxRetries == 0 {
+		maxRetries = DefaultMaxRenewalRetries
+	}
+
+	retryInterval := cfg.RetryInterval
+	if retryInterval == 0 {
+		retryInterval = DefaultRetryInterval
+	}
+
+	return &Renewer{
+		maxRetries:    maxRetries,
+		retryInterval: retryInterval,
+		store:         cfg.Store,
+		vaultClient:   cfg.VaultClient,
+		notifier:      cfg.Notifier,
+		logger:        cfg.Logger,
+	}
+}
+
+// RenewCertificate attempts to renew a certificate by issuing a new one,
+// storing the metadata, marking the old cert as renewed, and revoking the old cert.
+func (r *Renewer) RenewCertificate(
+	ctx context.Context, meta *CertificateMetadata,
+) error {
+	r.logger.Info("attempting certificate renewal",
+		zap.String("serial", meta.SerialNumber),
+		zap.String("common_name", meta.CommonName),
+		zap.String("role", meta.RoleName))
+
+	// Issue new certificate via Vault.
+	newCert, err := r.vaultClient.IssueCertificate(
+		ctx, meta.RoleName, &vault.CertificateRequest{
+			CommonName: meta.CommonName,
+		},
+	)
+	if err != nil {
+		return r.handleRenewalFailure(ctx, meta, err)
+	}
+
+	// Store new certificate metadata.
+	newMeta := &CertificateMetadata{
+		SerialNumber: newCert.SerialNumber,
+		UserID:       meta.UserID,
+		TenantID:     meta.TenantID,
+		CommonName:   meta.CommonName,
+		RoleName:     meta.RoleName,
+		Status:       StatusActive,
+		IssuedAt:     time.Now().UTC(),
+		ExpiresAt:    newCert.Expiration,
+		RenewedFrom:  meta.SerialNumber,
+		RenewalCount: meta.RenewalCount + 1,
+	}
+
+	if err := r.store.Create(ctx, newMeta); err != nil {
+		return fmt.Errorf(
+			"failed to store renewed certificate metadata: %w", err,
+		)
+	}
+
+	// Mark old certificate as renewed.
+	if err := r.store.MarkRenewed(
+		ctx, meta.SerialNumber, newCert.SerialNumber,
+	); err != nil {
+		r.logger.Error("failed to mark old certificate as renewed",
+			zap.String("old_serial", meta.SerialNumber),
+			zap.Error(err))
+	}
+
+	// Revoke old certificate in Vault.
+	if err := r.vaultClient.RevokeCertificateBySerial(
+		ctx, meta.SerialNumber,
+	); err != nil {
+		r.logger.Error("failed to revoke old certificate",
+			zap.String("old_serial", meta.SerialNumber),
+			zap.Error(err))
+	}
+
+	// Record metrics.
+	RecordRenewal(meta.TenantID, "success")
+	RecordRenewalAttempts(
+		meta.TenantID, "success", meta.RetryCount+1,
+	)
+	lifetime := meta.ExpiresAt.Sub(meta.IssuedAt).Seconds()
+	RecordLifetime(meta.TenantID, lifetime)
+
+	// Send notification.
+	r.notifyRenewal(ctx, newMeta)
+
+	r.logger.Info("certificate renewed successfully",
+		zap.String("old_serial", meta.SerialNumber),
+		zap.String("new_serial", newCert.SerialNumber))
+
+	return nil
+}
+
+// handleRenewalFailure records a renewal failure and schedules a retry.
+func (r *Renewer) handleRenewalFailure(
+	ctx context.Context,
+	meta *CertificateMetadata,
+	renewErr error,
+) error {
+	nextRetry := time.Now().Add(
+		exponentialBackoff(r.retryInterval, meta.RetryCount+1),
+	)
+
+	r.logger.Error("certificate renewal failed",
+		zap.String("serial", meta.SerialNumber),
+		zap.Int("retry_count", meta.RetryCount),
+		zap.Time("next_retry", nextRetry),
+		zap.Error(renewErr))
+
+	if meta.RetryCount+1 >= r.maxRetries {
+		RecordRenewal(meta.TenantID, "max_retries_exceeded")
+		RecordRenewalAttempts(
+			meta.TenantID, "max_retries_exceeded", meta.RetryCount+1,
+		)
+		r.notifyRenewalFailed(ctx, meta, renewErr)
+	} else {
+		RecordRenewal(meta.TenantID, "failure")
+	}
+
+	if storeErr := r.store.MarkRenewalFailed(
+		ctx, meta.SerialNumber, renewErr.Error(), nextRetry,
+	); storeErr != nil {
+		r.logger.Error("failed to record renewal failure",
+			zap.String("serial", meta.SerialNumber),
+			zap.Error(storeErr))
+	}
+
+	return fmt.Errorf("renewal failed for %s: %w", meta.SerialNumber, renewErr)
+}
+
+// notifyRenewal sends a renewal success notification if a notifier is configured.
+func (r *Renewer) notifyRenewal(ctx context.Context, meta *CertificateMetadata) {
+	if r.notifier == nil {
+		return
+	}
+	event := NewCertEvent(EventCertRenewed, meta)
+	if err := r.notifier.NotifyWithRetry(ctx, event); err != nil {
+		r.logger.Warn("failed to send renewal notification",
+			zap.String("serial", meta.SerialNumber),
+			zap.Error(err))
+	}
+}
+
+// notifyRenewalFailed sends a renewal failure notification.
+func (r *Renewer) notifyRenewalFailed(
+	ctx context.Context,
+	meta *CertificateMetadata,
+	renewErr error,
+) {
+	if r.notifier == nil {
+		return
+	}
+	meta.LastError = renewErr.Error()
+	event := NewCertEvent(EventCertRenewalFailed, meta)
+	if err := r.notifier.NotifyWithRetry(ctx, event); err != nil {
+		r.logger.Warn("failed to send renewal failure notification",
+			zap.String("serial", meta.SerialNumber),
+			zap.Error(err))
+	}
+}

--- a/internal/certlifecycle/renewer_test.go
+++ b/internal/certlifecycle/renewer_test.go
@@ -1,0 +1,293 @@
+package certlifecycle_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/piwi3910/netweave/internal/certlifecycle"
+	"github.com/piwi3910/netweave/internal/vault"
+)
+
+// mockVaultPKI implements certlifecycle.VaultPKI for testing.
+type mockVaultPKI struct {
+	issueFn  func(ctx context.Context, roleName string, req *vault.CertificateRequest) (*vault.Certificate, error)
+	revokeFn func(ctx context.Context, serialNumber string) error
+}
+
+func (m *mockVaultPKI) IssueCertificate(
+	ctx context.Context, roleName string, req *vault.CertificateRequest,
+) (*vault.Certificate, error) {
+	if m.issueFn != nil {
+		return m.issueFn(ctx, roleName, req)
+	}
+	return &vault.Certificate{
+		SerialNumber: "new-serial-001",
+		Expiration:   time.Now().Add(365 * 24 * time.Hour),
+	}, nil
+}
+
+func (m *mockVaultPKI) RevokeCertificateBySerial(
+	ctx context.Context, serialNumber string,
+) error {
+	if m.revokeFn != nil {
+		return m.revokeFn(ctx, serialNumber)
+	}
+	return nil
+}
+
+func TestRenewer_RenewCertificate_Success(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+	vaultPKI := &mockVaultPKI{}
+
+	// Add existing cert to store.
+	oldMeta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "old-serial-001",
+		UserID:       "user-1",
+		TenantID:     "tenant-1",
+		CommonName:   "test.example.com",
+		RoleName:     "web-server",
+		Status:       certlifecycle.StatusExpiringSoon,
+		IssuedAt:     time.Now().Add(-30 * 24 * time.Hour),
+		ExpiresAt:    time.Now().Add(5 * 24 * time.Hour),
+	}
+	store.certs["old-serial-001"] = oldMeta
+
+	renewer := certlifecycle.NewRenewer(&certlifecycle.RenewerConfig{
+		Store:       store,
+		VaultClient: vaultPKI,
+		Logger:      logger,
+	})
+
+	err := renewer.RenewCertificate(context.Background(), oldMeta)
+	require.NoError(t, err)
+
+	// New cert should be in the store.
+	newCert, getErr := store.Get(context.Background(), "new-serial-001")
+	require.NoError(t, getErr)
+	assert.Equal(t, "new-serial-001", newCert.SerialNumber)
+	assert.Equal(t, "user-1", newCert.UserID)
+	assert.Equal(t, "tenant-1", newCert.TenantID)
+	assert.Equal(t, "test.example.com", newCert.CommonName)
+	assert.Equal(t, "web-server", newCert.RoleName)
+	assert.Equal(t, certlifecycle.StatusActive, newCert.Status)
+	assert.Equal(t, "old-serial-001", newCert.RenewedFrom)
+	assert.Equal(t, 1, newCert.RenewalCount)
+}
+
+func TestRenewer_RenewCertificate_VaultFailure(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+	vaultErr := errors.New("vault unavailable")
+	vaultPKI := &mockVaultPKI{
+		issueFn: func(
+			_ context.Context, _ string, _ *vault.CertificateRequest,
+		) (*vault.Certificate, error) {
+			return nil, vaultErr
+		},
+	}
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "failing-serial",
+		TenantID:     "tenant-1",
+		CommonName:   "test.example.com",
+		RoleName:     "web-server",
+		Status:       certlifecycle.StatusExpiringSoon,
+		RetryCount:   0,
+	}
+	store.certs["failing-serial"] = meta
+
+	renewer := certlifecycle.NewRenewer(&certlifecycle.RenewerConfig{
+		MaxRetries:  3,
+		Store:       store,
+		VaultClient: vaultPKI,
+		Logger:      logger,
+	})
+
+	err := renewer.RenewCertificate(context.Background(), meta)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "renewal failed for failing-serial")
+}
+
+func TestRenewer_RenewCertificate_MaxRetriesExceeded(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+	vaultPKI := &mockVaultPKI{
+		issueFn: func(
+			_ context.Context, _ string, _ *vault.CertificateRequest,
+		) (*vault.Certificate, error) {
+			return nil, errors.New("vault error")
+		},
+	}
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "max-retry-serial",
+		TenantID:     "tenant-1",
+		CommonName:   "test.example.com",
+		RoleName:     "web-server",
+		Status:       certlifecycle.StatusExpiringSoon,
+		RetryCount:   2, // Already at retry 2, next attempt = 3 (maxRetries).
+	}
+	store.certs["max-retry-serial"] = meta
+
+	renewer := certlifecycle.NewRenewer(&certlifecycle.RenewerConfig{
+		MaxRetries:  3,
+		Store:       store,
+		VaultClient: vaultPKI,
+		Logger:      logger,
+	})
+
+	err := renewer.RenewCertificate(context.Background(), meta)
+	require.Error(t, err)
+}
+
+func TestRenewer_DefaultConfig(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+	vaultPKI := &mockVaultPKI{}
+
+	renewer := certlifecycle.NewRenewer(&certlifecycle.RenewerConfig{
+		Store:       store,
+		VaultClient: vaultPKI,
+		Logger:      logger,
+	})
+
+	require.NotNil(t, renewer)
+}
+
+func TestRenewer_RenewCertificate_WithNotifier(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+	vaultPKI := &mockVaultPKI{}
+
+	// Setup webhook server.
+	webhookServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer webhookServer.Close()
+
+	notifier, notifierErr := certlifecycle.NewNotifier(&certlifecycle.NotifierConfig{
+		WebhookURL: webhookServer.URL,
+		Logger:     logger,
+	})
+	require.NoError(t, notifierErr)
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "notify-serial",
+		TenantID:     "tenant-1",
+		CommonName:   "test.example.com",
+		RoleName:     "web-server",
+		Status:       certlifecycle.StatusExpiringSoon,
+		IssuedAt:     time.Now().Add(-30 * 24 * time.Hour),
+		ExpiresAt:    time.Now().Add(5 * 24 * time.Hour),
+	}
+	store.certs["notify-serial"] = meta
+
+	renewer := certlifecycle.NewRenewer(&certlifecycle.RenewerConfig{
+		Store:       store,
+		VaultClient: vaultPKI,
+		Notifier:    notifier,
+		Logger:      logger,
+	})
+
+	err := renewer.RenewCertificate(context.Background(), meta)
+	require.NoError(t, err)
+}
+
+func TestRenewer_RenewCertificate_FailureWithNotifier(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+	vaultPKI := &mockVaultPKI{
+		issueFn: func(
+			_ context.Context, _ string, _ *vault.CertificateRequest,
+		) (*vault.Certificate, error) {
+			return nil, errors.New("vault error")
+		},
+	}
+
+	webhookServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer webhookServer.Close()
+
+	notifier, notifierErr := certlifecycle.NewNotifier(&certlifecycle.NotifierConfig{
+		WebhookURL: webhookServer.URL,
+		Logger:     logger,
+	})
+	require.NoError(t, notifierErr)
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "fail-notify-serial",
+		TenantID:     "tenant-1",
+		CommonName:   "test.example.com",
+		RoleName:     "web-server",
+		Status:       certlifecycle.StatusExpiringSoon,
+		RetryCount:   2, // Will exceed max retries (3).
+	}
+	store.certs["fail-notify-serial"] = meta
+
+	renewer := certlifecycle.NewRenewer(&certlifecycle.RenewerConfig{
+		MaxRetries:  3,
+		Store:       store,
+		VaultClient: vaultPKI,
+		Notifier:    notifier,
+		Logger:      logger,
+	})
+
+	err := renewer.RenewCertificate(context.Background(), meta)
+	require.Error(t, err)
+}
+
+func TestRenewer_RenewCertificate_PreservesMetadata(t *testing.T) {
+	store := newMockStore()
+	logger := zaptest.NewLogger(t)
+	vaultPKI := &mockVaultPKI{
+		issueFn: func(
+			_ context.Context, _ string, _ *vault.CertificateRequest,
+		) (*vault.Certificate, error) {
+			return &vault.Certificate{
+				SerialNumber: "renewed-serial",
+				Expiration:   time.Now().Add(365 * 24 * time.Hour),
+			}, nil
+		},
+	}
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "original-serial",
+		UserID:       "user-42",
+		TenantID:     "tenant-99",
+		CommonName:   "deep.example.com",
+		RoleName:     "api-server",
+		Status:       certlifecycle.StatusExpiringSoon,
+		RenewalCount: 3,
+		IssuedAt:     time.Now().Add(-60 * 24 * time.Hour),
+		ExpiresAt:    time.Now().Add(2 * 24 * time.Hour),
+	}
+	store.certs["original-serial"] = meta
+
+	renewer := certlifecycle.NewRenewer(&certlifecycle.RenewerConfig{
+		Store:       store,
+		VaultClient: vaultPKI,
+		Logger:      logger,
+	})
+
+	err := renewer.RenewCertificate(context.Background(), meta)
+	require.NoError(t, err)
+
+	newCert, getErr := store.Get(context.Background(), "renewed-serial")
+	require.NoError(t, getErr)
+	assert.Equal(t, "user-42", newCert.UserID)
+	assert.Equal(t, "tenant-99", newCert.TenantID)
+	assert.Equal(t, "deep.example.com", newCert.CommonName)
+	assert.Equal(t, "api-server", newCert.RoleName)
+	assert.Equal(t, 4, newCert.RenewalCount)
+	assert.Equal(t, "original-serial", newCert.RenewedFrom)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,7 @@ type Config struct {
 	Postgres        database.PostgresConfig `mapstructure:"postgres"`
 	StorageMode     string                  `mapstructure:"storage_mode"`
 	FrontendPlugins FrontendPlugins         `mapstructure:"frontend_plugins"`
+	CertLifecycle   CertLifecycleConfig     `mapstructure:"cert_lifecycle"`
 
 	// Environment stores the detected environment (dev/staging/prod)
 	// This field is set automatically during Load() and used for validation
@@ -88,6 +89,36 @@ type FrontendPluginConfig struct {
 	// Enabled controls whether this frontend plugin is active.
 	// Default: false (all plugins disabled by default).
 	Enabled bool `mapstructure:"enabled"`
+}
+
+// CertLifecycleConfig configures automated certificate lifecycle management.
+type CertLifecycleConfig struct {
+	// Enabled activates certificate lifecycle automation.
+	Enabled bool `mapstructure:"enabled"`
+
+	// ScanInterval is how often to scan for expiring certificates.
+	ScanInterval time.Duration `mapstructure:"scan_interval"`
+
+	// RenewalWindow is how far before expiry to trigger renewal.
+	RenewalWindow time.Duration `mapstructure:"renewal_window"`
+
+	// MaxRenewalRetries is the maximum renewal attempts before giving up.
+	MaxRenewalRetries int `mapstructure:"max_renewal_retries"`
+
+	// RenewalRetryInterval is the base interval between renewal retries.
+	RenewalRetryInterval time.Duration `mapstructure:"renewal_retry_interval"`
+
+	// WebhookURL is the target URL for lifecycle event notifications.
+	WebhookURL string `mapstructure:"webhook_url"`
+
+	// WebhookHMACSecretEnvVar is the env var containing the HMAC secret.
+	WebhookHMACSecretEnvVar string `mapstructure:"webhook_hmac_secret_env_var"`
+
+	// VaultPKIPath is the Vault PKI mount path.
+	VaultPKIPath string `mapstructure:"vault_pki_path"`
+
+	// KeycloakSync enables Keycloak user attribute synchronization.
+	KeycloakSync bool `mapstructure:"keycloak_sync"`
 }
 
 // AuthConfig contains authentication backend configuration.
@@ -1004,6 +1035,14 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("frontend_plugins.o2smo.enabled", false)
 	v.SetDefault("frontend_plugins.tmforum.enabled", false)
 	v.SetDefault("frontend_plugins.graphql.enabled", false)
+
+	// Certificate lifecycle defaults
+	v.SetDefault("cert_lifecycle.enabled", false)
+	v.SetDefault("cert_lifecycle.scan_interval", "5m")
+	v.SetDefault("cert_lifecycle.renewal_window", "720h")
+	v.SetDefault("cert_lifecycle.max_renewal_retries", 3)
+	v.SetDefault("cert_lifecycle.renewal_retry_interval", "1h")
+	v.SetDefault("cert_lifecycle.vault_pki_path", "pki_int")
 
 	// PostgreSQL defaults
 	v.SetDefault("postgres.host", "localhost")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/piwi3910/netweave/internal/adapter"
 	"github.com/piwi3910/netweave/internal/auth"
 	"github.com/piwi3910/netweave/internal/backend"
+	"github.com/piwi3910/netweave/internal/certlifecycle"
 	"github.com/piwi3910/netweave/internal/config"
 	dmshandlers "github.com/piwi3910/netweave/internal/dms/handlers"
 	dmsregistry "github.com/piwi3910/netweave/internal/dms/registry"
@@ -785,6 +786,15 @@ func (s *Server) SetupAuth(authStore AuthStore, authMw AuthMiddleware) {
 	}
 
 	s.logger.Info("multi-tenancy and RBAC enabled")
+}
+
+// SetupCertLifecycle registers certificate lifecycle admin API routes on the server.
+// The handler provides endpoints for querying certificate metadata and monitoring stats.
+// Routes are registered under /admin/certificates.
+func (s *Server) SetupCertLifecycle(handler *certlifecycle.Handler) {
+	admin := s.router.Group("/admin")
+	handler.RegisterRoutes(admin)
+	s.logger.Info("certificate lifecycle admin routes registered")
 }
 
 // setupTenantRateLimiter configures per-tenant rate limiting based on tenant quota settings.


### PR DESCRIPTION
## Summary

- **Renewer service**: Automatic certificate renewal via Vault PKI with configurable retry (exponential backoff), failure tracking, and webhook notifications
- **Manager orchestrator**: Single entry point tying together monitor, renewer, and notifier; handles `RecordIssuance`/`RecordRevocation` with metrics and notifications
- **Admin API handler**: Gin HTTP endpoints at `/admin/certificates` for listing certs (with tenant/user/status filters), monitoring stats, and single-cert lookup
- **Configuration**: `CertLifecycleConfig` struct added to gateway config with scan interval, renewal window, retry settings, webhook URL, and Vault PKI path
- **Server integration**: Cert lifecycle manager wired into `ApplicationComponents` startup/shutdown and route registration

## Test plan

- [x] `go test -race -count=1 ./internal/certlifecycle/...` — all pass (no races)
- [x] `golangci-lint run ./...` — zero issues
- [x] Coverage: 81.9% (above 80% threshold)
- [x] Tests: renewer (7), manager (12), handler (7), monitor (5), notifier (9), postgres_store (15), metrics (7)
- [x] `gofmt -s -l .` — no output

Resolves #409