### PR TITLE
[Feature] Add Keycloak user attribute sync for certificates (#414)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -970,17 +970,45 @@ func initializeCertLifecycle(
 		hmacSecret = os.Getenv(cfg.CertLifecycle.WebhookHMACSecretEnvVar)
 	}
 
+	// Create Keycloak client for cert attribute sync if enabled.
+	var keycloakClient certlifecycle.KeycloakUserClient
+	if cfg.CertLifecycle.KeycloakSync && cfg.Auth.Keycloak.BaseURL != "" {
+		kcCfg := &keycloak.Config{
+			BaseURL:       cfg.Auth.Keycloak.BaseURL,
+			Realm:         cfg.Auth.Keycloak.Realm,
+			ClientID:      cfg.Auth.Keycloak.ClientID,
+			ClientSecret:  cfg.Auth.Keycloak.ClientSecret,
+			AdminUsername: cfg.Auth.Keycloak.AdminUsername,
+			AdminPassword: cfg.Auth.Keycloak.AdminPassword,
+			Timeout:       cfg.Auth.Keycloak.Timeout,
+		}
+		if secret, secretErr := cfg.Auth.Keycloak.GetClientSecret(); secretErr == nil {
+			kcCfg.ClientSecret = secret
+		}
+		if adminPass, adminErr := cfg.Auth.Keycloak.GetAdminPassword(); adminErr == nil {
+			kcCfg.AdminPassword = adminPass
+		}
+		kcClient, kcErr := keycloak.NewClient(kcCfg)
+		if kcErr != nil {
+			logger.Warn("failed to create Keycloak client for cert sync",
+				zap.Error(kcErr))
+		} else {
+			keycloakClient = kcClient
+		}
+	}
+
 	// Create lifecycle manager.
 	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
-		Store:         certStore,
-		VaultClient:   vaultPKI,
-		Logger:        logger,
-		ScanInterval:  cfg.CertLifecycle.ScanInterval,
-		RenewalWindow: cfg.CertLifecycle.RenewalWindow,
-		MaxRetries:    cfg.CertLifecycle.MaxRenewalRetries,
-		RetryInterval: cfg.CertLifecycle.RenewalRetryInterval,
-		WebhookURL:    cfg.CertLifecycle.WebhookURL,
-		HMACSecret:    hmacSecret,
+		Store:          certStore,
+		VaultClient:    vaultPKI,
+		KeycloakClient: keycloakClient,
+		Logger:         logger,
+		ScanInterval:   cfg.CertLifecycle.ScanInterval,
+		RenewalWindow:  cfg.CertLifecycle.RenewalWindow,
+		MaxRetries:     cfg.CertLifecycle.MaxRenewalRetries,
+		RetryInterval:  cfg.CertLifecycle.RenewalRetryInterval,
+		WebhookURL:     cfg.CertLifecycle.WebhookURL,
+		HMACSecret:     hmacSecret,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cert lifecycle manager: %w", err)
@@ -995,6 +1023,7 @@ func initializeCertLifecycle(
 		zap.Duration("renewal_window", cfg.CertLifecycle.RenewalWindow),
 		zap.Bool("vault_configured", vaultPKI != nil),
 		zap.Bool("webhook_configured", cfg.CertLifecycle.WebhookURL != ""),
+		zap.Bool("keycloak_sync", keycloakClient != nil),
 	)
 
 	return mgr, nil

