### PR TITLE
[Fix] Decrypt backend config in AdapterRegistry

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -333,7 +333,7 @@ func initializeBackendAdmin(
 
 	// Initialize dynamic adapter registry
 	factory := backend.NewAdapterFactory()
-	registry := backend.NewAdapterRegistry(factory, logger)
+	registry := backend.NewAdapterRegistry(factory, enc, logger)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/internal/backend/adapter_registry.go
+++ b/internal/backend/adapter_registry.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/piwi3910/netweave/internal/adapter"
+	"github.com/piwi3910/netweave/internal/encryption"
 )
 
 // ErrNoBackendAccess is returned when a tenant has no backend access configured.
@@ -20,19 +21,49 @@ var ErrAdapterNotFound = fmt.Errorf("adapter not found in registry")
 // It is thread-safe and supports loading adapters from the backend store on startup,
 // as well as refreshing individual adapters when backend configuration changes.
 type AdapterRegistry struct {
-	mu       sync.RWMutex
-	adapters map[string]adapter.Adapter
-	factory  *AdapterFactory
-	logger   *zap.Logger
+	mu        sync.RWMutex
+	adapters  map[string]adapter.Adapter
+	factory   *AdapterFactory
+	encryptor encryption.Encryptor
+	logger    *zap.Logger
 }
 
 // NewAdapterRegistry creates a new AdapterRegistry.
-func NewAdapterRegistry(factory *AdapterFactory, logger *zap.Logger) *AdapterRegistry {
+// The encryptor is used to decrypt backend Config and Credentials fields
+// loaded from the store before passing them to the adapter factory.
+func NewAdapterRegistry(factory *AdapterFactory, enc encryption.Encryptor, logger *zap.Logger) *AdapterRegistry {
 	return &AdapterRegistry{
-		adapters: make(map[string]adapter.Adapter),
-		factory:  factory,
-		logger:   logger,
+		adapters:  make(map[string]adapter.Adapter),
+		factory:   factory,
+		encryptor: enc,
+		logger:    logger,
 	}
+}
+
+// decryptInstance decrypts the Config and Credentials fields of a backend instance in-place.
+// If the encryptor is nil or a field is empty, that field is left unchanged.
+func (r *AdapterRegistry) decryptInstance(inst *Instance) error {
+	if r.encryptor == nil {
+		return nil
+	}
+
+	if len(inst.Config) > 0 {
+		decrypted, err := r.encryptor.Decrypt(inst.Config)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt config for backend %s: %w", inst.ID, err)
+		}
+		inst.Config = decrypted
+	}
+
+	if len(inst.Credentials) > 0 {
+		decrypted, err := r.encryptor.Decrypt(inst.Credentials)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt credentials for backend %s: %w", inst.ID, err)
+		}
+		inst.Credentials = decrypted
+	}
+
+	return nil
 }
 
 // LoadFromStore loads all active backend instances from the store and creates adapters.
@@ -50,6 +81,14 @@ func (r *AdapterRegistry) LoadFromStore(ctx context.Context, store Store) (int, 
 			r.logger.Info("skipping backend with non-active status",
 				zap.String("backend_id", inst.ID),
 				zap.String("status", inst.Status),
+			)
+			continue
+		}
+
+		if decErr := r.decryptInstance(inst); decErr != nil {
+			r.logger.Warn("failed to decrypt backend config, skipping",
+				zap.String("backend_id", inst.ID),
+				zap.Error(decErr),
 			)
 			continue
 		}
