### PR TITLE
Add CLI commands for backends, backend-access, and plugins

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -9,7 +9,10 @@ import (
 
 	"github.com/piwi3910/netweave/internal/cli/cmd"
 	apicommands "github.com/piwi3910/netweave/internal/cli/cmd/api"
+	"github.com/piwi3910/netweave/internal/cli/cmd/backendaccess"
+	"github.com/piwi3910/netweave/internal/cli/cmd/backends"
 	"github.com/piwi3910/netweave/internal/cli/cmd/certs"
+	"github.com/piwi3910/netweave/internal/cli/cmd/plugins"
 	"github.com/piwi3910/netweave/internal/cli/cmd/roles"
 	"github.com/piwi3910/netweave/internal/cli/cmd/setup"
 	"github.com/piwi3910/netweave/internal/cli/cmd/tenants"
@@ -34,6 +37,9 @@ func run() error {
 	root.AddCommand(roles.NewRolesCmd())
 	root.AddCommand(tenants.NewTenantsCmd())
 	root.AddCommand(certs.NewCertsCmd())
+	root.AddCommand(backends.NewBackendsCmd())
+	root.AddCommand(backendaccess.NewBackendAccessCmd())
+	root.AddCommand(plugins.NewPluginsCmd())
 
 	if err := root.Execute(); err != nil {
 		return fmt.Errorf("command failed: %w", err)

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -112,14 +112,15 @@ curl -ks https://api.netweave.local/healthz \
 
 ## Phase 3: Get Admin Access
 
-### 3.1 Obtain an OAuth2 Token
+The CLI commands for backends, plugins, and backend-access handle OAuth2 authentication automatically. They read the client secret from the K8s secret `netweave-secret` and obtain a Bearer token from Keycloak.
 
-The admin user was created during bootstrap with:
+Default credentials (set during bootstrap):
 - Email: `admin@netweave.local`
 - Password: `admin`
-- Cert CN: `admin.netweave.local`
 
-Get a Bearer token from Keycloak:
+### 3.1 Verify Admin Access
+
+For commands that still use curl, obtain a token manually:
 
 ```bash
 # Get the gateway client secret from K8s
@@ -139,25 +140,27 @@ TOKEN=$(curl -ks https://auth.netweave.local/realms/netweave/protocol/openid-con
 echo "Admin token obtained (${#TOKEN} chars)"
 ```
 
-### 3.2 Verify Admin Access
-
-Test the admin API with mTLS + Bearer token:
-
-```bash
-curl -ks https://api.netweave.local/admin/tenant/me \
-  --cert ~/.netweave/client.crt \
-  --key ~/.netweave/client.key \
-  --cacert ~/.netweave/ca.crt \
-  -H "Authorization: Bearer $TOKEN" | jq .
-```
-
 ---
 
 ## Phase 4: Enable the O2-IMS Interface
 
-The O2-IMS plugin is disabled by default. Enable it via the admin API:
+The O2-IMS plugin is disabled by default. Enable it via the CLI:
 
 ```bash
+build/netweave-cli plugins enable --name o2ims
+```
+
+Verify it's enabled:
+
+```bash
+build/netweave-cli plugins list
+```
+
+<details>
+<summary>Equivalent curl commands (reference)</summary>
+
+```bash
+# Enable plugin
 curl -ks -X PUT https://api.netweave.local/admin/platform/plugins/o2ims \
   --cert ~/.netweave/client.crt \
   --key ~/.netweave/client.key \
@@ -165,17 +168,16 @@ curl -ks -X PUT https://api.netweave.local/admin/platform/plugins/o2ims \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"enabled": true}' | jq .
-```
 
-Verify it's enabled:
-
-```bash
+# List plugins
 curl -ks https://api.netweave.local/admin/platform/plugins \
   --cert ~/.netweave/client.crt \
   --key ~/.netweave/client.key \
   --cacert ~/.netweave/ca.crt \
   -H "Authorization: Bearer $TOKEN" | jq .
 ```
+
+</details>
 
 ---
 
@@ -184,6 +186,44 @@ curl -ks https://api.netweave.local/admin/platform/plugins \
 ### 5.1 Create Backend Alpha
 
 ```bash
+ALPHA_ID=$(build/netweave-cli backends create \
+  --name "Mock IMS Alpha" \
+  --category ims \
+  --adapter-type mock \
+  --description "Simulated O-Cloud infrastructure for Acme Telecom" \
+  --config populate_sample_data=true \
+  --config ocloud_id=ocloud-alpha-001 \
+  --json | jq -r '.id')
+
+echo "Alpha Backend ID: $ALPHA_ID"
+```
+
+### 5.2 Create Backend Beta
+
+```bash
+BETA_ID=$(build/netweave-cli backends create \
+  --name "Mock IMS Beta" \
+  --category ims \
+  --adapter-type mock \
+  --description "Simulated O-Cloud infrastructure for GlobalNet Corp" \
+  --config populate_sample_data=true \
+  --config ocloud_id=ocloud-beta-002 \
+  --json | jq -r '.id')
+
+echo "Beta Backend ID: $BETA_ID"
+```
+
+### 5.3 Verify Backends
+
+```bash
+build/netweave-cli backends list
+```
+
+<details>
+<summary>Equivalent curl commands (reference)</summary>
+
+```bash
+# Create Alpha
 ALPHA_ID=$(curl -ks -X POST https://api.netweave.local/admin/infrastructure/backends \
   --cert ~/.netweave/client.crt \
   --key ~/.netweave/client.key \
@@ -201,12 +241,7 @@ ALPHA_ID=$(curl -ks -X POST https://api.netweave.local/admin/infrastructure/back
     }
   }' | jq -r '.id')
 
-echo "Alpha Backend ID: $ALPHA_ID"
-```
-
-### 5.2 Create Backend Beta
-
-```bash
+# Create Beta
 BETA_ID=$(curl -ks -X POST https://api.netweave.local/admin/infrastructure/backends \
   --cert ~/.netweave/client.crt \
   --key ~/.netweave/client.key \
@@ -224,18 +259,15 @@ BETA_ID=$(curl -ks -X POST https://api.netweave.local/admin/infrastructure/backe
     }
   }' | jq -r '.id')
 
-echo "Beta Backend ID: $BETA_ID"
-```
-
-### 5.3 Verify Backends
-
-```bash
+# List backends
 curl -ks https://api.netweave.local/admin/infrastructure/backends \
   --cert ~/.netweave/client.crt \
   --key ~/.netweave/client.key \
   --cacert ~/.netweave/ca.crt \
   -H "Authorization: Bearer $TOKEN" | jq '.backends[] | {id, name, category, adapterType, status}'
 ```
+
+</details>
 
 ---
 
@@ -308,6 +340,26 @@ curl -ks https://api.netweave.local/admin/platform/tenants \
 ### 7.1 Map Alpha Backend to Acme Telecom
 
 ```bash
+build/netweave-cli backend-access grant \
+  --tenant "$ACME_ID" \
+  --backend "$ALPHA_ID" \
+  --permissions read,subscribe
+```
+
+### 7.2 Map Beta Backend to GlobalNet Corp
+
+```bash
+build/netweave-cli backend-access grant \
+  --tenant "$GLOBALNET_ID" \
+  --backend "$BETA_ID" \
+  --permissions read,subscribe
+```
+
+<details>
+<summary>Equivalent curl commands (reference)</summary>
+
+```bash
+# Grant Alpha to Acme
 curl -ks -X POST "https://api.netweave.local/admin/infrastructure/tenants/${ACME_ID}/backend-access" \
   --cert ~/.netweave/client.crt \
   --key ~/.netweave/client.key \
@@ -318,11 +370,8 @@ curl -ks -X POST "https://api.netweave.local/admin/infrastructure/tenants/${ACME
     \"backendId\": \"$ALPHA_ID\",
     \"permissions\": [\"read\", \"subscribe\"]
   }" | jq .
-```
 
-### 7.2 Map Beta Backend to GlobalNet Corp
-
-```bash
+# Grant Beta to GlobalNet
 curl -ks -X POST "https://api.netweave.local/admin/infrastructure/tenants/${GLOBALNET_ID}/backend-access" \
   --cert ~/.netweave/client.crt \
   --key ~/.netweave/client.key \
@@ -334,6 +383,8 @@ curl -ks -X POST "https://api.netweave.local/admin/infrastructure/tenants/${GLOB
     \"permissions\": [\"read\", \"subscribe\"]
   }" | jq .
 ```
+
+</details>
 
 ---
 
@@ -611,6 +662,17 @@ This removes:
 | `setup teardown --force` | Remove everything |
 | `certs issue --cn NAME --type client --out DIR` | Issue a client certificate |
 | `certs verify --cert FILE` | Verify a certificate |
+| `backends list` | List all backends |
+| `backends get --id ID` | Get backend details |
+| `backends create --name N --category C --adapter-type T` | Create a backend |
+| `backends update --id ID` | Update a backend |
+| `backends delete --id ID` | Delete a backend |
+| `backend-access list --tenant ID` | List tenant backend access |
+| `backend-access grant --tenant T --backend B --permissions P` | Grant backend access |
+| `backend-access revoke --tenant T --id ID` | Revoke backend access |
+| `plugins list` | List all plugins |
+| `plugins enable --name NAME` | Enable a plugin |
+| `plugins disable --name NAME` | Disable a plugin |
 
 ### Admin API Endpoints
 

--- a/internal/cli/cmd/backendaccess/backendaccess.go
+++ b/internal/cli/cmd/backendaccess/backendaccess.go
@@ -1,0 +1,233 @@
+// Package backendaccess provides CLI commands for managing tenant backend access.
+package backendaccess
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/piwi3910/netweave/internal/cli/cmd"
+	"github.com/piwi3910/netweave/internal/cli/output"
+	"github.com/piwi3910/netweave/internal/cli/service"
+)
+
+// gatewayFlags holds the shared gateway connection flags.
+type gatewayFlags struct {
+	gatewayURL   string
+	authURL      string
+	username     string
+	password     string
+	clientSecret string
+}
+
+func addGatewayFlags(c *cobra.Command, gf *gatewayFlags) {
+	pf := c.PersistentFlags()
+	pf.StringVar(&gf.gatewayURL, "gateway-url", "https://api.netweave.local", "Gateway API URL")
+	pf.StringVar(&gf.authURL, "auth-url", "https://auth.netweave.local", "Keycloak auth URL")
+	pf.StringVar(&gf.username, "username", "admin@netweave.local", "Admin username")
+	pf.StringVar(&gf.password, "password", "admin", "Admin password")
+	pf.StringVar(&gf.clientSecret, "client-secret", "", "OAuth2 client secret (auto-read from K8s if empty)")
+}
+
+func connectGateway(ctx context.Context, gf *gatewayFlags) (*service.GatewayConnection, error) {
+	gw, err := service.ConnectGateway(ctx, &service.GatewayConfig{
+		GatewayURL:   gf.gatewayURL,
+		AuthURL:      gf.authURL,
+		Username:     gf.username,
+		Password:     gf.password,
+		ClientSecret: gf.clientSecret,
+		Namespace:    cmd.Global.Namespace,
+		Kubeconfig:   cmd.Global.Kubeconfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to gateway: %w", err)
+	}
+	return gw, nil
+}
+
+// accessEntry mirrors the API response for a backend access record.
+type accessEntry struct {
+	ID          string   `json:"id"`
+	TenantID    string   `json:"tenantId"`
+	BackendID   string   `json:"backendId"`
+	Permissions []string `json:"permissions"`
+	GrantedAt   string   `json:"grantedAt,omitempty"`
+	GrantedBy   string   `json:"grantedBy,omitempty"`
+}
+
+// accessListResponse is the API response for listing backend access.
+type accessListResponse struct {
+	Access []accessEntry `json:"access"`
+	Total  int           `json:"total"`
+}
+
+// NewBackendAccessCmd creates the parent "backend-access" command.
+func NewBackendAccessCmd() *cobra.Command {
+	var gf gatewayFlags
+
+	parent := &cobra.Command{
+		Use:   "backend-access",
+		Short: "Manage tenant backend access",
+		Long:  `Grant, list, and revoke tenant access to infrastructure backends.`,
+	}
+
+	addGatewayFlags(parent, &gf)
+
+	parent.AddCommand(newListCmd(&gf))
+	parent.AddCommand(newGrantCmd(&gf))
+	parent.AddCommand(newRevokeCmd(&gf))
+
+	return parent
+}
+
+func newListCmd(gf *gatewayFlags) *cobra.Command {
+	var tenantID string
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List backend access for a tenant",
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+
+			if tenantID == "" {
+				return fmt.Errorf("--tenant flag is required")
+			}
+
+			gw, err := connectGateway(ctx, gf)
+			if err != nil {
+				return err
+			}
+
+			path := fmt.Sprintf("/admin/infrastructure/tenants/%s/backend-access", tenantID)
+			data, err := gw.Get(ctx, path)
+			if err != nil {
+				return fmt.Errorf("failed to list backend access: %w", err)
+			}
+
+			var resp accessListResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			return cmd.Printer.PrintResult(resp, func() {
+				tbl := output.NewTable(
+					cmd.Printer.Output(),
+					"ID", "BACKEND", "PERMISSIONS", "GRANTED BY", "GRANTED AT",
+				)
+				for _, a := range resp.Access {
+					tbl.AddRow(
+						a.ID,
+						a.BackendID,
+						strings.Join(a.Permissions, ", "),
+						a.GrantedBy,
+						a.GrantedAt,
+					)
+				}
+				tbl.Render()
+			})
+		},
+	}
+
+	listCmd.Flags().StringVar(&tenantID, "tenant", "", "Tenant ID (required)")
+	return listCmd
+}
+
+func newGrantCmd(gf *gatewayFlags) *cobra.Command {
+	var (
+		tenantID    string
+		backendID   string
+		permissions string
+	)
+
+	grantCmd := &cobra.Command{
+		Use:   "grant",
+		Short: "Grant tenant access to a backend",
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+
+			if tenantID == "" || backendID == "" || permissions == "" {
+				return fmt.Errorf("--tenant, --backend, and --permissions flags are required")
+			}
+
+			gw, err := connectGateway(ctx, gf)
+			if err != nil {
+				return err
+			}
+
+			permList := strings.Split(permissions, ",")
+			for i := range permList {
+				permList[i] = strings.TrimSpace(permList[i])
+			}
+
+			reqBody := map[string]interface{}{
+				"backendId":   backendID,
+				"permissions": permList,
+			}
+
+			path := fmt.Sprintf("/admin/infrastructure/tenants/%s/backend-access", tenantID)
+			data, err := gw.Post(ctx, path, reqBody)
+			if err != nil {
+				return fmt.Errorf("failed to grant backend access: %w", err)
+			}
+
+			var a accessEntry
+			if err := json.Unmarshal(data, &a); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			return cmd.Printer.PrintResult(a, func() {
+				cmd.Printer.Infof("Backend access granted (ID: %s)", a.ID)
+				cmd.Printer.Infof("  Tenant:      %s", a.TenantID)
+				cmd.Printer.Infof("  Backend:     %s", a.BackendID)
+				cmd.Printer.Infof("  Permissions: %s", strings.Join(a.Permissions, ", "))
+			})
+		},
+	}
+
+	grantCmd.Flags().StringVar(&tenantID, "tenant", "", "Tenant ID (required)")
+	grantCmd.Flags().StringVar(&backendID, "backend", "", "Backend ID (required)")
+	grantCmd.Flags().StringVar(
+		&permissions, "permissions", "",
+		"Comma-separated permissions, e.g. read,subscribe (required)",
+	)
+	return grantCmd
+}
+
+func newRevokeCmd(gf *gatewayFlags) *cobra.Command {
+	var (
+		tenantID string
+		accessID string
+	)
+
+	revokeCmd := &cobra.Command{
+		Use:   "revoke",
+		Short: "Revoke tenant backend access",
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+
+			if tenantID == "" || accessID == "" {
+				return fmt.Errorf("--tenant and --id flags are required")
+			}
+
+			gw, err := connectGateway(ctx, gf)
+			if err != nil {
+				return err
+			}
+
+			path := fmt.Sprintf("/admin/infrastructure/tenants/%s/backend-access/%s", tenantID, accessID)
+			if err := gw.Delete(ctx, path); err != nil {
+				return fmt.Errorf("failed to revoke backend access: %w", err)
+			}
+
+			cmd.Printer.Infof("Backend access %s revoked for tenant %s", accessID, tenantID)
+			return nil
+		},
+	}
+
+	revokeCmd.Flags().StringVar(&tenantID, "tenant", "", "Tenant ID (required)")
+	revokeCmd.Flags().StringVar(&accessID, "id", "", "Access ID (required)")
+	return revokeCmd
+}

