### PR TITLE
Auto-register adapters on backend CRUD operations

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -347,6 +347,7 @@ func initializeBackendAdmin(
 	}
 
 	srv.SetAdapterRegistry(registry, backendStore)
+	backendHandler.SetAdapterRegistry(registry)
 
 	logger.Info("dynamic adapter registry initialized",
 		zap.Int("adapters_loaded", loaded),

--- a/internal/backend/adapter_registry.go
+++ b/internal/backend/adapter_registry.go
@@ -155,6 +155,25 @@ func (r *AdapterRegistry) RefreshAdapter(ctx context.Context, store Store, backe
 	return nil
 }
 
+// RemoveAdapter removes and closes the adapter for a given backend ID.
+func (r *AdapterRegistry) RemoveAdapter(backendID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if adp, ok := r.adapters[backendID]; ok {
+		if err := adp.Close(); err != nil {
+			r.logger.Warn("failed to close adapter during removal",
+				zap.String("backend_id", backendID),
+				zap.Error(err),
+			)
+		}
+		delete(r.adapters, backendID)
+		r.logger.Info("adapter removed for backend",
+			zap.String("backend_id", backendID),
+		)
+	}
+}
+
 // Count returns the number of adapters in the registry.
 func (r *AdapterRegistry) Count() int {
 	r.mu.RLock()

--- a/internal/backend/adapter_registry_test.go
+++ b/internal/backend/adapter_registry_test.go
@@ -228,6 +228,67 @@ func TestAdapterRegistry_RefreshAdapter(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, registry.Count())
 	})
+
+	t.Run("registers new adapter without prior load", func(t *testing.T) {
+		registry := newTestRegistry(t)
+		assert.Equal(t, 0, registry.Count())
+
+		store := &fakeBackendStore{
+			backends: []*backend.Instance{
+				{
+					ID:          "new-backend",
+					AdapterType: "mock",
+					Status:      "active",
+				},
+			},
+		}
+
+		err := registry.RefreshAdapter(
+			context.Background(), store, "new-backend",
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 1, registry.Count())
+
+		adp, err := registry.GetAdapter("new-backend")
+		require.NoError(t, err)
+		require.NotNil(t, adp)
+		assert.Equal(t, "mock", adp.Name())
+	})
+}
+
+func TestAdapterRegistry_RemoveAdapter(t *testing.T) {
+	t.Run("removes existing adapter", func(t *testing.T) {
+		registry := newTestRegistry(t)
+		store := &fakeBackendStore{
+			backends: []*backend.Instance{
+				{
+					ID:          "b1",
+					AdapterType: "mock",
+					Status:      "active",
+				},
+			},
+		}
+
+		loaded, err := registry.LoadFromStore(
+			context.Background(), store,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 1, loaded)
+
+		registry.RemoveAdapter("b1")
+		assert.Equal(t, 0, registry.Count())
+
+		_, err = registry.GetAdapter("b1")
+		assert.ErrorIs(t, err, backend.ErrAdapterNotFound)
+	})
+
+	t.Run("no-op for non-existent adapter", func(t *testing.T) {
+		registry := newTestRegistry(t)
+		assert.Equal(t, 0, registry.Count())
+
+		registry.RemoveAdapter("nonexistent")
+		assert.Equal(t, 0, registry.Count())
+	})
 }
 
 func TestAdapterRegistry_Close(t *testing.T) {

--- a/internal/handlers/backend.go
+++ b/internal/handlers/backend.go
@@ -11,10 +11,11 @@ import (
 
 // BackendHandler handles admin API endpoints for backend instance management.
 type BackendHandler struct {
-	store     backend.Store
-	encryptor encryption.Encryptor
-	registry  *backend.SchemaRegistry
-	logger    *zap.Logger
+	store           backend.Store
+	encryptor       encryption.Encryptor
+	registry        *backend.SchemaRegistry
+	adapterRegistry *backend.AdapterRegistry
+	logger          *zap.Logger
 }
 
 // NewBackendHandler creates a new BackendHandler.
@@ -43,6 +44,13 @@ func NewBackendHandler(
 		registry:  registry,
 		logger:    logger,
 	}
+}
+
+// SetAdapterRegistry sets the adapter registry for live adapter management.
+// When set, backend CRUD operations will automatically register/refresh/remove
+// adapters in the registry so they become available immediately without restart.
+func (h *BackendHandler) SetAdapterRegistry(ar *backend.AdapterRegistry) {
+	h.adapterRegistry = ar
 }
 
 // RegisterRoutes registers all backend admin API routes on the given router group.

--- a/internal/handlers/backend_crud.go
+++ b/internal/handlers/backend_crud.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -86,6 +87,8 @@ func (h *BackendHandler) CreateBackend(c *gin.Context) {
 		zap.String("backend_id", instance.ID),
 		zap.String("name", instance.Name),
 	)
+
+	h.refreshAdapterAsync(c.Request.Context(), instance.ID)
 
 	c.JSON(http.StatusCreated, backendToResponse(instance))
 }
@@ -235,6 +238,9 @@ func (h *BackendHandler) UpdateBackend(c *gin.Context) {
 	}
 
 	h.logger.Info("backend updated", zap.String("backend_id", id))
+
+	h.refreshAdapterAsync(c.Request.Context(), id)
+
 	c.JSON(http.StatusOK, backendToResponse(existing))
 }
 
@@ -294,6 +300,8 @@ func (h *BackendHandler) DeleteBackend(c *gin.Context) {
 		return
 	}
 
+	h.removeAdapter(id)
+
 	h.logger.Info("backend deleted", zap.String("backend_id", id))
 	c.Status(http.StatusNoContent)
 }
@@ -326,6 +334,28 @@ func (h *BackendHandler) TestBackend(c *gin.Context) {
 		"status":    "unknown",
 		"message":   "Connection test not yet implemented",
 	})
+}
+
+// refreshAdapterAsync refreshes the adapter for a backend in the registry.
+// Errors are logged but do not fail the HTTP request.
+func (h *BackendHandler) refreshAdapterAsync(ctx context.Context, backendID string) {
+	if h.adapterRegistry == nil {
+		return
+	}
+	if err := h.adapterRegistry.RefreshAdapter(ctx, h.store, backendID); err != nil {
+		h.logger.Warn("failed to refresh adapter after backend change",
+			zap.String("backend_id", backendID),
+			zap.Error(err),
+		)
+	}
+}
+
+// removeAdapter removes an adapter from the registry.
+func (h *BackendHandler) removeAdapter(backendID string) {
+	if h.adapterRegistry == nil {
+		return
+	}
+	h.adapterRegistry.RemoveAdapter(backendID)
 }
 
 // encryptMap marshals a map to JSON and encrypts it.


### PR DESCRIPTION
## Summary
- Backend create/update/delete via admin API now immediately registers/refreshes/removes adapters in the live `AdapterRegistry`
- No gateway restart required for new backends to become available
- Adds `RemoveAdapter` method and `SetAdapterRegistry` wiring

## Test plan
- [x] Existing adapter registry tests pass
- [x] Existing backend handler tests pass  
- [x] New tests for `RemoveAdapter` and `RefreshAdapter` on fresh registry
- [x] Lint passes (zero issues)
- [ ] CI pipeline

Resolves #424