--- a/internal/certlifecycle/keycloak_sync.go
+++ b/internal/certlifecycle/keycloak_sync.go
@@ -1,0 +1,124 @@
+package certlifecycle
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// KeycloakUserClient defines the Keycloak operations needed for certificate sync.
+type KeycloakUserClient interface {
+	SetUserAttribute(ctx context.Context, userID, attributeName, attributeValue string) error
+}
+
+// KeycloakSyncer synchronizes certificate metadata to Keycloak user attributes.
+// Sync failures are logged as warnings and never block certificate operations.
+type KeycloakSyncer struct {
+	client KeycloakUserClient
+	logger *zap.Logger
+}
+
+// NewKeycloakSyncer creates a new KeycloakSyncer.
+func NewKeycloakSyncer(client KeycloakUserClient, logger *zap.Logger) *KeycloakSyncer {
+	return &KeycloakSyncer{
+		client: client,
+		logger: logger,
+	}
+}
+
+// SyncIssuance sets certificate attributes on the Keycloak user.
+// It stores the serial number, common name, issued_at, expires_at, and status.
+func (s *KeycloakSyncer) SyncIssuance(ctx context.Context, meta *CertificateMetadata) {
+	if meta.UserID == "" {
+		return
+	}
+
+	attrs := map[string]string{
+		"cert_serial":     meta.SerialNumber,
+		"cert_cn":         meta.CommonName,
+		"cert_issued_at":  meta.IssuedAt.Format(time.RFC3339),
+		"cert_expires_at": meta.ExpiresAt.Format(time.RFC3339),
+		"cert_status":     string(meta.Status),
+	}
+
+	for name, value := range attrs {
+		if err := s.client.SetUserAttribute(ctx, meta.UserID, name, value); err != nil {
+			s.logger.Warn("failed to sync cert attribute to Keycloak",
+				zap.String("user_id", meta.UserID),
+				zap.String("attribute", name),
+				zap.Error(err))
+			return
+		}
+	}
+
+	s.logger.Debug("synced certificate issuance to Keycloak",
+		zap.String("user_id", meta.UserID),
+		zap.String("serial", meta.SerialNumber))
+}
+
+// SyncRevocation updates the cert_status attribute to "revoked" on the Keycloak user.
+func (s *KeycloakSyncer) SyncRevocation(ctx context.Context, userID string) {
+	if userID == "" {
+		return
+	}
+
+	if err := s.client.SetUserAttribute(ctx, userID, "cert_status", string(StatusRevoked)); err != nil {
+		s.logger.Warn("failed to sync cert revocation to Keycloak",
+			zap.String("user_id", userID),
+			zap.Error(err))
+		return
+	}
+
+	s.logger.Debug("synced certificate revocation to Keycloak",
+		zap.String("user_id", userID))
+}
+
+// SyncRenewal updates the certificate attributes on the Keycloak user after renewal.
+func (s *KeycloakSyncer) SyncRenewal(ctx context.Context, meta *CertificateMetadata) {
+	if meta.UserID == "" {
+		return
+	}
+
+	attrs := map[string]string{
+		"cert_serial":     meta.SerialNumber,
+		"cert_cn":         meta.CommonName,
+		"cert_expires_at": meta.ExpiresAt.Format(time.RFC3339),
+		"cert_status":     string(meta.Status),
+		"cert_renewed_at": time.Now().Format(time.RFC3339),
+	}
+
+	for name, value := range attrs {
+		if err := s.client.SetUserAttribute(ctx, meta.UserID, name, value); err != nil {
+			s.logger.Warn("failed to sync cert renewal to Keycloak",
+				zap.String("user_id", meta.UserID),
+				zap.String("attribute", name),
+				zap.Error(err))
+			return
+		}
+	}
+
+	s.logger.Debug("synced certificate renewal to Keycloak",
+		zap.String("user_id", meta.UserID),
+		zap.String("serial", meta.SerialNumber))
+}
+
+// SyncExpiringSoon updates the cert_status attribute when a cert is expiring soon.
+func (s *KeycloakSyncer) SyncExpiringSoon(ctx context.Context, meta *CertificateMetadata) {
+	if meta.UserID == "" {
+		return
+	}
+
+	if err := s.client.SetUserAttribute(
+		ctx, meta.UserID, "cert_status", string(StatusExpiringSoon),
+	); err != nil {
+		s.logger.Warn("failed to sync expiring_soon status to Keycloak",
+			zap.String("user_id", meta.UserID),
+			zap.Error(err))
+		return
+	}
+
+	s.logger.Debug("synced expiring_soon status to Keycloak",
+		zap.String("user_id", meta.UserID),
+		zap.String("serial", meta.SerialNumber))
+}

