### PR TITLE
[Fix] Handle string-valued config in adapter factory

### DIFF
--- a/internal/backend/adapter_factory.go
+++ b/internal/backend/adapter_factory.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/piwi3910/netweave/internal/adapter"
 	imsmock "github.com/piwi3910/netweave/internal/adapters/mock"
@@ -70,65 +71,88 @@ func (f *AdapterFactory) CreateSMOAdapter(instance *Instance) (smo.Plugin, error
 // ErrUnsupportedAdapterType is returned when an adapter type is not supported by the factory.
 var ErrUnsupportedAdapterType = fmt.Errorf("unsupported adapter type")
 
-// mockConfig holds parsed configuration for a mock adapter instance.
-type mockConfig struct {
-	PopulateSampleData bool   `json:"populate_sample_data"`
-	OCloudID           string `json:"ocloud_id"`
+// parseConfigMap parses instance.Config as a generic map.
+// Config values can be strings (from admin API map[string]string)
+// or native JSON types (booleans, numbers). Returns an empty map if Config is empty.
+func parseConfigMap(config []byte) (map[string]interface{}, error) {
+	if len(config) == 0 {
+		return make(map[string]interface{}), nil
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(config, &m); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+	return m, nil
+}
+
+// configBool extracts a boolean from a config map, handling both native JSON booleans
+// and string values ("true"/"false"). Returns the default if the key is absent.
+func configBool(m map[string]interface{}, key string, defaultVal bool) bool {
+	v, ok := m[key]
+	if !ok {
+		return defaultVal
+	}
+
+	switch val := v.(type) {
+	case bool:
+		return val
+	case string:
+		return strings.EqualFold(val, "true")
+	default:
+		return defaultVal
+	}
+}
+
+// configString extracts a string from a config map, handling both string values
+// and fmt.Stringer types. Returns empty string if the key is absent.
+func configString(m map[string]interface{}, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+
+	if s, isStr := v.(string); isStr {
+		return s
+	}
+	return fmt.Sprintf("%v", v)
 }
 
 // createMockAdapter creates a mock IMS adapter from instance configuration.
 func (f *AdapterFactory) createMockAdapter(instance *Instance) (adapter.Adapter, error) {
-	cfg := mockConfig{
-		PopulateSampleData: true,
-		OCloudID:           instance.ID,
+	configMap, err := parseConfigMap(instance.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse mock adapter config: %w", err)
 	}
 
-	// Parse config if present.
-	if len(instance.Config) > 0 {
-		if err := json.Unmarshal(instance.Config, &cfg); err != nil {
-			return nil, fmt.Errorf("failed to parse mock adapter config: %w", err)
-		}
+	populateSampleData := configBool(configMap, "populate_sample_data", true)
+
+	ocloudID := configString(configMap, "ocloud_id")
+	if ocloudID == "" {
+		ocloudID = instance.ID
 	}
 
-	// Use instance ID as OCloudID if not explicitly configured.
-	if cfg.OCloudID == "" {
-		cfg.OCloudID = instance.ID
-	}
-
-	return imsmock.NewAdapterWithOCloudID(cfg.OCloudID, cfg.PopulateSampleData), nil
-}
-
-// mockDMSConfig holds parsed configuration for a mock DMS adapter instance.
-type mockDMSConfig struct {
-	PopulateSampleData bool `json:"populate_sample_data"`
+	return imsmock.NewAdapterWithOCloudID(ocloudID, populateSampleData), nil
 }
 
 // createMockDMSAdapter creates a mock DMS adapter from instance configuration.
 func (f *AdapterFactory) createMockDMSAdapter(instance *Instance) (dmsadapter.DMSAdapter, error) {
-	cfg := mockDMSConfig{
-		PopulateSampleData: true,
+	configMap, err := parseConfigMap(instance.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse mock DMS adapter config: %w", err)
 	}
 
-	// Parse config if present.
-	if len(instance.Config) > 0 {
-		if err := json.Unmarshal(instance.Config, &cfg); err != nil {
-			return nil, fmt.Errorf("failed to parse mock DMS adapter config: %w", err)
-		}
-	}
+	populateSampleData := configBool(configMap, "populate_sample_data", true)
 
-	return dmsmock.NewAdapter(cfg.PopulateSampleData), nil
+	return dmsmock.NewAdapter(populateSampleData), nil
 }
 
 // createMockSMOAdapter creates a mock SMO plugin from instance configuration.
 func (f *AdapterFactory) createMockSMOAdapter(instance *Instance) (smo.Plugin, error) {
 	plugin := smomock.NewPlugin()
 
-	// Parse config to pass to Initialize if present.
-	var configMap map[string]interface{}
-	if len(instance.Config) > 0 {
-		if err := json.Unmarshal(instance.Config, &configMap); err != nil {
-			return nil, fmt.Errorf("failed to parse mock SMO adapter config: %w", err)
-		}
+	if _, err := parseConfigMap(instance.Config); err != nil {
+		return nil, fmt.Errorf("failed to parse mock SMO adapter config: %w", err)
 	}
 
 	return plugin, nil

--- a/internal/backend/adapter_factory_test.go
+++ b/internal/backend/adapter_factory_test.go
@@ -104,6 +104,54 @@ func TestAdapterFactory_CreateAdapter(t *testing.T) {
 		assert.Contains(t, err.Error(), "parse mock adapter config")
 	})
 
+	t.Run("mock adapter with string-valued config from admin API", func(t *testing.T) {
+		// Admin API stores config as map[string]string, so booleans become strings.
+		cfg := map[string]string{
+			"populate_sample_data": "true",
+			"ocloud_id":            "string-ocloud",
+		}
+		cfgJSON, err := json.Marshal(cfg)
+		require.NoError(t, err)
+
+		instance := &backend.Instance{
+			ID:          "test-backend-string-config",
+			AdapterType: "mock",
+			Config:      cfgJSON,
+		}
+		adp, err := factory.CreateAdapter(instance)
+		require.NoError(t, err)
+		require.NotNil(t, adp)
+
+		dms, dmErr := adp.ListDeploymentManagers(
+			context.Background(), nil,
+		)
+		require.NoError(t, dmErr)
+		require.Len(t, dms, 1)
+		assert.Equal(t, "string-ocloud", dms[0].OCloudID)
+	})
+
+	t.Run("mock adapter with string false disables sample data", func(t *testing.T) {
+		cfg := map[string]string{
+			"populate_sample_data": "false",
+		}
+		cfgJSON, err := json.Marshal(cfg)
+		require.NoError(t, err)
+
+		instance := &backend.Instance{
+			ID:          "test-string-false",
+			AdapterType: "mock",
+			Config:      cfgJSON,
+		}
+		adp, err := factory.CreateAdapter(instance)
+		require.NoError(t, err)
+
+		pools, poolErr := adp.ListResourcePools(
+			context.Background(), nil,
+		)
+		require.NoError(t, poolErr)
+		assert.Empty(t, pools)
+	})
+
 	t.Run("mock adapter uses instance ID as OCloudID when not configured", func(t *testing.T) {
 		instance := &backend.Instance{
 			ID:          "my-special-backend",


### PR DESCRIPTION
## Summary

- Replaced typed struct-based config parsing with generic `map[string]interface{}` parsing
- Added `configBool` and `configString` helpers that handle both native JSON types and string values
- Removed `mockConfig` and `mockDMSConfig` structs in favor of the generic parsing approach
- Unified config parsing across IMS, DMS, and SMO mock adapter factories via `parseConfigMap`

## Problem

The admin API stores backend config as `map[string]string`, producing JSON like `{"populate_sample_data":"true"}` where boolean values are strings. The adapter factory used `json.Unmarshal` into typed structs (`mockConfig.PopulateSampleData bool`), which failed with:
```
json: cannot unmarshal string into Go struct field mockConfig.populate_sample_data of type bool
```

## Test plan

- [x] Existing factory tests pass (native JSON boolean configs still work)
- [x] New test: `mock adapter with string-valued config from admin API` — verifies string `"true"` works
- [x] New test: `mock adapter with string false disables sample data` — verifies string `"false"` works
- [x] `make lint` passes (0 issues)
- [x] `go test -race ./internal/backend/` all pass

Resolves #426