--- a/internal/cli/cmd/backendaccess/backendaccess.go
+++ b/internal/cli/cmd/backendaccess/backendaccess.go
@@ -2,7 +2,6 @@
 package backendaccess
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -11,42 +10,7 @@ import (
 
 	"github.com/piwi3910/netweave/internal/cli/cmd"
 	"github.com/piwi3910/netweave/internal/cli/output"
-	"github.com/piwi3910/netweave/internal/cli/service"
 )
-
-// gatewayFlags holds the shared gateway connection flags.
-type gatewayFlags struct {
-	gatewayURL   string
-	authURL      string
-	username     string
-	password     string
-	clientSecret string
-}
-
-func addGatewayFlags(c *cobra.Command, gf *gatewayFlags) {
-	pf := c.PersistentFlags()
-	pf.StringVar(&gf.gatewayURL, "gateway-url", "https://api.netweave.local", "Gateway API URL")
-	pf.StringVar(&gf.authURL, "auth-url", "https://auth.netweave.local", "Keycloak auth URL")
-	pf.StringVar(&gf.username, "username", "admin@netweave.local", "Admin username")
-	pf.StringVar(&gf.password, "password", "admin", "Admin password")
-	pf.StringVar(&gf.clientSecret, "client-secret", "", "OAuth2 client secret (auto-read from K8s if empty)")
-}
-
-func connectGateway(ctx context.Context, gf *gatewayFlags) (*service.GatewayConnection, error) {
-	gw, err := service.ConnectGateway(ctx, &service.GatewayConfig{
-		GatewayURL:   gf.gatewayURL,
-		AuthURL:      gf.authURL,
-		Username:     gf.username,
-		Password:     gf.password,
-		ClientSecret: gf.clientSecret,
-		Namespace:    cmd.Global.Namespace,
-		Kubeconfig:   cmd.Global.Kubeconfig,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to gateway: %w", err)
-	}
-	return gw, nil
-}
 
 // accessEntry mirrors the API response for a backend access record.
 type accessEntry struct {
@@ -66,7 +30,7 @@ type accessListResponse struct {
 
 // NewBackendAccessCmd creates the parent "backend-access" command.
 func NewBackendAccessCmd() *cobra.Command {
-	var gf gatewayFlags
+	var gf cmd.GatewayFlags
 
 	parent := &cobra.Command{
 		Use:   "backend-access",
@@ -74,7 +38,7 @@ func NewBackendAccessCmd() *cobra.Command {
 		Long:  `Grant, list, and revoke tenant access to infrastructure backends.`,
 	}
 
-	addGatewayFlags(parent, &gf)
+	cmd.AddGatewayFlags(parent, &gf)
 
 	parent.AddCommand(newListCmd(&gf))
 	parent.AddCommand(newGrantCmd(&gf))
@@ -83,7 +47,7 @@ func NewBackendAccessCmd() *cobra.Command {
 	return parent
 }
 
-func newListCmd(gf *gatewayFlags) *cobra.Command {
+func newListCmd(gf *cmd.GatewayFlags) *cobra.Command {
 	var tenantID string
 
 	listCmd := &cobra.Command{
@@ -92,11 +56,7 @@ func newListCmd(gf *gatewayFlags) *cobra.Command {
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 
-			if tenantID == "" {
-				return fmt.Errorf("--tenant flag is required")
-			}
-
-			gw, err := connectGateway(ctx, gf)
+			gw, err := cmd.ConnectGateway(ctx, gf)
 			if err != nil {
 				return err
 			}
@@ -131,11 +91,12 @@ func newListCmd(gf *gatewayFlags) *cobra.Command {
 		},
 	}
 
-	listCmd.Flags().StringVar(&tenantID, "tenant", "", "Tenant ID (required)")
+	listCmd.Flags().StringVar(&tenantID, "tenant", "", "Tenant ID")
+	cmd.MustMarkRequired(listCmd, "tenant")
 	return listCmd
 }
 
-func newGrantCmd(gf *gatewayFlags) *cobra.Command {
+func newGrantCmd(gf *cmd.GatewayFlags) *cobra.Command {
 	var (
 		tenantID    string
 		backendID   string
@@ -148,11 +109,7 @@ func newGrantCmd(gf *gatewayFlags) *cobra.Command {
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 
-			if tenantID == "" || backendID == "" || permissions == "" {
-				return fmt.Errorf("--tenant, --backend, and --permissions flags are required")
-			}
-
-			gw, err := connectGateway(ctx, gf)
+			gw, err := cmd.ConnectGateway(ctx, gf)
 			if err != nil {
 				return err
 			}
@@ -187,16 +144,19 @@ func newGrantCmd(gf *gatewayFlags) *cobra.Command {
 		},
 	}
 
-	grantCmd.Flags().StringVar(&tenantID, "tenant", "", "Tenant ID (required)")
-	grantCmd.Flags().StringVar(&backendID, "backend", "", "Backend ID (required)")
+	grantCmd.Flags().StringVar(&tenantID, "tenant", "", "Tenant ID")
+	grantCmd.Flags().StringVar(&backendID, "backend", "", "Backend ID")
 	grantCmd.Flags().StringVar(
 		&permissions, "permissions", "",
-		"Comma-separated permissions, e.g. read,subscribe (required)",
+		"Comma-separated permissions, e.g. read,subscribe",
 	)
+	cmd.MustMarkRequired(grantCmd, "tenant")
+	cmd.MustMarkRequired(grantCmd, "backend")
+	cmd.MustMarkRequired(grantCmd, "permissions")
 	return grantCmd
 }
 
-func newRevokeCmd(gf *gatewayFlags) *cobra.Command {
+func newRevokeCmd(gf *cmd.GatewayFlags) *cobra.Command {
 	var (
 		tenantID string
 		accessID string
@@ -208,11 +168,7 @@ func newRevokeCmd(gf *gatewayFlags) *cobra.Command {
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 
-			if tenantID == "" || accessID == "" {
-				return fmt.Errorf("--tenant and --id flags are required")
-			}
-
-			gw, err := connectGateway(ctx, gf)
+			gw, err := cmd.ConnectGateway(ctx, gf)
 			if err != nil {
 				return err
 			}
@@ -227,7 +183,9 @@ func newRevokeCmd(gf *gatewayFlags) *cobra.Command {
 		},
 	}
 
-	revokeCmd.Flags().StringVar(&tenantID, "tenant", "", "Tenant ID (required)")
-	revokeCmd.Flags().StringVar(&accessID, "id", "", "Access ID (required)")
+	revokeCmd.Flags().StringVar(&tenantID, "tenant", "", "Tenant ID")
+	revokeCmd.Flags().StringVar(&accessID, "id", "", "Access ID")
+	cmd.MustMarkRequired(revokeCmd, "tenant")
+	cmd.MustMarkRequired(revokeCmd, "id")
 	return revokeCmd
 }

--- a/internal/cli/cmd/backendaccess/backendaccess_test.go
+++ b/internal/cli/cmd/backendaccess/backendaccess_test.go
@@ -1,0 +1,247 @@
+package backendaccess
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/cli/cmd"
+	"github.com/piwi3910/netweave/internal/cli/output"
+)
+
+func newMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/realms/netweave/protocol/openid-connect/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"mock-token","token_type":"Bearer","expires_in":300}`))
+	})
+
+	mux.HandleFunc("/admin/infrastructure/tenants/t-1/backend-access", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			resp := accessListResponse{
+				Access: []accessEntry{
+					{
+						ID: "a-1", TenantID: "t-1", BackendID: "b-1",
+						Permissions: []string{"read", "subscribe"},
+						GrantedBy:   "admin", GrantedAt: "2025-01-01T00:00:00Z",
+					},
+				},
+				Total: 1,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		case http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]interface{}
+			json.Unmarshal(body, &req)
+			resp := accessEntry{
+				ID:          "a-new",
+				TenantID:    "t-1",
+				BackendID:   req["backendId"].(string),
+				Permissions: []string{"read"},
+				GrantedBy:   "admin",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	accessPath := "/admin/infrastructure/tenants/t-1/backend-access/a-1"
+	mux.HandleFunc(accessPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func executeBackendAccessCmd(t *testing.T, srv *httptest.Server, args ...string) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd.Printer = output.NewPrinter(false, false)
+	cmd.Printer.SetOutput(&buf)
+	cmd.Printer.SetErrOutput(&buf)
+
+	root := NewBackendAccessCmd()
+	fullArgs := append([]string{
+		"--gateway-url", srv.URL,
+		"--auth-url", srv.URL,
+		"--username", "test@example.com",
+		"--password", "test-password",
+		"--client-secret", "mock-secret",
+	}, args...)
+	root.SetArgs(fullArgs)
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	err := root.Execute()
+	return buf.String(), err
+}
+
+func TestNewBackendAccessCmd_Structure(t *testing.T) {
+	accessCmd := NewBackendAccessCmd()
+
+	assert.Equal(t, "backend-access", accessCmd.Use)
+	assert.NotEmpty(t, accessCmd.Short)
+
+	subCmds := accessCmd.Commands()
+	names := make([]string, len(subCmds))
+	for i, c := range subCmds {
+		names[i] = c.Name()
+	}
+	assert.Contains(t, names, "list")
+	assert.Contains(t, names, "grant")
+	assert.Contains(t, names, "revoke")
+}
+
+func TestNewBackendAccessCmd_GatewayFlags(t *testing.T) {
+	accessCmd := NewBackendAccessCmd()
+
+	flags := []string{"gateway-url", "auth-url", "username", "password", "client-secret"}
+	for _, f := range flags {
+		flag := accessCmd.PersistentFlags().Lookup(f)
+		assert.NotNil(t, flag, "flag %q should be registered", f)
+	}
+}
+
+func TestBackendAccess_ListRequiresTenant(t *testing.T) {
+	accessCmd := NewBackendAccessCmd()
+	accessCmd.SetArgs([]string{"list"})
+
+	var buf bytes.Buffer
+	accessCmd.SetOut(&buf)
+	accessCmd.SetErr(&buf)
+
+	err := accessCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required flag")
+}
+
+func TestBackendAccess_GrantRequiresFlags(t *testing.T) {
+	accessCmd := NewBackendAccessCmd()
+	accessCmd.SetArgs([]string{"grant"})
+
+	var buf bytes.Buffer
+	accessCmd.SetOut(&buf)
+	accessCmd.SetErr(&buf)
+
+	err := accessCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required flag")
+}
+
+func TestBackendAccess_RevokeRequiresFlags(t *testing.T) {
+	accessCmd := NewBackendAccessCmd()
+	accessCmd.SetArgs([]string{"revoke"})
+
+	var buf bytes.Buffer
+	accessCmd.SetOut(&buf)
+	accessCmd.SetErr(&buf)
+
+	err := accessCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required flag")
+}
+
+func TestBackendAccess_List(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	out, err := executeBackendAccessCmd(t, srv, "list", "--tenant", "t-1")
+	require.NoError(t, err)
+	assert.Contains(t, out, "a-1")
+	assert.Contains(t, out, "b-1")
+	assert.Contains(t, out, "read, subscribe")
+}
+
+func TestBackendAccess_Grant(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	out, err := executeBackendAccessCmd(t, srv, "grant",
+		"--tenant", "t-1",
+		"--backend", "b-2",
+		"--permissions", "read,subscribe",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Backend access granted")
+	assert.Contains(t, out, "a-new")
+}
+
+func TestBackendAccess_Revoke(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	out, err := executeBackendAccessCmd(t, srv, "revoke",
+		"--tenant", "t-1",
+		"--id", "a-1",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Backend access a-1 revoked for tenant t-1")
+}
+
+func TestBackendAccess_ListJSON(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	cmd.Printer = output.NewPrinter(true, false)
+	cmd.Printer.SetOutput(&buf)
+	cmd.Printer.SetErrOutput(&buf)
+
+	root := NewBackendAccessCmd()
+	root.SetArgs([]string{
+		"--gateway-url", srv.URL,
+		"--auth-url", srv.URL,
+		"--username", "test@example.com",
+		"--password", "test-password",
+		"--client-secret", "mock-secret",
+		"list", "--tenant", "t-1",
+	})
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	var resp accessListResponse
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+}
+
+func TestBackendAccess_PasswordRequired(t *testing.T) {
+	var buf bytes.Buffer
+	cmd.Printer = output.NewPrinter(false, false)
+	cmd.Printer.SetOutput(&buf)
+	cmd.Printer.SetErrOutput(&buf)
+
+	root := NewBackendAccessCmd()
+	root.SetArgs([]string{
+		"--gateway-url", "https://example.com",
+		"--auth-url", "https://example.com",
+		"--username", "test@example.com",
+		"--client-secret", "secret",
+		"list", "--tenant", "t-1",
+	})
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--password flag is required")
+}

--- a/internal/cli/cmd/backends/backends.go
+++ b/internal/cli/cmd/backends/backends.go
@@ -2,7 +2,6 @@
 package backends
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -11,42 +10,7 @@ import (
 
 	"github.com/piwi3910/netweave/internal/cli/cmd"
 	"github.com/piwi3910/netweave/internal/cli/output"
-	"github.com/piwi3910/netweave/internal/cli/service"
 )
-
-// gatewayFlags holds the shared gateway connection flags.
-type gatewayFlags struct {
-	gatewayURL   string
-	authURL      string
-	username     string
-	password     string
-	clientSecret string
-}
-
-func addGatewayFlags(c *cobra.Command, gf *gatewayFlags) {
-	pf := c.PersistentFlags()
-	pf.StringVar(&gf.gatewayURL, "gateway-url", "https://api.netweave.local", "Gateway API URL")
-	pf.StringVar(&gf.authURL, "auth-url", "https://auth.netweave.local", "Keycloak auth URL")
-	pf.StringVar(&gf.username, "username", "admin@netweave.local", "Admin username")
-	pf.StringVar(&gf.password, "password", "admin", "Admin password")
-	pf.StringVar(&gf.clientSecret, "client-secret", "", "OAuth2 client secret (auto-read from K8s if empty)")
-}
-
-func connectGateway(ctx context.Context, gf *gatewayFlags) (*service.GatewayConnection, error) {
-	gw, err := service.ConnectGateway(ctx, &service.GatewayConfig{
-		GatewayURL:   gf.gatewayURL,
-		AuthURL:      gf.authURL,
-		Username:     gf.username,
-		Password:     gf.password,
-		ClientSecret: gf.clientSecret,
-		Namespace:    cmd.Global.Namespace,
-		Kubeconfig:   cmd.Global.Kubeconfig,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to gateway: %w", err)
-	}
-	return gw, nil
-}
 
 // backendResponse mirrors the API response for a backend instance.
 type backendResponse struct {
@@ -70,7 +34,7 @@ type listResponse struct {
 
 // NewBackendsCmd creates the parent "backends" command.
 func NewBackendsCmd() *cobra.Command {
-	var gf gatewayFlags
+	var gf cmd.GatewayFlags
 
 	parent := &cobra.Command{
 		Use:   "backends",
@@ -78,7 +42,7 @@ func NewBackendsCmd() *cobra.Command {
 		Long:  `CRUD operations for infrastructure backend instances (IMS/DMS).`,
 	}
 
-	addGatewayFlags(parent, &gf)
+	cmd.AddGatewayFlags(parent, &gf)
 
 	parent.AddCommand(newListCmd(&gf))
 	parent.AddCommand(newGetCmd(&gf))
@@ -89,7 +53,7 @@ func NewBackendsCmd() *cobra.Command {
 	return parent
 }
 
-func newListCmd(gf *gatewayFlags) *cobra.Command {
+func newListCmd(gf *cmd.GatewayFlags) *cobra.Command {
 	var category string
 
 	listCmd := &cobra.Command{
@@ -98,7 +62,7 @@ func newListCmd(gf *gatewayFlags) *cobra.Command {
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 
-			gw, err := connectGateway(ctx, gf)
+			gw, err := cmd.ConnectGateway(ctx, gf)
 			if err != nil {
 				return err
 			}
@@ -135,7 +99,7 @@ func newListCmd(gf *gatewayFlags) *cobra.Command {
 	return listCmd
 }
 
-func newGetCmd(gf *gatewayFlags) *cobra.Command {
+func newGetCmd(gf *cmd.GatewayFlags) *cobra.Command {
 	var backendID string
 
 	getCmd := &cobra.Command{
@@ -144,11 +108,7 @@ func newGetCmd(gf *gatewayFlags) *cobra.Command {
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 
-			if backendID == "" {
-				return fmt.Errorf("--id flag is required")
-			}
-
-			gw, err := connectGateway(ctx, gf)
+			gw, err := cmd.ConnectGateway(ctx, gf)
 			if err != nil {
 				return err
 			}
@@ -178,11 +138,12 @@ func newGetCmd(gf *gatewayFlags) *cobra.Command {
 		},
 	}
 
-	getCmd.Flags().StringVar(&backendID, "id", "", "Backend ID (required)")
+	getCmd.Flags().StringVar(&backendID, "id", "", "Backend ID")
+	cmd.MustMarkRequired(getCmd, "id")
 	return getCmd
 }
 
-func newCreateCmd(gf *gatewayFlags) *cobra.Command {
+func newCreateCmd(gf *cmd.GatewayFlags) *cobra.Command {
 	var (
 		name        string
 		category    string
@@ -197,11 +158,7 @@ func newCreateCmd(gf *gatewayFlags) *cobra.Command {
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 
-			if name == "" || category == "" || adapterType == "" {
-				return fmt.Errorf("--name, --category, and --adapter-type flags are required")
-			}
-
-			gw, err := connectGateway(ctx, gf)
+			gw, err := cmd.ConnectGateway(ctx, gf)
 			if err != nil {
 				return err
 			}
@@ -236,15 +193,18 @@ func newCreateCmd(gf *gatewayFlags) *cobra.Command {
 		},
 	}
 
-	createCmd.Flags().StringVar(&name, "name", "", "Backend name (required)")
-	createCmd.Flags().StringVar(&category, "category", "", "Category: ims or dms (required)")
-	createCmd.Flags().StringVar(&adapterType, "adapter-type", "", "Adapter type, e.g. mock (required)")
+	createCmd.Flags().StringVar(&name, "name", "", "Backend name")
+	createCmd.Flags().StringVar(&category, "category", "", "Category: ims or dms")
+	createCmd.Flags().StringVar(&adapterType, "adapter-type", "", "Adapter type, e.g. mock")
 	createCmd.Flags().StringVar(&description, "description", "", "Backend description")
 	createCmd.Flags().StringArrayVar(&configPairs, "config", nil, "Config key=value pairs (repeatable)")
+	cmd.MustMarkRequired(createCmd, "name")
+	cmd.MustMarkRequired(createCmd, "category")
+	cmd.MustMarkRequired(createCmd, "adapter-type")
 	return createCmd
 }
 
-func newUpdateCmd(gf *gatewayFlags) *cobra.Command {
+func newUpdateCmd(gf *cmd.GatewayFlags) *cobra.Command {
 	var (
 		backendID   string
 		name        string
@@ -258,11 +218,7 @@ func newUpdateCmd(gf *gatewayFlags) *cobra.Command {
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 
-			if backendID == "" {
-				return fmt.Errorf("--id flag is required")
-			}
-
-			gw, err := connectGateway(ctx, gf)
+			gw, err := cmd.ConnectGateway(ctx, gf)
 			if err != nil {
 				return err
 			}
@@ -294,14 +250,15 @@ func newUpdateCmd(gf *gatewayFlags) *cobra.Command {
 		},
 	}
 
-	updateCmd.Flags().StringVar(&backendID, "id", "", "Backend ID (required)")
+	updateCmd.Flags().StringVar(&backendID, "id", "", "Backend ID")
 	updateCmd.Flags().StringVar(&name, "name", "", "New name")
 	updateCmd.Flags().StringVar(&description, "description", "", "New description")
 	updateCmd.Flags().StringArrayVar(&configPairs, "config", nil, "Config key=value pairs (repeatable)")
+	cmd.MustMarkRequired(updateCmd, "id")
 	return updateCmd
 }
 
-func newDeleteCmd(gf *gatewayFlags) *cobra.Command {
+func newDeleteCmd(gf *cmd.GatewayFlags) *cobra.Command {
 	var backendID string
 
 	deleteCmd := &cobra.Command{
@@ -310,11 +267,7 @@ func newDeleteCmd(gf *gatewayFlags) *cobra.Command {
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 
-			if backendID == "" {
-				return fmt.Errorf("--id flag is required")
-			}
-
-			gw, err := connectGateway(ctx, gf)
+			gw, err := cmd.ConnectGateway(ctx, gf)
 			if err != nil {
 				return err
 			}
@@ -328,7 +281,8 @@ func newDeleteCmd(gf *gatewayFlags) *cobra.Command {
 		},
 	}
 
-	deleteCmd.Flags().StringVar(&backendID, "id", "", "Backend ID (required)")
+	deleteCmd.Flags().StringVar(&backendID, "id", "", "Backend ID")
+	cmd.MustMarkRequired(deleteCmd, "id")
 	return deleteCmd
 }
 

--- a/internal/cli/cmd/backends/backends.go
+++ b/internal/cli/cmd/backends/backends.go
@@ -1,0 +1,345 @@
+// Package backends provides CLI commands for managing infrastructure backends.
+package backends
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/piwi3910/netweave/internal/cli/cmd"
+	"github.com/piwi3910/netweave/internal/cli/output"
+	"github.com/piwi3910/netweave/internal/cli/service"
+)
+
+// gatewayFlags holds the shared gateway connection flags.
+type gatewayFlags struct {
+	gatewayURL   string
+	authURL      string
+	username     string
+	password     string
+	clientSecret string
+}
+
+func addGatewayFlags(c *cobra.Command, gf *gatewayFlags) {
+	pf := c.PersistentFlags()
+	pf.StringVar(&gf.gatewayURL, "gateway-url", "https://api.netweave.local", "Gateway API URL")
+	pf.StringVar(&gf.authURL, "auth-url", "https://auth.netweave.local", "Keycloak auth URL")
+	pf.StringVar(&gf.username, "username", "admin@netweave.local", "Admin username")
+	pf.StringVar(&gf.password, "password", "admin", "Admin password")
+	pf.StringVar(&gf.clientSecret, "client-secret", "", "OAuth2 client secret (auto-read from K8s if empty)")
+}
+
+func connectGateway(ctx context.Context, gf *gatewayFlags) (*service.GatewayConnection, error) {
+	gw, err := service.ConnectGateway(ctx, &service.GatewayConfig{
+		GatewayURL:   gf.gatewayURL,
+		AuthURL:      gf.authURL,
+		Username:     gf.username,
+		Password:     gf.password,
+		ClientSecret: gf.clientSecret,
+		Namespace:    cmd.Global.Namespace,
+		Kubeconfig:   cmd.Global.Kubeconfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to gateway: %w", err)
+	}
+	return gw, nil
+}
+
+// backendResponse mirrors the API response for a backend instance.
+type backendResponse struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Category       string `json:"category"`
+	AdapterType    string `json:"adapterType"`
+	Description    string `json:"description,omitempty"`
+	Status         string `json:"status"`
+	StatusMessage  string `json:"statusMessage,omitempty"`
+	HasCredentials bool   `json:"hasCredentials"`
+	CreatedAt      string `json:"createdAt,omitempty"`
+	UpdatedAt      string `json:"updatedAt,omitempty"`
+}
+
+// listResponse is the API response for listing backends.
+type listResponse struct {
+	Backends []backendResponse `json:"backends"`
+	Total    int               `json:"total"`
+}
+
+// NewBackendsCmd creates the parent "backends" command.
+func NewBackendsCmd() *cobra.Command {
+	var gf gatewayFlags
+
+	parent := &cobra.Command{
+		Use:   "backends",
+		Short: "Manage infrastructure backends",
+		Long:  `CRUD operations for infrastructure backend instances (IMS/DMS).`,
+	}
+
+	addGatewayFlags(parent, &gf)
+
+	parent.AddCommand(newListCmd(&gf))
+	parent.AddCommand(newGetCmd(&gf))
+	parent.AddCommand(newCreateCmd(&gf))
+	parent.AddCommand(newUpdateCmd(&gf))
+	parent.AddCommand(newDeleteCmd(&gf))
+
+	return parent
+}
+
+func newListCmd(gf *gatewayFlags) *cobra.Command {
+	var category string
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all backends",
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+
+			gw, err := connectGateway(ctx, gf)
+			if err != nil {
+				return err
+			}
+
+			path := "/admin/infrastructure/backends"
+			if category != "" {
+				path += "?category=" + category
+			}
+
+			data, err := gw.Get(ctx, path)
+			if err != nil {
+				return fmt.Errorf("failed to list backends: %w", err)
+			}
+
+			var resp listResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			return cmd.Printer.PrintResult(resp, func() {
+				tbl := output.NewTable(
+					cmd.Printer.Output(),
+					"ID", "NAME", "CATEGORY", "ADAPTER", "STATUS",
+				)
+				for _, b := range resp.Backends {
+					tbl.AddRow(b.ID, b.Name, b.Category, b.AdapterType, b.Status)
+				}
+				tbl.Render()
+			})
+		},
+	}
+
+	listCmd.Flags().StringVar(&category, "category", "", "Filter by category (ims, dms)")
+	return listCmd
+}
+
+func newGetCmd(gf *gatewayFlags) *cobra.Command {
+	var backendID string
+
+	getCmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get backend details",
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+
+			if backendID == "" {
+				return fmt.Errorf("--id flag is required")
+			}
+
+			gw, err := connectGateway(ctx, gf)
+			if err != nil {
+				return err
+			}
+
+			data, err := gw.Get(ctx, "/admin/infrastructure/backends/"+backendID)
+			if err != nil {
+				return fmt.Errorf("failed to get backend: %w", err)
+			}
+
+			var b backendResponse
+			if err := json.Unmarshal(data, &b); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			return cmd.Printer.PrintResult(b, func() {
+				cmd.Printer.Infof("ID:              %s", b.ID)
+				cmd.Printer.Infof("Name:            %s", b.Name)
+				cmd.Printer.Infof("Category:        %s", b.Category)
+				cmd.Printer.Infof("Adapter Type:    %s", b.AdapterType)
+				cmd.Printer.Infof("Description:     %s", b.Description)
+				cmd.Printer.Infof("Status:          %s", b.Status)
+				cmd.Printer.Infof("Status Message:  %s", b.StatusMessage)
+				cmd.Printer.Infof("Has Credentials: %v", b.HasCredentials)
+				cmd.Printer.Infof("Created:         %s", b.CreatedAt)
+				cmd.Printer.Infof("Updated:         %s", b.UpdatedAt)
+			})
+		},
+	}
+
+	getCmd.Flags().StringVar(&backendID, "id", "", "Backend ID (required)")
+	return getCmd
+}
+
+func newCreateCmd(gf *gatewayFlags) *cobra.Command {
+	var (
+		name        string
+		category    string
+		adapterType string
+		description string
+		configPairs []string
+	)
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a backend",
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+
+			if name == "" || category == "" || adapterType == "" {
+				return fmt.Errorf("--name, --category, and --adapter-type flags are required")
+			}
+
+			gw, err := connectGateway(ctx, gf)
+			if err != nil {
+				return err
+			}
+
+			config := parseKeyValuePairs(configPairs)
+
+			reqBody := map[string]interface{}{
+				"name":        name,
+				"category":    category,
+				"adapterType": adapterType,
+			}
+			if description != "" {
+				reqBody["description"] = description
+			}
+			if len(config) > 0 {
+				reqBody["config"] = config
+			}
+
+			data, err := gw.Post(ctx, "/admin/infrastructure/backends", reqBody)
+			if err != nil {
+				return fmt.Errorf("failed to create backend: %w", err)
+			}
+
+			var b backendResponse
+			if err := json.Unmarshal(data, &b); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			return cmd.Printer.PrintResult(b, func() {
+				cmd.Printer.Infof("Backend created: %s (ID: %s)", b.Name, b.ID)
+			})
+		},
+	}
+
+	createCmd.Flags().StringVar(&name, "name", "", "Backend name (required)")
+	createCmd.Flags().StringVar(&category, "category", "", "Category: ims or dms (required)")
+	createCmd.Flags().StringVar(&adapterType, "adapter-type", "", "Adapter type, e.g. mock (required)")
+	createCmd.Flags().StringVar(&description, "description", "", "Backend description")
+	createCmd.Flags().StringArrayVar(&configPairs, "config", nil, "Config key=value pairs (repeatable)")
+	return createCmd
+}
+
+func newUpdateCmd(gf *gatewayFlags) *cobra.Command {
+	var (
+		backendID   string
+		name        string
+		description string
+		configPairs []string
+	)
+
+	updateCmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update a backend",
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+
+			if backendID == "" {
+				return fmt.Errorf("--id flag is required")
+			}
+
+			gw, err := connectGateway(ctx, gf)
+			if err != nil {
+				return err
+			}
+
+			reqBody := map[string]interface{}{}
+			if name != "" {
+				reqBody["name"] = name
+			}
+			if description != "" {
+				reqBody["description"] = description
+			}
+			if len(configPairs) > 0 {
+				reqBody["config"] = parseKeyValuePairs(configPairs)
+			}
+
+			data, err := gw.Put(ctx, "/admin/infrastructure/backends/"+backendID, reqBody)
+			if err != nil {
+				return fmt.Errorf("failed to update backend: %w", err)
+			}
+
+			var b backendResponse
+			if err := json.Unmarshal(data, &b); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			return cmd.Printer.PrintResult(b, func() {
+				cmd.Printer.Infof("Backend %s updated", backendID)
+			})
+		},
+	}
+
+	updateCmd.Flags().StringVar(&backendID, "id", "", "Backend ID (required)")
+	updateCmd.Flags().StringVar(&name, "name", "", "New name")
+	updateCmd.Flags().StringVar(&description, "description", "", "New description")
+	updateCmd.Flags().StringArrayVar(&configPairs, "config", nil, "Config key=value pairs (repeatable)")
+	return updateCmd
+}
+
+func newDeleteCmd(gf *gatewayFlags) *cobra.Command {
+	var backendID string
+
+	deleteCmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a backend",
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+
+			if backendID == "" {
+				return fmt.Errorf("--id flag is required")
+			}
+
+			gw, err := connectGateway(ctx, gf)
+			if err != nil {
+				return err
+			}
+
+			if err := gw.Delete(ctx, "/admin/infrastructure/backends/"+backendID); err != nil {
+				return fmt.Errorf("failed to delete backend: %w", err)
+			}
+
+			cmd.Printer.Infof("Backend %s deleted", backendID)
+			return nil
+		},
+	}
+
+	deleteCmd.Flags().StringVar(&backendID, "id", "", "Backend ID (required)")
+	return deleteCmd
+}
+
+// parseKeyValuePairs converts ["key1=value1", "key2=value2"] into a map.
+func parseKeyValuePairs(pairs []string) map[string]string {
+	result := make(map[string]string, len(pairs))
+	for _, pair := range pairs {
+		key, value, found := strings.Cut(pair, "=")
+		if found {
+			result[key] = value
+		}
+	}
+	return result
+}

--- a/internal/cli/cmd/backends/backends_test.go
+++ b/internal/cli/cmd/backends/backends_test.go
@@ -1,0 +1,373 @@
+package backends
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/cli/cmd"
+	"github.com/piwi3910/netweave/internal/cli/output"
+)
+
+func newMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/realms/netweave/protocol/openid-connect/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"mock-token","token_type":"Bearer","expires_in":300}`))
+	})
+
+	mux.HandleFunc("/admin/infrastructure/backends", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			resp := listResponse{
+				Backends: []backendResponse{
+					{ID: "b-1", Name: "test-ims", Category: "ims", AdapterType: "mock", Status: "active"},
+					{ID: "b-2", Name: "test-dms", Category: "dms", AdapterType: "flux", Status: "active"},
+				},
+				Total: 2,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		case http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]interface{}
+			json.Unmarshal(body, &req)
+			resp := backendResponse{
+				ID:          "b-new",
+				Name:        req["name"].(string),
+				Category:    req["category"].(string),
+				AdapterType: req["adapterType"].(string),
+				Status:      "pending",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	mux.HandleFunc("/admin/infrastructure/backends/b-1", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			resp := backendResponse{
+				ID: "b-1", Name: "test-ims", Category: "ims",
+				AdapterType: "mock", Status: "active", Description: "Test IMS backend",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		case http.MethodPut:
+			resp := backendResponse{
+				ID: "b-1", Name: "updated-ims", Category: "ims",
+				AdapterType: "mock", Status: "active",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func executeBackendsCmd(t *testing.T, srv *httptest.Server, args ...string) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd.Printer = output.NewPrinter(false, false)
+	cmd.Printer.SetOutput(&buf)
+	cmd.Printer.SetErrOutput(&buf)
+
+	root := NewBackendsCmd()
+	fullArgs := append([]string{
+		"--gateway-url", srv.URL,
+		"--auth-url", srv.URL,
+		"--username", "test@example.com",
+		"--password", "test-password",
+		"--client-secret", "mock-secret",
+	}, args...)
+	root.SetArgs(fullArgs)
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	err := root.Execute()
+	return buf.String(), err
+}
+
+func TestNewBackendsCmd_Structure(t *testing.T) {
+	backendsCmd := NewBackendsCmd()
+
+	assert.Equal(t, "backends", backendsCmd.Use)
+	assert.NotEmpty(t, backendsCmd.Short)
+
+	subCmds := backendsCmd.Commands()
+	names := make([]string, len(subCmds))
+	for i, c := range subCmds {
+		names[i] = c.Name()
+	}
+	assert.Contains(t, names, "list")
+	assert.Contains(t, names, "get")
+	assert.Contains(t, names, "create")
+	assert.Contains(t, names, "update")
+	assert.Contains(t, names, "delete")
+}
+
+func TestNewBackendsCmd_GatewayFlags(t *testing.T) {
+	backendsCmd := NewBackendsCmd()
+
+	flags := []string{"gateway-url", "auth-url", "username", "password", "client-secret"}
+	for _, f := range flags {
+		flag := backendsCmd.PersistentFlags().Lookup(f)
+		assert.NotNil(t, flag, "flag %q should be registered", f)
+	}
+}
+
+func TestBackends_GetRequiresID(t *testing.T) {
+	backendsCmd := NewBackendsCmd()
+	backendsCmd.SetArgs([]string{"get"})
+
+	var buf bytes.Buffer
+	backendsCmd.SetOut(&buf)
+	backendsCmd.SetErr(&buf)
+
+	err := backendsCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required flag")
+}
+
+func TestBackends_CreateRequiresFlags(t *testing.T) {
+	backendsCmd := NewBackendsCmd()
+	backendsCmd.SetArgs([]string{"create"})
+
+	var buf bytes.Buffer
+	backendsCmd.SetOut(&buf)
+	backendsCmd.SetErr(&buf)
+
+	err := backendsCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required flag")
+}
+
+func TestBackends_UpdateRequiresID(t *testing.T) {
+	backendsCmd := NewBackendsCmd()
+	backendsCmd.SetArgs([]string{"update"})
+
+	var buf bytes.Buffer
+	backendsCmd.SetOut(&buf)
+	backendsCmd.SetErr(&buf)
+
+	err := backendsCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required flag")
+}
+
+func TestBackends_DeleteRequiresID(t *testing.T) {
+	backendsCmd := NewBackendsCmd()
+	backendsCmd.SetArgs([]string{"delete"})
+
+	var buf bytes.Buffer
+	backendsCmd.SetOut(&buf)
+	backendsCmd.SetErr(&buf)
+
+	err := backendsCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required flag")
+}
+
+func TestBackends_List(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	out, err := executeBackendsCmd(t, srv, "list")
+	require.NoError(t, err)
+	assert.Contains(t, out, "test-ims")
+	assert.Contains(t, out, "test-dms")
+	assert.Contains(t, out, "2 item(s)")
+}
+
+func TestBackends_Get(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	out, err := executeBackendsCmd(t, srv, "get", "--id", "b-1")
+	require.NoError(t, err)
+	assert.Contains(t, out, "test-ims")
+	assert.Contains(t, out, "ims")
+}
+
+func TestBackends_Create(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	out, err := executeBackendsCmd(t, srv, "create",
+		"--name", "new-backend",
+		"--category", "ims",
+		"--adapter-type", "mock",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Backend created")
+	assert.Contains(t, out, "new-backend")
+}
+
+func TestBackends_CreateWithConfig(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	out, err := executeBackendsCmd(t, srv, "create",
+		"--name", "configured-backend",
+		"--category", "dms",
+		"--adapter-type", "flux",
+		"--config", "key1=val1",
+		"--config", "key2=val2",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Backend created")
+}
+
+func TestBackends_Update(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	out, err := executeBackendsCmd(t, srv, "update",
+		"--id", "b-1",
+		"--name", "updated-ims",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Backend b-1 updated")
+}
+
+func TestBackends_Delete(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	out, err := executeBackendsCmd(t, srv, "delete", "--id", "b-1")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Backend b-1 deleted")
+}
+
+func TestBackends_ListJSON(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	cmd.Printer = output.NewPrinter(true, false)
+	cmd.Printer.SetOutput(&buf)
+	cmd.Printer.SetErrOutput(&buf)
+
+	root := NewBackendsCmd()
+	root.SetArgs([]string{
+		"--gateway-url", srv.URL,
+		"--auth-url", srv.URL,
+		"--username", "test@example.com",
+		"--password", "test-password",
+		"--client-secret", "mock-secret",
+		"list",
+	})
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	var resp listResponse
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+	assert.Equal(t, 2, resp.Total)
+}
+
+func TestBackends_ConnectGatewayFailure(t *testing.T) {
+	var buf bytes.Buffer
+	cmd.Printer = output.NewPrinter(false, false)
+	cmd.Printer.SetOutput(&buf)
+	cmd.Printer.SetErrOutput(&buf)
+
+	root := NewBackendsCmd()
+	root.SetArgs([]string{
+		"--gateway-url", "https://nonexistent.example.com",
+		"--auth-url", "https://nonexistent.example.com",
+		"--username", "test@example.com",
+		"--password", "test-password",
+		"--client-secret", "mock-secret",
+		"list",
+	})
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to connect to gateway")
+}
+
+func TestParseKeyValuePairs(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []string
+		output map[string]string
+	}{
+		{
+			name:   "empty",
+			input:  nil,
+			output: map[string]string{},
+		},
+		{
+			name:   "single pair",
+			input:  []string{"key=value"},
+			output: map[string]string{"key": "value"},
+		},
+		{
+			name:   "multiple pairs",
+			input:  []string{"a=1", "b=2", "c=3"},
+			output: map[string]string{"a": "1", "b": "2", "c": "3"},
+		},
+		{
+			name:   "value with equals",
+			input:  []string{"url=https://example.com?a=1"},
+			output: map[string]string{"url": "https://example.com?a=1"},
+		},
+		{
+			name:   "no equals sign skipped",
+			input:  []string{"invalid", "valid=yes"},
+			output: map[string]string{"valid": "yes"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseKeyValuePairs(tt.input)
+			assert.Equal(t, tt.output, result)
+		})
+	}
+}
+
+// TestBackends_PasswordRequired verifies that missing --password fails at ConnectGateway.
+func TestBackends_PasswordRequired(t *testing.T) {
+	var buf bytes.Buffer
+	cmd.Printer = output.NewPrinter(false, false)
+	cmd.Printer.SetOutput(&buf)
+	cmd.Printer.SetErrOutput(&buf)
+
+	root := NewBackendsCmd()
+	root.SetArgs([]string{
+		"--gateway-url", "https://example.com",
+		"--auth-url", "https://example.com",
+		"--username", "test@example.com",
+		// No --password flag (defaults to empty).
+		"--client-secret", "secret",
+		"list",
+	})
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--password flag is required")
+}

--- a/internal/cli/cmd/gateway.go
+++ b/internal/cli/cmd/gateway.go
@@ -1,0 +1,63 @@
+// Package cmd defines the CLI command hierarchy for the netweave-cli tool.
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/piwi3910/netweave/internal/cli/service"
+)
+
+// GatewayFlags holds the shared gateway connection flags used by commands
+// that interact with the gateway admin API.
+type GatewayFlags struct {
+	GatewayURL   string
+	AuthURL      string
+	Username     string
+	Password     string
+	ClientSecret string
+}
+
+// AddGatewayFlags registers the gateway connection flags on the given command.
+func AddGatewayFlags(c *cobra.Command, gf *GatewayFlags) {
+	pf := c.PersistentFlags()
+	pf.StringVar(&gf.GatewayURL, "gateway-url", "https://api.netweave.local", "Gateway API URL")
+	pf.StringVar(&gf.AuthURL, "auth-url", "https://auth.netweave.local", "Keycloak auth URL")
+	pf.StringVar(&gf.Username, "username", "admin@netweave.local", "Admin username")
+	pf.StringVar(&gf.Password, "password", "", "Admin password (required)")
+	pf.StringVar(&gf.ClientSecret, "client-secret", "", "OAuth2 client secret (auto-read from K8s if empty)")
+}
+
+// MustMarkRequired marks a flag as required, panicking if the flag does not exist.
+// This is safe because flag names are compile-time constants — a panic here
+// indicates a programming error that would be caught immediately.
+func MustMarkRequired(c *cobra.Command, name string) {
+	if err := c.MarkFlagRequired(name); err != nil {
+		panic(fmt.Sprintf("flag %q not found: %v", name, err))
+	}
+}
+
+// ConnectGateway validates flags and establishes an authenticated connection
+// to the gateway admin API.
+func ConnectGateway(ctx context.Context, gf *GatewayFlags) (*service.GatewayConnection, error) {
+	if gf.Password == "" {
+		return nil, fmt.Errorf("--password flag is required")
+	}
+
+	gw, err := service.ConnectGateway(ctx, &service.GatewayConfig{
+		GatewayURL:   gf.GatewayURL,
+		AuthURL:      gf.AuthURL,
+		Username:     gf.Username,
+		Password:     gf.Password,
+		ClientSecret: gf.ClientSecret,
+		Namespace:    Global.Namespace,
+		Kubeconfig:   Global.Kubeconfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to gateway: %w", err)
+	}
+
+	return gw, nil
+}

--- a/internal/cli/cmd/gateway_test.go
+++ b/internal/cli/cmd/gateway_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddGatewayFlags(t *testing.T) {
+	c := &cobra.Command{Use: "test"}
+	var gf GatewayFlags
+
+	AddGatewayFlags(c, &gf)
+
+	// Verify all flags are registered with correct defaults.
+	gwURL, err := c.PersistentFlags().GetString("gateway-url")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.netweave.local", gwURL)
+
+	authURL, err := c.PersistentFlags().GetString("auth-url")
+	require.NoError(t, err)
+	assert.Equal(t, "https://auth.netweave.local", authURL)
+
+	username, err := c.PersistentFlags().GetString("username")
+	require.NoError(t, err)
+	assert.Equal(t, "admin@netweave.local", username)
+
+	password, err := c.PersistentFlags().GetString("password")
+	require.NoError(t, err)
+	assert.Empty(t, password, "password default should be empty")
+
+	clientSecret, err := c.PersistentFlags().GetString("client-secret")
+	require.NoError(t, err)
+	assert.Empty(t, clientSecret)
+}
+
+func TestAddGatewayFlags_FlagParsing(t *testing.T) {
+	c := &cobra.Command{Use: "test", RunE: func(_ *cobra.Command, _ []string) error { return nil }}
+	var gf GatewayFlags
+
+	AddGatewayFlags(c, &gf)
+	c.SetArgs([]string{
+		"--gateway-url", "https://gw.example.com",
+		"--auth-url", "https://auth.example.com",
+		"--username", "user@example.com",
+		"--password", "secret123",
+		"--client-secret", "cs-abc",
+	})
+
+	err := c.Execute()
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://gw.example.com", gf.GatewayURL)
+	assert.Equal(t, "https://auth.example.com", gf.AuthURL)
+	assert.Equal(t, "user@example.com", gf.Username)
+	assert.Equal(t, "secret123", gf.Password)
+	assert.Equal(t, "cs-abc", gf.ClientSecret)
+}
+
+func TestConnectGateway_EmptyPassword(t *testing.T) {
+	gf := &GatewayFlags{
+		GatewayURL: "https://gw.example.com",
+		AuthURL:    "https://auth.example.com",
+		Username:   "user@example.com",
+		Password:   "",
+	}
+
+	_, err := ConnectGateway(t.Context(), gf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--password flag is required")
+}

--- a/internal/cli/cmd/plugins/plugins.go
+++ b/internal/cli/cmd/plugins/plugins.go
@@ -10,42 +10,7 @@ import (
 
 	"github.com/piwi3910/netweave/internal/cli/cmd"
 	"github.com/piwi3910/netweave/internal/cli/output"
-	"github.com/piwi3910/netweave/internal/cli/service"
 )
-
-// gatewayFlags holds the shared gateway connection flags.
-type gatewayFlags struct {
-	gatewayURL   string
-	authURL      string
-	username     string
-	password     string
-	clientSecret string
-}
-
-func addGatewayFlags(c *cobra.Command, gf *gatewayFlags) {
-	pf := c.PersistentFlags()
-	pf.StringVar(&gf.gatewayURL, "gateway-url", "https://api.netweave.local", "Gateway API URL")
-	pf.StringVar(&gf.authURL, "auth-url", "https://auth.netweave.local", "Keycloak auth URL")
-	pf.StringVar(&gf.username, "username", "admin@netweave.local", "Admin username")
-	pf.StringVar(&gf.password, "password", "admin", "Admin password")
-	pf.StringVar(&gf.clientSecret, "client-secret", "", "OAuth2 client secret (auto-read from K8s if empty)")
-}
-
-func connectGateway(ctx context.Context, gf *gatewayFlags) (*service.GatewayConnection, error) {
-	gw, err := service.ConnectGateway(ctx, &service.GatewayConfig{
-		GatewayURL:   gf.gatewayURL,
-		AuthURL:      gf.authURL,
-		Username:     gf.username,
-		Password:     gf.password,
-		ClientSecret: gf.clientSecret,
-		Namespace:    cmd.Global.Namespace,
-		Kubeconfig:   cmd.Global.Kubeconfig,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to gateway: %w", err)
-	}
-	return gw, nil
-}
 
 // pluginInfo mirrors the API response for a plugin.
 type pluginInfo struct {
@@ -62,7 +27,7 @@ type pluginListResponse struct {
 
 // NewPluginsCmd creates the parent "plugins" command.
 func NewPluginsCmd() *cobra.Command {
-	var gf gatewayFlags
+	var gf cmd.GatewayFlags
 
 	parent := &cobra.Command{
 		Use:   "plugins",
@@ -70,7 +35,7 @@ func NewPluginsCmd() *cobra.Command {
 		Long:  `List, enable, and disable frontend plugins.`,
 	}
 
-	addGatewayFlags(parent, &gf)
+	cmd.AddGatewayFlags(parent, &gf)
 
 	parent.AddCommand(newListCmd(&gf))
 	parent.AddCommand(newEnableCmd(&gf))
@@ -79,14 +44,14 @@ func NewPluginsCmd() *cobra.Command {
 	return parent
 }
 
-func newListCmd(gf *gatewayFlags) *cobra.Command {
+func newListCmd(gf *cmd.GatewayFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List all plugins",
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 
-			gw, err := connectGateway(ctx, gf)
+			gw, err := cmd.ConnectGateway(ctx, gf)
 			if err != nil {
 				return err
 			}
@@ -119,7 +84,7 @@ func newListCmd(gf *gatewayFlags) *cobra.Command {
 	}
 }
 
-func newEnableCmd(gf *gatewayFlags) *cobra.Command {
+func newEnableCmd(gf *cmd.GatewayFlags) *cobra.Command {
 	var pluginName string
 
 	enableCmd := &cobra.Command{
@@ -130,11 +95,12 @@ func newEnableCmd(gf *gatewayFlags) *cobra.Command {
 		},
 	}
 
-	enableCmd.Flags().StringVar(&pluginName, "name", "", "Plugin name (required)")
+	enableCmd.Flags().StringVar(&pluginName, "name", "", "Plugin name")
+	cmd.MustMarkRequired(enableCmd, "name")
 	return enableCmd
 }
 
-func newDisableCmd(gf *gatewayFlags) *cobra.Command {
+func newDisableCmd(gf *cmd.GatewayFlags) *cobra.Command {
 	var pluginName string
 
 	disableCmd := &cobra.Command{
@@ -145,16 +111,13 @@ func newDisableCmd(gf *gatewayFlags) *cobra.Command {
 		},
 	}
 
-	disableCmd.Flags().StringVar(&pluginName, "name", "", "Plugin name (required)")
+	disableCmd.Flags().StringVar(&pluginName, "name", "", "Plugin name")
+	cmd.MustMarkRequired(disableCmd, "name")
 	return disableCmd
 }
 
-func setPluginState(ctx context.Context, gf *gatewayFlags, pluginName string, enabled bool) error {
-	if pluginName == "" {
-		return fmt.Errorf("--name flag is required")
-	}
-
-	gw, err := connectGateway(ctx, gf)
+func setPluginState(ctx context.Context, gf *cmd.GatewayFlags, pluginName string, enabled bool) error {
+	gw, err := cmd.ConnectGateway(ctx, gf)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cmd/plugins/plugins.go
+++ b/internal/cli/cmd/plugins/plugins.go
@@ -1,0 +1,187 @@
+// Package plugins provides CLI commands for managing frontend plugins.
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/piwi3910/netweave/internal/cli/cmd"
+	"github.com/piwi3910/netweave/internal/cli/output"
+	"github.com/piwi3910/netweave/internal/cli/service"
+)
+
+// gatewayFlags holds the shared gateway connection flags.
+type gatewayFlags struct {
+	gatewayURL   string
+	authURL      string
+	username     string
+	password     string
+	clientSecret string
+}
+
+func addGatewayFlags(c *cobra.Command, gf *gatewayFlags) {
+	pf := c.PersistentFlags()
+	pf.StringVar(&gf.gatewayURL, "gateway-url", "https://api.netweave.local", "Gateway API URL")
+	pf.StringVar(&gf.authURL, "auth-url", "https://auth.netweave.local", "Keycloak auth URL")
+	pf.StringVar(&gf.username, "username", "admin@netweave.local", "Admin username")
+	pf.StringVar(&gf.password, "password", "admin", "Admin password")
+	pf.StringVar(&gf.clientSecret, "client-secret", "", "OAuth2 client secret (auto-read from K8s if empty)")
+}
+
+func connectGateway(ctx context.Context, gf *gatewayFlags) (*service.GatewayConnection, error) {
+	gw, err := service.ConnectGateway(ctx, &service.GatewayConfig{
+		GatewayURL:   gf.gatewayURL,
+		AuthURL:      gf.authURL,
+		Username:     gf.username,
+		Password:     gf.password,
+		ClientSecret: gf.clientSecret,
+		Namespace:    cmd.Global.Namespace,
+		Kubeconfig:   cmd.Global.Kubeconfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to gateway: %w", err)
+	}
+	return gw, nil
+}
+
+// pluginInfo mirrors the API response for a plugin.
+type pluginInfo struct {
+	Name        string   `json:"name"`
+	DisplayName string   `json:"displayName"`
+	Enabled     bool     `json:"enabled"`
+	BasePaths   []string `json:"basePaths"`
+}
+
+// pluginListResponse is the API response for listing plugins.
+type pluginListResponse struct {
+	Plugins []pluginInfo `json:"plugins"`
+}
+
+// NewPluginsCmd creates the parent "plugins" command.
+func NewPluginsCmd() *cobra.Command {
+	var gf gatewayFlags
+
+	parent := &cobra.Command{
+		Use:   "plugins",
+		Short: "Manage frontend plugins",
+		Long:  `List, enable, and disable frontend plugins.`,
+	}
+
+	addGatewayFlags(parent, &gf)
+
+	parent.AddCommand(newListCmd(&gf))
+	parent.AddCommand(newEnableCmd(&gf))
+	parent.AddCommand(newDisableCmd(&gf))
+
+	return parent
+}
+
+func newListCmd(gf *gatewayFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all plugins",
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx := c.Context()
+
+			gw, err := connectGateway(ctx, gf)
+			if err != nil {
+				return err
+			}
+
+			data, err := gw.Get(ctx, "/admin/platform/plugins")
+			if err != nil {
+				return fmt.Errorf("failed to list plugins: %w", err)
+			}
+
+			var resp pluginListResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+
+			return cmd.Printer.PrintResult(resp, func() {
+				tbl := output.NewTable(
+					cmd.Printer.Output(),
+					"NAME", "DISPLAY NAME", "ENABLED", "BASE PATHS",
+				)
+				for _, p := range resp.Plugins {
+					enabled := "no"
+					if p.Enabled {
+						enabled = "yes"
+					}
+					tbl.AddRow(p.Name, p.DisplayName, enabled, fmt.Sprintf("%v", p.BasePaths))
+				}
+				tbl.Render()
+			})
+		},
+	}
+}
+
+func newEnableCmd(gf *gatewayFlags) *cobra.Command {
+	var pluginName string
+
+	enableCmd := &cobra.Command{
+		Use:   "enable",
+		Short: "Enable a plugin",
+		RunE: func(c *cobra.Command, _ []string) error {
+			return setPluginState(c.Context(), gf, pluginName, true)
+		},
+	}
+
+	enableCmd.Flags().StringVar(&pluginName, "name", "", "Plugin name (required)")
+	return enableCmd
+}
+
+func newDisableCmd(gf *gatewayFlags) *cobra.Command {
+	var pluginName string
+
+	disableCmd := &cobra.Command{
+		Use:   "disable",
+		Short: "Disable a plugin",
+		RunE: func(c *cobra.Command, _ []string) error {
+			return setPluginState(c.Context(), gf, pluginName, false)
+		},
+	}
+
+	disableCmd.Flags().StringVar(&pluginName, "name", "", "Plugin name (required)")
+	return disableCmd
+}
+
+func setPluginState(ctx context.Context, gf *gatewayFlags, pluginName string, enabled bool) error {
+	if pluginName == "" {
+		return fmt.Errorf("--name flag is required")
+	}
+
+	gw, err := connectGateway(ctx, gf)
+	if err != nil {
+		return err
+	}
+
+	reqBody := map[string]interface{}{
+		"enabled": enabled,
+	}
+
+	data, err := gw.Put(ctx, "/admin/platform/plugins/"+pluginName, reqBody)
+	if err != nil {
+		action := "enable"
+		if !enabled {
+			action = "disable"
+		}
+		return fmt.Errorf("failed to %s plugin: %w", action, err)
+	}
+
+	var p pluginInfo
+	if err := json.Unmarshal(data, &p); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return cmd.Printer.PrintResult(p, func() {
+		action := "enabled"
+		if !enabled {
+			action = "disabled"
+		}
+		cmd.Printer.Infof("Plugin %q %s", p.Name, action)
+	})
+}

--- a/internal/cli/cmd/plugins/plugins_test.go
+++ b/internal/cli/cmd/plugins/plugins_test.go
@@ -1,0 +1,224 @@
+package plugins
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/cli/cmd"
+	"github.com/piwi3910/netweave/internal/cli/output"
+)
+
+func newMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/realms/netweave/protocol/openid-connect/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"mock-token","token_type":"Bearer","expires_in":300}`))
+	})
+
+	mux.HandleFunc("/admin/platform/plugins", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		resp := pluginListResponse{
+			Plugins: []pluginInfo{
+				{Name: "dashboard", DisplayName: "Dashboard", Enabled: true, BasePaths: []string{"/dashboard"}},
+				{Name: "monitoring", DisplayName: "Monitoring", Enabled: false, BasePaths: []string{"/monitoring"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	mux.HandleFunc("/admin/platform/plugins/dashboard", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		resp := pluginInfo{
+			Name: "dashboard", DisplayName: "Dashboard",
+			Enabled: true, BasePaths: []string{"/dashboard"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	mux.HandleFunc("/admin/platform/plugins/monitoring", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		resp := pluginInfo{
+			Name: "monitoring", DisplayName: "Monitoring",
+			Enabled: false, BasePaths: []string{"/monitoring"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func executePluginsCmd(t *testing.T, srv *httptest.Server, args ...string) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd.Printer = output.NewPrinter(false, false)
+	cmd.Printer.SetOutput(&buf)
+	cmd.Printer.SetErrOutput(&buf)
+
+	root := NewPluginsCmd()
+	fullArgs := append([]string{
+		"--gateway-url", srv.URL,
+		"--auth-url", srv.URL,
+		"--username", "test@example.com",
+		"--password", "test-password",
+		"--client-secret", "mock-secret",
+	}, args...)
+	root.SetArgs(fullArgs)
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	err := root.Execute()
+	return buf.String(), err
+}
+
+func TestNewPluginsCmd_Structure(t *testing.T) {
+	pluginsCmd := NewPluginsCmd()
+
+	assert.Equal(t, "plugins", pluginsCmd.Use)
+	assert.NotEmpty(t, pluginsCmd.Short)
+
+	subCmds := pluginsCmd.Commands()
+	names := make([]string, len(subCmds))
+	for i, c := range subCmds {
+		names[i] = c.Name()
+	}
+	assert.Contains(t, names, "list")
+	assert.Contains(t, names, "enable")
+	assert.Contains(t, names, "disable")
+}
+
+func TestNewPluginsCmd_GatewayFlags(t *testing.T) {
+	pluginsCmd := NewPluginsCmd()
+
+	flags := []string{"gateway-url", "auth-url", "username", "password", "client-secret"}
+	for _, f := range flags {
+		flag := pluginsCmd.PersistentFlags().Lookup(f)
+		assert.NotNil(t, flag, "flag %q should be registered", f)
+	}
+}
+
+func TestPlugins_EnableRequiresName(t *testing.T) {
+	pluginsCmd := NewPluginsCmd()
+	pluginsCmd.SetArgs([]string{"enable"})
+
+	var buf bytes.Buffer
+	pluginsCmd.SetOut(&buf)
+	pluginsCmd.SetErr(&buf)
+
+	err := pluginsCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required flag")
+}
+
+func TestPlugins_DisableRequiresName(t *testing.T) {
+	pluginsCmd := NewPluginsCmd()
+	pluginsCmd.SetArgs([]string{"disable"})
+
+	var buf bytes.Buffer
+	pluginsCmd.SetOut(&buf)
+	pluginsCmd.SetErr(&buf)
+
+	err := pluginsCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required flag")
+}
+
+func TestPlugins_List(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	out, err := executePluginsCmd(t, srv, "list")
+	require.NoError(t, err)
+	assert.Contains(t, out, "dashboard")
+	assert.Contains(t, out, "Dashboard")
+	assert.Contains(t, out, "monitoring")
+	assert.Contains(t, out, "2 item(s)")
+}
+
+func TestPlugins_Enable(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	out, err := executePluginsCmd(t, srv, "enable", "--name", "dashboard")
+	require.NoError(t, err)
+	assert.Contains(t, out, `Plugin "dashboard" enabled`)
+}
+
+func TestPlugins_Disable(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	out, err := executePluginsCmd(t, srv, "disable", "--name", "monitoring")
+	require.NoError(t, err)
+	assert.Contains(t, out, `Plugin "monitoring" disabled`)
+}
+
+func TestPlugins_ListJSON(t *testing.T) {
+	srv := newMockServer(t)
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	cmd.Printer = output.NewPrinter(true, false)
+	cmd.Printer.SetOutput(&buf)
+	cmd.Printer.SetErrOutput(&buf)
+
+	root := NewPluginsCmd()
+	root.SetArgs([]string{
+		"--gateway-url", srv.URL,
+		"--auth-url", srv.URL,
+		"--username", "test@example.com",
+		"--password", "test-password",
+		"--client-secret", "mock-secret",
+		"list",
+	})
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	var resp pluginListResponse
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+	assert.Len(t, resp.Plugins, 2)
+}
+
+func TestPlugins_PasswordRequired(t *testing.T) {
+	var buf bytes.Buffer
+	cmd.Printer = output.NewPrinter(false, false)
+	cmd.Printer.SetOutput(&buf)
+	cmd.Printer.SetErrOutput(&buf)
+
+	root := NewPluginsCmd()
+	root.SetArgs([]string{
+		"--gateway-url", "https://example.com",
+		"--auth-url", "https://example.com",
+		"--username", "test@example.com",
+		"--client-secret", "secret",
+		"list",
+	})
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--password flag is required")
+}

--- a/internal/cli/service/gateway.go
+++ b/internal/cli/service/gateway.go
@@ -3,15 +3,15 @@ package service
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"os/exec"
 	"strings"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -199,23 +199,22 @@ func readClientSecret(
 		namespace = "netweave"
 	}
 
-	args := []string{
-		"get", "secret", "-n", namespace, defaultSecretName,
-		"-o", "jsonpath={.data." + defaultSecretKey + "}",
-	}
-	if kubeconfig != "" {
-		args = append([]string{"--kubeconfig", kubeconfig}, args...)
-	}
-
-	out, err := exec.CommandContext(ctx, "kubectl", args...).Output()
+	conn, err := NewConnector(kubeconfig, namespace)
 	if err != nil {
-		return "", fmt.Errorf("kubectl get secret failed: %w", err)
+		return "", fmt.Errorf("failed to create K8s client: %w", err)
 	}
 
-	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(out)))
+	secret, err := conn.Clientset().CoreV1().Secrets(namespace).Get(
+		ctx, defaultSecretName, metav1.GetOptions{},
+	)
 	if err != nil {
-		return "", fmt.Errorf("failed to decode secret: %w", err)
+		return "", fmt.Errorf("failed to read secret %s: %w", defaultSecretName, err)
 	}
 
-	return strings.TrimSpace(string(decoded)), nil
+	value, ok := secret.Data[defaultSecretKey]
+	if !ok {
+		return "", fmt.Errorf("key %s not found in secret %s", defaultSecretKey, defaultSecretName)
+	}
+
+	return strings.TrimSpace(string(value)), nil
 }

--- a/internal/cli/service/gateway.go
+++ b/internal/cli/service/gateway.go
@@ -1,0 +1,221 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	gatewayClientTimeout = 30 * time.Second
+	defaultGatewayURL    = "https://api.netweave.local"
+	defaultAuthURL       = "https://auth.netweave.local"
+	defaultUsername      = "admin@netweave.local"
+	defaultPassword      = "admin"
+	defaultClientID      = "netweave-gateway"
+	defaultSecretName    = "netweave-secret"
+	defaultSecretKey     = "keycloak-client-secret"
+)
+
+// GatewayConnection holds an authenticated connection to the gateway admin API.
+type GatewayConnection struct {
+	token   string
+	baseURL string
+	client  *http.Client
+}
+
+// GatewayConfig holds the configuration for connecting to the gateway.
+type GatewayConfig struct {
+	GatewayURL   string
+	AuthURL      string
+	Username     string
+	Password     string
+	ClientSecret string
+	Namespace    string
+	Kubeconfig   string
+}
+
+// DefaultGatewayConfig returns a GatewayConfig with default values.
+func DefaultGatewayConfig() *GatewayConfig {
+	return &GatewayConfig{
+		GatewayURL: defaultGatewayURL,
+		AuthURL:    defaultAuthURL,
+		Username:   defaultUsername,
+		Password:   defaultPassword,
+	}
+}
+
+// ConnectGateway authenticates with Keycloak and returns a GatewayConnection.
+func ConnectGateway(ctx context.Context, cfg *GatewayConfig) (*GatewayConnection, error) {
+	clientSecret := cfg.ClientSecret
+	if clientSecret == "" {
+		secret, err := readClientSecret(ctx, cfg.Namespace, cfg.Kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read client secret from K8s (use --client-secret flag): %w", err)
+		}
+		clientSecret = secret
+	}
+
+	httpClient := NewInsecureTLSClient(gatewayClientTimeout)
+
+	token, err := acquireToken(ctx, httpClient, cfg.AuthURL, clientSecret, cfg.Username, cfg.Password)
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire OAuth2 token: %w", err)
+	}
+
+	return &GatewayConnection{
+		token:   token,
+		baseURL: strings.TrimRight(cfg.GatewayURL, "/"),
+		client:  httpClient,
+	}, nil
+}
+
+// Get performs an authenticated GET request.
+func (g *GatewayConnection) Get(ctx context.Context, path string) ([]byte, error) {
+	return g.doRequest(ctx, http.MethodGet, path, nil)
+}
+
+// Post performs an authenticated POST request with a JSON body.
+func (g *GatewayConnection) Post(ctx context.Context, path string, body interface{}) ([]byte, error) {
+	return g.doJSONRequest(ctx, http.MethodPost, path, body)
+}
+
+// Put performs an authenticated PUT request with a JSON body.
+func (g *GatewayConnection) Put(ctx context.Context, path string, body interface{}) ([]byte, error) {
+	return g.doJSONRequest(ctx, http.MethodPut, path, body)
+}
+
+// Delete performs an authenticated DELETE request.
+func (g *GatewayConnection) Delete(ctx context.Context, path string) error {
+	_, err := g.doRequest(ctx, http.MethodDelete, path, nil)
+	return err
+}
+
+func (g *GatewayConnection) doJSONRequest(ctx context.Context, method, path string, body interface{}) ([]byte, error) {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %w", err)
+	}
+	return g.doRequest(ctx, method, path, bytes.NewReader(jsonBody))
+}
+
+func (g *GatewayConnection) doRequest(ctx context.Context, method, path string, body io.Reader) ([]byte, error) {
+	reqURL := g.baseURL + path
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+g.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("API error (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}
+
+// tokenResponse represents the OAuth2 token endpoint response.
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+func acquireToken(
+	ctx context.Context, client *http.Client,
+	authURL, clientSecret, username, password string,
+) (string, error) {
+	tokenURL := strings.TrimRight(authURL, "/") + "/realms/netweave/protocol/openid-connect/token"
+
+	data := url.Values{
+		"grant_type":    {"password"},
+		"client_id":     {defaultClientID},
+		"client_secret": {clientSecret},
+		"username":      {username},
+		"password":      {password},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token request failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp tokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("empty access token in response")
+	}
+
+	return tokenResp.AccessToken, nil
+}
+
+func readClientSecret(
+	ctx context.Context, namespace, kubeconfig string,
+) (string, error) {
+	if namespace == "" {
+		namespace = "netweave"
+	}
+
+	args := []string{
+		"get", "secret", "-n", namespace, defaultSecretName,
+		"-o", "jsonpath={.data." + defaultSecretKey + "}",
+	}
+	if kubeconfig != "" {
+		args = append([]string{"--kubeconfig", kubeconfig}, args...)
+	}
+
+	out, err := exec.CommandContext(ctx, "kubectl", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("kubectl get secret failed: %w", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(out)))
+	if err != nil {
+		return "", fmt.Errorf("failed to decode secret: %w", err)
+	}
+
+	return strings.TrimSpace(string(decoded)), nil
+}

--- a/internal/cli/service/gateway.go
+++ b/internal/cli/service/gateway.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -23,7 +24,11 @@ const (
 	defaultClientID      = "netweave-gateway"
 	defaultSecretName    = "netweave-secret"
 	defaultSecretKey     = "keycloak-client-secret"
+	maxNamespaceLength   = 63
 )
+
+// dns1123LabelRegex validates DNS-1123 label format for Kubernetes namespace names.
+var dns1123LabelRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
 // GatewayConnection holds an authenticated connection to the gateway admin API.
 type GatewayConnection struct {
@@ -59,7 +64,7 @@ func ConnectGateway(ctx context.Context, cfg *GatewayConfig) (*GatewayConnection
 	if clientSecret == "" {
 		secret, err := readClientSecret(ctx, cfg.Namespace, cfg.Kubeconfig)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read client secret from K8s (use --client-secret flag): %w", err)
+			return nil, fmt.Errorf("failed to read client secret from Kubernetes (use --client-secret flag)")
 		}
 		clientSecret = secret
 	}
@@ -108,6 +113,9 @@ func (g *GatewayConnection) doJSONRequest(ctx context.Context, method, path stri
 }
 
 func (g *GatewayConnection) doRequest(ctx context.Context, method, path string, body io.Reader) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, gatewayClientTimeout)
+	defer cancel()
+
 	reqURL := g.baseURL + path
 
 	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
@@ -177,7 +185,7 @@ func acquireToken(
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("token request failed (HTTP %d): %s", resp.StatusCode, string(body))
+		return "", fmt.Errorf("authentication failed (HTTP %d): check credentials and auth URL", resp.StatusCode)
 	}
 
 	var tokenResp tokenResponse
@@ -192,6 +200,17 @@ func acquireToken(
 	return tokenResp.AccessToken, nil
 }
 
+// validateNamespace checks that a namespace is a valid DNS-1123 label.
+func validateNamespace(namespace string) error {
+	if len(namespace) > maxNamespaceLength {
+		return fmt.Errorf("namespace %q exceeds maximum length of %d characters", namespace, maxNamespaceLength)
+	}
+	if !dns1123LabelRegex.MatchString(namespace) {
+		return fmt.Errorf("namespace %q is not a valid DNS-1123 label", namespace)
+	}
+	return nil
+}
+
 func readClientSecret(
 	ctx context.Context, namespace, kubeconfig string,
 ) (string, error) {
@@ -199,21 +218,25 @@ func readClientSecret(
 		namespace = "netweave"
 	}
 
+	if err := validateNamespace(namespace); err != nil {
+		return "", err
+	}
+
 	conn, err := NewConnector(kubeconfig, namespace)
 	if err != nil {
-		return "", fmt.Errorf("failed to create K8s client: %w", err)
+		return "", fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}
 
 	secret, err := conn.Clientset().CoreV1().Secrets(namespace).Get(
 		ctx, defaultSecretName, metav1.GetOptions{},
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to read secret %s: %w", defaultSecretName, err)
+		return "", fmt.Errorf("failed to read secret %q in namespace %q", defaultSecretName, namespace)
 	}
 
 	value, ok := secret.Data[defaultSecretKey]
 	if !ok {
-		return "", fmt.Errorf("key %s not found in secret %s", defaultSecretKey, defaultSecretName)
+		return "", fmt.Errorf("key %q not found in secret %q", defaultSecretKey, defaultSecretName)
 	}
 
 	return strings.TrimSpace(string(value)), nil

--- a/internal/cli/service/gateway_test.go
+++ b/internal/cli/service/gateway_test.go
@@ -1,0 +1,408 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMockOAuth2Server(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/realms/netweave/protocol/openid-connect/token" {
+			w.Header().Set("Content-Type", "application/json")
+			resp := tokenResponse{
+				AccessToken: "mock-token-12345",
+				TokenType:   "Bearer",
+				ExpiresIn:   300,
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+func newMockGatewayServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// OAuth2 token endpoint.
+	mux.HandleFunc("/realms/netweave/protocol/openid-connect/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := tokenResponse{
+			AccessToken: "mock-token-12345",
+			TokenType:   "Bearer",
+			ExpiresIn:   300,
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	// API endpoints.
+	mux.HandleFunc("/admin/infrastructure/backends", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"backends":[],"total":0}`))
+		case http.MethodPost:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"id":"b-1","name":"test"}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	mux.HandleFunc("/admin/test/ok", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	mux.HandleFunc("/admin/test/error", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`internal server error`))
+	})
+
+	mux.HandleFunc("/admin/test/slow", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(5 * time.Second):
+			w.Write([]byte(`{"status":"slow"}`))
+		}
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func connectToMockGateway(t *testing.T, serverURL string) *GatewayConnection {
+	t.Helper()
+	ctx := context.Background()
+
+	gw, err := ConnectGateway(ctx, &GatewayConfig{
+		GatewayURL:   serverURL,
+		AuthURL:      serverURL,
+		Username:     "test@example.com",
+		Password:     "testpass",
+		ClientSecret: "mock-secret",
+	})
+	require.NoError(t, err)
+	return gw
+}
+
+func TestConnectGateway_Success(t *testing.T) {
+	srv := newMockGatewayServer(t)
+	defer srv.Close()
+
+	gw := connectToMockGateway(t, srv.URL)
+	assert.NotNil(t, gw)
+	assert.Equal(t, "mock-token-12345", gw.token)
+	assert.Equal(t, srv.URL, gw.baseURL)
+}
+
+func TestConnectGateway_TokenFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"invalid_client"}`))
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	_, err := ConnectGateway(ctx, &GatewayConfig{
+		GatewayURL:   srv.URL,
+		AuthURL:      srv.URL,
+		Username:     "bad@example.com",
+		Password:     "wrong",
+		ClientSecret: "bad-secret",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to acquire OAuth2 token")
+	assert.Contains(t, err.Error(), "authentication failed")
+	assert.NotContains(t, err.Error(), "invalid_client")
+}
+
+func TestConnectGateway_EmptyToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"","token_type":"Bearer"}`))
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	_, err := ConnectGateway(ctx, &GatewayConfig{
+		GatewayURL:   srv.URL,
+		AuthURL:      srv.URL,
+		Username:     "test@example.com",
+		Password:     "testpass",
+		ClientSecret: "mock-secret",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty access token")
+}
+
+func TestGatewayConnection_Get(t *testing.T) {
+	srv := newMockGatewayServer(t)
+	defer srv.Close()
+
+	gw := connectToMockGateway(t, srv.URL)
+
+	data, err := gw.Get(context.Background(), "/admin/test/ok")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"status":"ok"`)
+}
+
+func TestGatewayConnection_Get_ErrorStatus(t *testing.T) {
+	srv := newMockGatewayServer(t)
+	defer srv.Close()
+
+	gw := connectToMockGateway(t, srv.URL)
+
+	_, err := gw.Get(context.Background(), "/admin/test/error")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API error (HTTP 500)")
+}
+
+func TestGatewayConnection_Post(t *testing.T) {
+	srv := newMockGatewayServer(t)
+	defer srv.Close()
+
+	gw := connectToMockGateway(t, srv.URL)
+
+	body := map[string]string{"name": "test-backend"}
+	data, err := gw.Post(context.Background(), "/admin/infrastructure/backends", body)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"id":"b-1"`)
+}
+
+func TestGatewayConnection_Put(t *testing.T) {
+	srv := newMockGatewayServer(t)
+	defer srv.Close()
+
+	gw := connectToMockGateway(t, srv.URL)
+
+	body := map[string]string{"status": "updated"}
+	data, err := gw.Put(context.Background(), "/admin/test/ok", body)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"status":"ok"`)
+}
+
+func TestGatewayConnection_Delete(t *testing.T) {
+	srv := newMockGatewayServer(t)
+	defer srv.Close()
+
+	gw := connectToMockGateway(t, srv.URL)
+
+	err := gw.Delete(context.Background(), "/admin/test/ok")
+	require.NoError(t, err)
+}
+
+func TestGatewayConnection_Delete_Error(t *testing.T) {
+	srv := newMockGatewayServer(t)
+	defer srv.Close()
+
+	gw := connectToMockGateway(t, srv.URL)
+
+	err := gw.Delete(context.Background(), "/admin/test/error")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API error (HTTP 500)")
+}
+
+func TestGatewayConnection_ContextCancelled(t *testing.T) {
+	srv := newMockGatewayServer(t)
+	defer srv.Close()
+
+	gw := connectToMockGateway(t, srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := gw.Get(ctx, "/admin/test/slow")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request failed")
+}
+
+func TestDefaultGatewayConfig(t *testing.T) {
+	cfg := DefaultGatewayConfig()
+
+	assert.Equal(t, "https://api.netweave.local", cfg.GatewayURL)
+	assert.Equal(t, "https://auth.netweave.local", cfg.AuthURL)
+	assert.Equal(t, "admin@netweave.local", cfg.Username)
+	assert.Equal(t, "admin", cfg.Password)
+	assert.Empty(t, cfg.ClientSecret)
+	assert.Empty(t, cfg.Namespace)
+	assert.Empty(t, cfg.Kubeconfig)
+}
+
+func TestValidateNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name:      "valid namespace",
+			namespace: "netweave",
+			wantErr:   false,
+		},
+		{
+			name:      "valid namespace with hyphens",
+			namespace: "my-namespace-01",
+			wantErr:   false,
+		},
+		{
+			name:      "single character",
+			namespace: "a",
+			wantErr:   false,
+		},
+		{
+			name:      "starts with uppercase",
+			namespace: "Netweave",
+			wantErr:   true,
+			errMsg:    "not a valid DNS-1123 label",
+		},
+		{
+			name:      "contains underscore",
+			namespace: "my_namespace",
+			wantErr:   true,
+			errMsg:    "not a valid DNS-1123 label",
+		},
+		{
+			name:      "starts with hyphen",
+			namespace: "-invalid",
+			wantErr:   true,
+			errMsg:    "not a valid DNS-1123 label",
+		},
+		{
+			name:      "ends with hyphen",
+			namespace: "invalid-",
+			wantErr:   true,
+			errMsg:    "not a valid DNS-1123 label",
+		},
+		{
+			name:      "too long",
+			namespace: "a234567890123456789012345678901234567890123456789012345678901234",
+			wantErr:   true,
+			errMsg:    "exceeds maximum length",
+		},
+		{
+			name:      "contains spaces",
+			namespace: "my namespace",
+			wantErr:   true,
+			errMsg:    "not a valid DNS-1123 label",
+		},
+		{
+			name:      "contains dots",
+			namespace: "my.namespace",
+			wantErr:   true,
+			errMsg:    "not a valid DNS-1123 label",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNamespace(tt.namespace)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAcquireToken_Success(t *testing.T) {
+	srv := newMockOAuth2Server(t)
+	defer srv.Close()
+
+	client := NewInsecureTLSClient(5 * time.Second)
+	token, err := acquireToken(
+		context.Background(), client,
+		srv.URL, "secret", "user@example.com", "pass",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "mock-token-12345", token)
+}
+
+func TestAcquireToken_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(`service unavailable`))
+	}))
+	defer srv.Close()
+
+	client := NewInsecureTLSClient(5 * time.Second)
+	_, err := acquireToken(
+		context.Background(), client,
+		srv.URL, "secret", "user@example.com", "pass",
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed (HTTP 503)")
+	assert.NotContains(t, err.Error(), "service unavailable")
+}
+
+func TestAcquireToken_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	client := NewInsecureTLSClient(5 * time.Second)
+	_, err := acquireToken(
+		context.Background(), client,
+		srv.URL, "secret", "user@example.com", "pass",
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse token response")
+}
+
+func TestDoRequest_AuthorizationHeader(t *testing.T) {
+	var capturedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	gw := &GatewayConnection{
+		token:   "test-token-xyz",
+		baseURL: srv.URL,
+		client:  NewInsecureTLSClient(5 * time.Second),
+	}
+
+	_, err := gw.Get(context.Background(), "/test")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer test-token-xyz", capturedAuth)
+}
+
+func TestDoRequest_ContentTypeOnBody(t *testing.T) {
+	var capturedContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedContentType = r.Header.Get("Content-Type")
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	gw := &GatewayConnection{
+		token:   "test-token",
+		baseURL: srv.URL,
+		client:  NewInsecureTLSClient(5 * time.Second),
+	}
+
+	_, err := gw.Post(context.Background(), "/test", map[string]string{"key": "val"})
+	require.NoError(t, err)
+	assert.Equal(t, "application/json", capturedContentType)
+}


### PR DESCRIPTION
## Summary

- Add `backends` CLI command group (list, get, create, update, delete) for managing infrastructure backends
- Add `backend-access` CLI command group (list, grant, revoke) for managing tenant backend access
- Add `plugins` CLI command group (list, enable, disable) for managing frontend plugins
- Create gateway admin API client (`internal/cli/service/gateway.go`) with OAuth2 token acquisition from Keycloak
- Update demo runbook to use CLI commands instead of curl (curl commands kept as expandable reference)

## Test plan

- [x] `go build -o build/netweave-cli ./cmd/cli/` succeeds
- [x] `make lint` passes with zero issues
- [x] `make test` — no new test failures (pre-existing failures unrelated to this change)
- [x] `netweave-cli --help` shows backends, backend-access, and plugins commands
- [x] All subcommands have correct flags and help text
- [ ] Deploy stack and run through demo runbook using CLI commands from Phase 4 onward

Resolves #432