--- a/internal/certlifecycle/keycloak_sync_test.go
+++ b/internal/certlifecycle/keycloak_sync_test.go
@@ -1,0 +1,287 @@
+package certlifecycle_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/piwi3910/netweave/internal/certlifecycle"
+)
+
+// mockKeycloakClient implements certlifecycle.KeycloakUserClient for testing.
+type mockKeycloakClient struct {
+	mu    sync.Mutex
+	attrs map[string]map[string]string // userID -> attrName -> attrValue
+	err   error
+}
+
+func newMockKeycloakClient() *mockKeycloakClient {
+	return &mockKeycloakClient{
+		attrs: make(map[string]map[string]string),
+	}
+}
+
+func (m *mockKeycloakClient) SetUserAttribute(
+	_ context.Context, userID, attributeName, attributeValue string,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return m.err
+	}
+	if m.attrs[userID] == nil {
+		m.attrs[userID] = make(map[string]string)
+	}
+	m.attrs[userID][attributeName] = attributeValue
+	return nil
+}
+
+func (m *mockKeycloakClient) getAttr(userID, attrName string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.attrs[userID] == nil {
+		return ""
+	}
+	return m.attrs[userID][attrName]
+}
+
+func (m *mockKeycloakClient) attrCount(userID string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.attrs[userID])
+}
+
+func TestKeycloakSyncer_SyncIssuance(t *testing.T) {
+	kcClient := newMockKeycloakClient()
+	logger := zaptest.NewLogger(t)
+	syncer := certlifecycle.NewKeycloakSyncer(kcClient, logger)
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "serial-001",
+		UserID:       "user-1",
+		CommonName:   "test.example.com",
+		Status:       certlifecycle.StatusActive,
+		IssuedAt:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		ExpiresAt:    time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	syncer.SyncIssuance(context.Background(), meta)
+
+	assert.Equal(t, 5, kcClient.attrCount("user-1"))
+	assert.Equal(t, "serial-001", kcClient.getAttr("user-1", "cert_serial"))
+	assert.Equal(t, "test.example.com", kcClient.getAttr("user-1", "cert_cn"))
+	assert.Equal(t, "active", kcClient.getAttr("user-1", "cert_status"))
+	assert.Contains(t, kcClient.getAttr("user-1", "cert_issued_at"), "2026-01-01")
+	assert.Contains(t, kcClient.getAttr("user-1", "cert_expires_at"), "2027-01-01")
+}
+
+func TestKeycloakSyncer_SyncIssuance_EmptyUserID(t *testing.T) {
+	kcClient := newMockKeycloakClient()
+	logger := zaptest.NewLogger(t)
+	syncer := certlifecycle.NewKeycloakSyncer(kcClient, logger)
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "serial-002",
+		UserID:       "",
+		CommonName:   "no-user.example.com",
+		Status:       certlifecycle.StatusActive,
+	}
+
+	syncer.SyncIssuance(context.Background(), meta)
+
+	// No attributes should be set when userID is empty.
+	assert.Equal(t, 0, kcClient.attrCount(""))
+}
+
+func TestKeycloakSyncer_SyncIssuance_Error(t *testing.T) {
+	kcClient := newMockKeycloakClient()
+	kcClient.err = errors.New("keycloak unavailable")
+	logger := zaptest.NewLogger(t)
+	syncer := certlifecycle.NewKeycloakSyncer(kcClient, logger)
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "serial-003",
+		UserID:       "user-1",
+		CommonName:   "err.example.com",
+		Status:       certlifecycle.StatusActive,
+		IssuedAt:     time.Now(),
+		ExpiresAt:    time.Now().Add(365 * 24 * time.Hour),
+	}
+
+	// Should not panic; errors are logged as warnings.
+	syncer.SyncIssuance(context.Background(), meta)
+}
+
+func TestKeycloakSyncer_SyncRevocation(t *testing.T) {
+	kcClient := newMockKeycloakClient()
+	logger := zaptest.NewLogger(t)
+	syncer := certlifecycle.NewKeycloakSyncer(kcClient, logger)
+
+	syncer.SyncRevocation(context.Background(), "user-1")
+
+	assert.Equal(t, "revoked", kcClient.getAttr("user-1", "cert_status"))
+}
+
+func TestKeycloakSyncer_SyncRevocation_EmptyUserID(t *testing.T) {
+	kcClient := newMockKeycloakClient()
+	logger := zaptest.NewLogger(t)
+	syncer := certlifecycle.NewKeycloakSyncer(kcClient, logger)
+
+	syncer.SyncRevocation(context.Background(), "")
+
+	assert.Equal(t, 0, kcClient.attrCount(""))
+}
+
+func TestKeycloakSyncer_SyncRevocation_Error(t *testing.T) {
+	kcClient := newMockKeycloakClient()
+	kcClient.err = errors.New("keycloak unavailable")
+	logger := zaptest.NewLogger(t)
+	syncer := certlifecycle.NewKeycloakSyncer(kcClient, logger)
+
+	// Should not panic.
+	syncer.SyncRevocation(context.Background(), "user-1")
+}
+
+func TestKeycloakSyncer_SyncRenewal(t *testing.T) {
+	kcClient := newMockKeycloakClient()
+	logger := zaptest.NewLogger(t)
+	syncer := certlifecycle.NewKeycloakSyncer(kcClient, logger)
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "renewed-serial",
+		UserID:       "user-2",
+		CommonName:   "renewed.example.com",
+		Status:       certlifecycle.StatusActive,
+		ExpiresAt:    time.Date(2028, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	syncer.SyncRenewal(context.Background(), meta)
+
+	assert.Equal(t, "renewed-serial", kcClient.getAttr("user-2", "cert_serial"))
+	assert.Equal(t, "renewed.example.com", kcClient.getAttr("user-2", "cert_cn"))
+	assert.Equal(t, "active", kcClient.getAttr("user-2", "cert_status"))
+	assert.Contains(t, kcClient.getAttr("user-2", "cert_expires_at"), "2028-01-01")
+	assert.NotEmpty(t, kcClient.getAttr("user-2", "cert_renewed_at"))
+}
+
+func TestKeycloakSyncer_SyncRenewal_EmptyUserID(t *testing.T) {
+	kcClient := newMockKeycloakClient()
+	logger := zaptest.NewLogger(t)
+	syncer := certlifecycle.NewKeycloakSyncer(kcClient, logger)
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "renewed-serial",
+		UserID:       "",
+	}
+
+	syncer.SyncRenewal(context.Background(), meta)
+	assert.Equal(t, 0, kcClient.attrCount(""))
+}
+
+func TestKeycloakSyncer_SyncExpiringSoon(t *testing.T) {
+	kcClient := newMockKeycloakClient()
+	logger := zaptest.NewLogger(t)
+	syncer := certlifecycle.NewKeycloakSyncer(kcClient, logger)
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "expiring-serial",
+		UserID:       "user-3",
+	}
+
+	syncer.SyncExpiringSoon(context.Background(), meta)
+
+	assert.Equal(t, "expiring_soon", kcClient.getAttr("user-3", "cert_status"))
+}
+
+func TestKeycloakSyncer_SyncExpiringSoon_EmptyUserID(t *testing.T) {
+	kcClient := newMockKeycloakClient()
+	logger := zaptest.NewLogger(t)
+	syncer := certlifecycle.NewKeycloakSyncer(kcClient, logger)
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "expiring-serial",
+		UserID:       "",
+	}
+
+	syncer.SyncExpiringSoon(context.Background(), meta)
+	assert.Equal(t, 0, kcClient.attrCount(""))
+}
+
+func TestKeycloakSyncer_SyncExpiringSoon_Error(t *testing.T) {
+	kcClient := newMockKeycloakClient()
+	kcClient.err = errors.New("keycloak down")
+	logger := zaptest.NewLogger(t)
+	syncer := certlifecycle.NewKeycloakSyncer(kcClient, logger)
+
+	meta := &certlifecycle.CertificateMetadata{
+		SerialNumber: "expiring-serial",
+		UserID:       "user-3",
+	}
+
+	// Should not panic.
+	syncer.SyncExpiringSoon(context.Background(), meta)
+}
+
+func TestManager_RecordIssuance_WithKeycloak(t *testing.T) {
+	store := newMockStore()
+	kcClient := newMockKeycloakClient()
+	logger := zaptest.NewLogger(t)
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:          store,
+		KeycloakClient: kcClient,
+		Logger:         logger,
+	})
+	require.NoError(t, err)
+
+	cert := &certlifecycle.CertificateMetadata{
+		SerialNumber: "kc-serial-001",
+		UserID:       "user-kc-1",
+		TenantID:     "tenant-1",
+		CommonName:   "kc.example.com",
+		Status:       certlifecycle.StatusActive,
+		IssuedAt:     time.Now(),
+		ExpiresAt:    time.Now().Add(365 * 24 * time.Hour),
+	}
+
+	err = mgr.RecordIssuance(context.Background(), cert)
+	require.NoError(t, err)
+
+	// Verify Keycloak attributes were set.
+	assert.Equal(t, "kc-serial-001", kcClient.getAttr("user-kc-1", "cert_serial"))
+	assert.Equal(t, "kc.example.com", kcClient.getAttr("user-kc-1", "cert_cn"))
+	assert.Equal(t, "active", kcClient.getAttr("user-kc-1", "cert_status"))
+}
+
+func TestManager_RecordRevocation_WithKeycloak(t *testing.T) {
+	store := newMockStore()
+	kcClient := newMockKeycloakClient()
+	logger := zaptest.NewLogger(t)
+
+	// Pre-populate cert.
+	store.certs["kc-revoke-serial"] = &certlifecycle.CertificateMetadata{
+		SerialNumber: "kc-revoke-serial",
+		UserID:       "user-kc-2",
+		TenantID:     "tenant-1",
+		Status:       certlifecycle.StatusActive,
+	}
+
+	mgr, err := certlifecycle.NewManager(&certlifecycle.ManagerConfig{
+		Store:          store,
+		KeycloakClient: kcClient,
+		Logger:         logger,
+	})
+	require.NoError(t, err)
+
+	err = mgr.RecordRevocation(context.Background(), "kc-revoke-serial")
+	require.NoError(t, err)
+
+	// Verify Keycloak status was updated.
+	assert.Equal(t, "revoked", kcClient.getAttr("user-kc-2", "cert_status"))
+}