@@ -127,6 +166,10 @@ func (r *AdapterRegistry) RefreshAdapter(ctx context.Context, store Store, backe
 	instance, err := store.GetBackend(ctx, backendID)
 	if err != nil {
 		return fmt.Errorf("failed to get backend %s: %w", backendID, err)
+	}
+
+	if decErr := r.decryptInstance(instance); decErr != nil {
+		return fmt.Errorf("failed to decrypt backend %s: %w", backendID, decErr)
 	}
 
 	adp, createErr := r.factory.CreateAdapter(instance)

--- a/internal/backend/adapter_registry_test.go
+++ b/internal/backend/adapter_registry_test.go
@@ -9,13 +9,21 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/piwi3910/netweave/internal/backend"
+	"github.com/piwi3910/netweave/internal/encryption"
 )
 
 func newTestRegistry(t *testing.T) *backend.AdapterRegistry {
 	t.Helper()
 	factory := backend.NewAdapterFactory()
 	logger := zap.NewNop()
-	return backend.NewAdapterRegistry(factory, logger)
+	return backend.NewAdapterRegistry(factory, nil, logger)
+}
+
+func newTestRegistryWithEncryptor(t *testing.T, enc encryption.Encryptor) *backend.AdapterRegistry {
+	t.Helper()
+	factory := backend.NewAdapterFactory()
+	logger := zap.NewNop()
+	return backend.NewAdapterRegistry(factory, enc, logger)
 }
 
 func TestAdapterRegistry_GetAdapter(t *testing.T) {
@@ -318,6 +326,78 @@ func TestAdapterRegistry_Close(t *testing.T) {
 		err = registry.Close()
 		require.NoError(t, err)
 		assert.Equal(t, 0, registry.Count())
+	})
+}
+
+func TestAdapterRegistry_LoadFromStore_WithEncryption(t *testing.T) {
+	t.Run("decrypts config before creating adapter", func(t *testing.T) {
+		key := make([]byte, 32)
+		for i := range key {
+			key[i] = byte(i)
+		}
+		enc, err := encryption.NewAESEncryptor(key)
+		require.NoError(t, err)
+
+		plainConfig := []byte(`{"populate_sample_data":true}`)
+		encConfig, err := enc.Encrypt(plainConfig)
+		require.NoError(t, err)
+
+		registry := newTestRegistryWithEncryptor(t, enc)
+		store := &fakeBackendStore{
+			backends: []*backend.Instance{
+				{
+					ID:          "encrypted-backend",
+					AdapterType: "mock",
+					Status:      "active",
+					Config:      encConfig,
+				},
+			},
+		}
+
+		loaded, loadErr := registry.LoadFromStore(context.Background(), store)
+		require.NoError(t, loadErr)
+		assert.Equal(t, 1, loaded)
+
+		adp, adpErr := registry.GetAdapter("encrypted-backend")
+		require.NoError(t, adpErr)
+		require.NotNil(t, adp)
+		assert.Equal(t, "mock", adp.Name())
+	})
+}
+
+func TestAdapterRegistry_RefreshAdapter_WithEncryption(t *testing.T) {
+	t.Run("decrypts config before creating adapter", func(t *testing.T) {
+		key := make([]byte, 32)
+		for i := range key {
+			key[i] = byte(i)
+		}
+		enc, err := encryption.NewAESEncryptor(key)
+		require.NoError(t, err)
+
+		plainConfig := []byte(`{"populate_sample_data":true}`)
+		encConfig, err := enc.Encrypt(plainConfig)
+		require.NoError(t, err)
+
+		registry := newTestRegistryWithEncryptor(t, enc)
+		store := &fakeBackendStore{
+			backends: []*backend.Instance{
+				{
+					ID:          "encrypted-backend",
+					AdapterType: "mock",
+					Status:      "active",
+					Config:      encConfig,
+				},
+			},
+		}
+
+		refreshErr := registry.RefreshAdapter(context.Background(), store, "encrypted-backend")
+		require.NoError(t, refreshErr)
+		assert.Equal(t, 1, registry.Count())
+
+		adp, adpErr := registry.GetAdapter("encrypted-backend")
+		require.NoError(t, adpErr)
+		require.NotNil(t, adp)
+		assert.Equal(t, "mock", adp.Name())
 	})
 }
 


### PR DESCRIPTION
## Summary

- AdapterRegistry now decrypts `Config` and `Credentials` fields using the Encryptor before passing instances to AdapterFactory
- `NewAdapterRegistry` accepts an `encryption.Encryptor` parameter (nil-safe — plaintext configs still work)
- `decryptInstance` helper method handles both fields with proper error handling
- Wired encryptor from `main.go` into the registry

## Problem

Backends created via the admin API have their Config/Credentials encrypted (Vault transit or AES) before storage. When the `AdapterRegistry` loaded backends from PostgreSQL, it passed encrypted bytes directly to the factory which tried `json.Unmarshal` — causing failures like:
```
failed to parse mock adapter config: invalid character 'å' looking for beginning of value
```

## Test plan

- [x] Existing registry tests pass with nil encryptor (plaintext configs)
- [x] New `TestAdapterRegistry_LoadFromStore_WithEncryption` — verifies AES-encrypted config is decrypted before adapter creation
- [x] New `TestAdapterRegistry_RefreshAdapter_WithEncryption` — verifies refresh path also decrypts
- [x] `make lint` passes
- [x] All changed packages pass: `go test -race ./internal/backend/ ./internal/handlers/ ./cmd/gateway/`

Resolves #426