### PR TITLE
[Fix] Remove redundant TenantID filter from mock adapter

### DIFF
--- a/internal/adapters/mock/adapter.go
+++ b/internal/adapters/mock/adapter.go
@@ -620,9 +620,9 @@ func (a *Adapter) matchesPoolFilter(pool *adapter.ResourcePool, filter *adapter.
 		return false
 	}
 
-	if filter.TenantID != "" && pool.TenantID != filter.TenantID {
-		return false
-	}
+	// TenantID filtering is not applied here because each mock adapter instance
+	// is scoped to a single backend. Tenant isolation is enforced by the adapter
+	// registry, which resolves the correct adapter per tenant.
 
 	return true
 }
@@ -640,9 +640,9 @@ func (a *Adapter) matchesResourceFilter(resource *adapter.Resource, filter *adap
 		return false
 	}
 
-	if filter.TenantID != "" && resource.TenantID != filter.TenantID {
-		return false
-	}
+	// TenantID filtering is not applied here because each mock adapter instance
+	// is scoped to a single backend. Tenant isolation is enforced by the adapter
+	// registry, which resolves the correct adapter per tenant.
 
 	return true
 }


### PR DESCRIPTION
## Summary

- Removed TenantID filter from mock adapter's `matchesPoolFilter` and `matchesResourceFilter`
- Tenant isolation is already enforced by the AdapterRegistry (each tenant gets their own adapter instance via backend access mapping)
- The redundant filter was causing all resource pools and resources to return empty because mock sample data doesn't set TenantID

## Problem

When querying `GET /o2ims-infrastructureInventory/v1/resourcePools` with a tenant-scoped mTLS cert, the response was always `{"resourcePools":[],"total":0}` despite the correct adapter being resolved. The filter's TenantID (from the cert's auth context) didn't match the pool's empty TenantID.

## Test plan

- [x] `make lint` passes
- [x] Server tests pass (tenant middleware, adapter registry tests)
- [x] Manual verification pending after deploy

Resolves #426