--- a/internal/certlifecycle/manager.go
+++ b/internal/certlifecycle/manager.go
@@ -11,24 +11,26 @@ import (
 
 // ManagerConfig holds configuration for the lifecycle manager.
 type ManagerConfig struct {
-	Store         Store
-	VaultClient   VaultPKI
-	Logger        *zap.Logger
-	ScanInterval  time.Duration
-	RenewalWindow time.Duration
-	MaxRetries    int
-	RetryInterval time.Duration
-	WebhookURL    string
-	HMACSecret    string
+	Store          Store
+	VaultClient    VaultPKI
+	KeycloakClient KeycloakUserClient
+	Logger         *zap.Logger
+	ScanInterval   time.Duration
+	RenewalWindow  time.Duration
+	MaxRetries     int
+	RetryInterval  time.Duration
+	WebhookURL     string
+	HMACSecret     string
 }
 
 // Manager orchestrates certificate lifecycle automation.
-// It ties together the monitor, renewer, and notifier.
+// It ties together the monitor, renewer, notifier, and Keycloak syncer.
 type Manager struct {
 	store    Store
 	monitor  *Monitor
 	renewer  *Renewer
 	notifier *Notifier
+	keycloak *KeycloakSyncer
 	logger   *zap.Logger
 	stopCh   chan struct{}
 	wg       sync.WaitGroup
@@ -72,6 +74,11 @@ func NewManager(cfg *ManagerConfig) (*Manager, error) {
 			Notifier:      m.notifier,
 			Logger:        cfg.Logger,
 		})
+	}
+
+	// Initialize Keycloak syncer if client is provided.
+	if cfg.KeycloakClient != nil {
+		m.keycloak = NewKeycloakSyncer(cfg.KeycloakClient, cfg.Logger)
 	}
 
 	// Initialize monitor.
@@ -140,6 +147,10 @@ func (m *Manager) RecordIssuance(
 		}
 	}
 
+	if m.keycloak != nil {
+		m.keycloak.SyncIssuance(ctx, cert)
+	}
+
 	return nil
 }
 
@@ -168,6 +179,10 @@ func (m *Manager) RecordRevocation(
 		}
 	}
 
+	if m.keycloak != nil {
+		m.keycloak.SyncRevocation(ctx, meta.UserID)
+	}
+
 	return nil
 }
 
@@ -181,6 +196,10 @@ func (m *Manager) onExpiringSoon(ctx context.Context, meta *CertificateMetadata)
 				zap.String("serial", meta.SerialNumber),
 				zap.Error(err))
 		}
+	}
+
+	if m.keycloak != nil {
+		m.keycloak.SyncExpiringSoon(ctx, meta)
 	}
 
 	// Attempt automatic renewal if renewer is available.


### PR DESCRIPTION
## Summary

- **KeycloakSyncer**: Synchronizes certificate metadata to Keycloak user attributes on issuance, revocation, renewal, and expiring_soon events
- **KeycloakUserClient interface**: Decouples from concrete Keycloak client for testability
- **Manager integration**: Wired into RecordIssuance, RecordRevocation, and onExpiringSoon callbacks
- **Gateway wiring**: Creates Keycloak client when `cert_lifecycle.keycloak_sync` is enabled in config
- **Fail-safe**: All sync failures logged as warnings, never block certificate operations

## Test plan

- [x] `go test -race -count=1 ./internal/certlifecycle/...` — all pass (no races)
- [x] `golangci-lint run ./...` — zero issues
- [x] Coverage: 82.8% (above 80% threshold)
- [x] 15 new Keycloak sync tests: issuance, revocation, renewal, expiring_soon, empty user IDs, error handling, manager integration
- [x] `gofmt -s -l .` — no output

Resolves #414