### PR TITLE
[Fix] Hoist shared Keycloak helper + enforce mapstructure on Viper configs

### DIFF
--- a/internal/adapters/dtias/adapter.go
+++ b/internal/adapters/dtias/adapter.go
@@ -52,43 +52,46 @@ type Adapter struct {
 }
 
 // Config holds configuration for creating a DTIASAdapter.
+// Tags use `mapstructure` so Viper's UnmarshalKey can decode YAML/JSON/env
+// sources consistently — see internal/smo/adapters/onap/plugin.go for the
+// reference convention.
 type Config struct {
 	// Endpoint is the DTIAS API endpoint URL (e.g., "https://dtias.dell.com/api/v1")
-	Endpoint string `yaml:"endpoint"`
+	Endpoint string `mapstructure:"endpoint"`
 
 	// APIKey is the authentication API key for DTIAS
-	APIKey string `yaml:"apiKey"`
+	APIKey string `mapstructure:"apiKey"`
 
 	// ClientCert is the path to the client certificate for mTLS (optional)
-	ClientCert string `yaml:"clientCert"`
+	ClientCert string `mapstructure:"clientCert"`
 
 	// ClientKey is the path to the client key for mTLS (optional)
-	ClientKey string `yaml:"clientKey"`
+	ClientKey string `mapstructure:"clientKey"`
 
 	// CACert is the path to the CA certificate for server verification (optional)
 	// If not provided, system root CAs are used for certificate validation
-	CACert string `yaml:"caCert"`
+	CACert string `mapstructure:"caCert"`
 
 	// Timeout is the HTTP client timeout
-	Timeout time.Duration `yaml:"timeout"`
+	Timeout time.Duration `mapstructure:"timeout"`
 
 	// OCloudID is the identifier of the parent O-Cloud
-	OCloudID string `yaml:"ocloudId"`
+	OCloudID string `mapstructure:"ocloudId"`
 
 	// DeploymentManagerID is the identifier for this deployment manager
-	DeploymentManagerID string `yaml:"deploymentManagerId"`
+	DeploymentManagerID string `mapstructure:"deploymentManagerId"`
 
 	// Datacenter is the DTIAS datacenter identifier
-	Datacenter string `yaml:"datacenter"`
+	Datacenter string `mapstructure:"datacenter"`
 
 	// RetryAttempts is the number of retry attempts for failed API calls
-	RetryAttempts int `yaml:"retryAttempts"`
+	RetryAttempts int `mapstructure:"retryAttempts"`
 
 	// RetryDelay is the delay between retry attempts
-	RetryDelay time.Duration `yaml:"retryDelay"`
+	RetryDelay time.Duration `mapstructure:"retryDelay"`
 
 	// Logger is the logger to use. If nil, a default logger will be created.
-	Logger *zap.Logger `yaml:"-"`
+	Logger *zap.Logger `mapstructure:"-"`
 }
 
 // New creates a new DTIASAdapter with the provided configuration.

--- a/internal/adapters/dtias/config_test.go
+++ b/internal/adapters/dtias/config_test.go
@@ -1,0 +1,68 @@
+package dtias_test
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/adapters/dtias"
+)
+
+// TestConfig_ViperUnmarshal verifies that every field on Config has a working
+// `mapstructure` tag, by loading a YAML document through Viper (which only
+// respects `mapstructure`, not `yaml` tags) and asserting every tagged field
+// is populated. This guards against accidental regressions to `yaml:"..."`
+// tags that would silently depend on field-name fallbacks.
+func TestConfig_ViperUnmarshal(t *testing.T) {
+	yamlInput := `
+dtias:
+  endpoint: https://dtias.example.com/api/v1
+  apiKey: test-api-key
+  clientCert: /etc/certs/dtias/client.crt
+  clientKey: /etc/certs/dtias/client.key
+  caCert: /etc/certs/dtias/ca.crt
+  timeout: 45s
+  ocloudId: ocloud-dtias-1
+  deploymentManagerId: ocloud-dtias-edge-1
+  datacenter: dc-dallas-1
+  retryAttempts: 5
+  retryDelay: 3s
+`
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(bytes.NewBufferString(yamlInput)))
+
+	var cfg dtias.Config
+	require.NoError(t, v.UnmarshalKey("dtias", &cfg))
+
+	assert.Equal(t, "https://dtias.example.com/api/v1", cfg.Endpoint)
+	assert.Equal(t, "test-api-key", cfg.APIKey)
+	assert.Equal(t, "/etc/certs/dtias/client.crt", cfg.ClientCert)
+	assert.Equal(t, "/etc/certs/dtias/client.key", cfg.ClientKey)
+	assert.Equal(t, "/etc/certs/dtias/ca.crt", cfg.CACert)
+	assert.Equal(t, 45*time.Second, cfg.Timeout)
+	assert.Equal(t, "ocloud-dtias-1", cfg.OCloudID)
+	assert.Equal(t, "ocloud-dtias-edge-1", cfg.DeploymentManagerID)
+	assert.Equal(t, "dc-dallas-1", cfg.Datacenter)
+	assert.Equal(t, 5, cfg.RetryAttempts)
+	assert.Equal(t, 3*time.Second, cfg.RetryDelay)
+
+	// Belt-and-suspenders: every exported field on Config must carry a
+	// non-empty `mapstructure` tag so Viper decoding stays deterministic.
+	rt := reflect.TypeOf(dtias.Config{})
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		tag := f.Tag.Get("mapstructure")
+		require.NotEmpty(t, tag,
+			"Config.%s must declare a mapstructure tag", f.Name)
+		require.False(t, strings.HasPrefix(tag, "yaml"),
+			"Config.%s must not use a yaml tag (found %q)", f.Name, tag)
+	}
+}

--- a/internal/cli/cmd/keycloak.go
+++ b/internal/cli/cmd/keycloak.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/cli/service"
+)
+
+// Default Keycloak connection parameters used by CLI commands that manage
+// users, roles, and tenants. These mirror the bootstrap values produced by
+// the platform setup flow.
+const (
+	DefaultKeycloakRealm         = "netweave"
+	DefaultKeycloakAdminUser     = "admin"
+	DefaultKeycloakAdminPassword = "admin"
+)
+
+// ConnectKeycloakDefaults establishes a Keycloak connection using the default
+// realm and bootstrap admin credentials. It uses the global kubeconfig and
+// namespace flags registered on the root command.
+//
+// Callers must invoke Close on the returned connection when finished.
+func ConnectKeycloakDefaults(ctx context.Context) (*service.KeycloakConnection, error) {
+	kc, err := service.ConnectKeycloak(
+		ctx,
+		Global.Kubeconfig,
+		Global.Namespace,
+		DefaultKeycloakRealm,
+		DefaultKeycloakAdminUser,
+		DefaultKeycloakAdminPassword,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to keycloak: %w", err)
+	}
+	return kc, nil
+}

--- a/internal/cli/cmd/roles/roles.go
+++ b/internal/cli/cmd/roles/roles.go
@@ -2,7 +2,6 @@
 package roles
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -11,13 +10,6 @@ import (
 	"github.com/piwi3910/netweave/internal/auth"
 	"github.com/piwi3910/netweave/internal/cli/cmd"
 	"github.com/piwi3910/netweave/internal/cli/output"
-	"github.com/piwi3910/netweave/internal/cli/service"
-)
-
-const (
-	defaultRealm         = "netweave"
-	defaultAdminUser     = "admin"
-	defaultAdminPassword = "admin"
 )
 
 // NewRolesCmd creates the parent "roles" command.
@@ -37,21 +29,6 @@ func NewRolesCmd() *cobra.Command {
 	return parent
 }
 
-func connectKeycloak(ctx context.Context) (*service.KeycloakConnection, error) {
-	kc, err := service.ConnectKeycloak(
-		ctx,
-		cmd.Global.Kubeconfig,
-		cmd.Global.Namespace,
-		defaultRealm,
-		defaultAdminUser,
-		defaultAdminPassword,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to keycloak: %w", err)
-	}
-	return kc, nil
-}
-
 func newListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
@@ -59,7 +36,7 @@ func newListCmd() *cobra.Command {
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}
@@ -98,7 +75,7 @@ func newGetCmd() *cobra.Command {
 				return fmt.Errorf("--name flag is required")
 			}
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}
@@ -151,7 +128,7 @@ func newCreateCmd() *cobra.Command {
 				return fmt.Errorf("--type must be 'platform' or 'tenant'")
 			}
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}
@@ -203,7 +180,7 @@ func newUpdateCmd() *cobra.Command {
 				return fmt.Errorf("--name flag is required")
 			}
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}
@@ -253,7 +230,7 @@ func newDeleteCmd() *cobra.Command {
 				return fmt.Errorf("--name flag is required")
 			}
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/cmd/tenants/tenants.go
+++ b/internal/cli/cmd/tenants/tenants.go
@@ -2,7 +2,6 @@
 package tenants
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -10,13 +9,6 @@ import (
 	"github.com/piwi3910/netweave/internal/auth"
 	"github.com/piwi3910/netweave/internal/cli/cmd"
 	"github.com/piwi3910/netweave/internal/cli/output"
-	"github.com/piwi3910/netweave/internal/cli/service"
-)
-
-const (
-	defaultRealm         = "netweave"
-	defaultAdminUser     = "admin"
-	defaultAdminPassword = "admin"
 )
 
 // NewTenantsCmd creates the parent "tenants" command.
@@ -36,21 +28,6 @@ func NewTenantsCmd() *cobra.Command {
 	return parent
 }
 
-func connectKeycloak(ctx context.Context) (*service.KeycloakConnection, error) {
-	kc, err := service.ConnectKeycloak(
-		ctx,
-		cmd.Global.Kubeconfig,
-		cmd.Global.Namespace,
-		defaultRealm,
-		defaultAdminUser,
-		defaultAdminPassword,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to keycloak: %w", err)
-	}
-	return kc, nil
-}
-
 func newListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
@@ -58,7 +35,7 @@ func newListCmd() *cobra.Command {
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}
@@ -96,7 +73,7 @@ func newGetCmd() *cobra.Command {
 				return fmt.Errorf("--id flag is required")
 			}
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}
@@ -151,7 +128,7 @@ func newCreateCmd() *cobra.Command {
 				return fmt.Errorf("--id and --name flags are required")
 			}
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}
@@ -212,7 +189,7 @@ func newUpdateCmd() *cobra.Command {
 				return fmt.Errorf("--id flag is required")
 			}
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}
@@ -270,7 +247,7 @@ func newDeleteCmd() *cobra.Command {
 				return fmt.Errorf("--id flag is required")
 			}
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/cmd/users/users.go
+++ b/internal/cli/cmd/users/users.go
@@ -2,7 +2,6 @@
 package users
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -11,13 +10,6 @@ import (
 	"github.com/piwi3910/netweave/internal/auth"
 	"github.com/piwi3910/netweave/internal/cli/cmd"
 	"github.com/piwi3910/netweave/internal/cli/output"
-	"github.com/piwi3910/netweave/internal/cli/service"
-)
-
-const (
-	defaultRealm         = "netweave"
-	defaultAdminUser     = "admin"
-	defaultAdminPassword = "admin"
 )
 
 // NewUsersCmd creates the parent "users" command.
@@ -37,21 +29,6 @@ func NewUsersCmd() *cobra.Command {
 	return parent
 }
 
-func connectKeycloak(ctx context.Context) (*service.KeycloakConnection, error) {
-	kc, err := service.ConnectKeycloak(
-		ctx,
-		cmd.Global.Kubeconfig,
-		cmd.Global.Namespace,
-		defaultRealm,
-		defaultAdminUser,
-		defaultAdminPassword,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to keycloak: %w", err)
-	}
-	return kc, nil
-}
-
 func newListCmd() *cobra.Command {
 	var tenantID string
 
@@ -61,7 +38,7 @@ func newListCmd() *cobra.Command {
 		RunE: func(c *cobra.Command, _ []string) error {
 			ctx := c.Context()
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}
@@ -109,7 +86,7 @@ func newGetCmd() *cobra.Command {
 				return fmt.Errorf("--id flag is required")
 			}
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}
@@ -157,7 +134,7 @@ func newCreateCmd() *cobra.Command {
 				)
 			}
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}
@@ -213,7 +190,7 @@ func newUpdateCmd() *cobra.Command {
 				return fmt.Errorf("--id flag is required")
 			}
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}
@@ -267,7 +244,7 @@ func newDeleteCmd() *cobra.Command {
 				return fmt.Errorf("--id flag is required")
 			}
 
-			kc, err := connectKeycloak(ctx)
+			kc, err := cmd.ConnectKeycloakDefaults(ctx)
 			if err != nil {
 				return err
 			}

--- a/internal/smo/adapters/osm/config_test.go
+++ b/internal/smo/adapters/osm/config_test.go
@@ -1,0 +1,72 @@
+package osm_test
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/smo/adapters/osm"
+)
+
+// TestConfig_ViperUnmarshal verifies that every field on Config has a working
+// `mapstructure` tag, by loading a YAML document through Viper (which only
+// respects `mapstructure`, not `yaml` tags) and asserting every exported field
+// is populated. This guards against accidental regressions to `yaml:"..."`
+// tags that would silently depend on field-name fallbacks.
+func TestConfig_ViperUnmarshal(t *testing.T) {
+	yamlInput := `
+osm:
+  nbiUrl: https://osm.example.com:9999
+  username: osm-admin
+  password: s3cret
+  project: netweave
+  requestTimeout: 45s
+  inventorySyncInterval: 10m
+  lcmPollingInterval: 15s
+  maxRetries: 5
+  retryDelay: 2s
+  retryMaxDelay: 60s
+  retryMultiplier: 3.5
+  enableInventorySync: true
+  enableEventPublish: true
+`
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(bytes.NewBufferString(yamlInput)))
+
+	var cfg osm.Config
+	require.NoError(t, v.UnmarshalKey("osm", &cfg))
+
+	assert.Equal(t, "https://osm.example.com:9999", cfg.NBIURL)
+	assert.Equal(t, "osm-admin", cfg.Username)
+	assert.Equal(t, "s3cret", cfg.Password)
+	assert.Equal(t, "netweave", cfg.Project)
+	assert.Equal(t, 45*time.Second, cfg.RequestTimeout)
+	assert.Equal(t, 10*time.Minute, cfg.InventorySyncInterval)
+	assert.Equal(t, 15*time.Second, cfg.LCMPollingInterval)
+	assert.Equal(t, 5, cfg.MaxRetries)
+	assert.Equal(t, 2*time.Second, cfg.RetryDelay)
+	assert.Equal(t, 60*time.Second, cfg.RetryMaxDelay)
+	assert.InDelta(t, 3.5, cfg.RetryMultiplier, 0.0001)
+	assert.True(t, cfg.EnableInventorySync)
+	assert.True(t, cfg.EnableEventPublish)
+
+	// Belt-and-suspenders: every exported field on Config must carry a
+	// non-empty `mapstructure` tag so Viper decoding stays deterministic.
+	rt := reflect.TypeOf(osm.Config{})
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		tag := f.Tag.Get("mapstructure")
+		require.NotEmpty(t, tag,
+			"Config.%s must declare a mapstructure tag", f.Name)
+		require.False(t, strings.HasPrefix(tag, "yaml"),
+			"Config.%s must not use a yaml tag (found %q)", f.Name, tag)
+	}
+}

--- a/internal/smo/adapters/osm/plugin.go
+++ b/internal/smo/adapters/osm/plugin.go
@@ -42,27 +42,30 @@ type Plugin struct {
 }
 
 // Config holds the configuration for the OSM plugin.
+// Tags use `mapstructure` so Viper's UnmarshalKey can decode YAML/JSON/env
+// sources consistently — see internal/smo/adapters/onap/plugin.go for the
+// reference convention.
 type Config struct {
 	// OSM NBI (Northbound Interface) configuration
-	NBIURL   string `yaml:"nbiUrl"`   // OSM NBI API endpoint (e.g., https://osm.example.com:9999)
-	Username string `yaml:"username"` // OSM username
-	Password string `yaml:"password"` // OSM password
-	Project  string `yaml:"project"`  // OSM project/tenant (default: "admin")
+	NBIURL   string `mapstructure:"nbiUrl"`   // OSM NBI API endpoint (e.g., https://osm.example.com:9999)
+	Username string `mapstructure:"username"` // OSM username
+	Password string `mapstructure:"password"` // OSM password
+	Project  string `mapstructure:"project"`  // OSM project/tenant (default: "admin")
 
 	// Timeouts and intervals
-	RequestTimeout        time.Duration `yaml:"requestTimeout"`        // HTTP request timeout (default: 30s)
-	InventorySyncInterval time.Duration `yaml:"inventorySyncInterval"` // Inventory sync interval (default: 5m)
-	LCMPollingInterval    time.Duration `yaml:"lcmPollingInterval"`    // LCM operation polling interval (default: 10s)
+	RequestTimeout        time.Duration `mapstructure:"requestTimeout"`        // HTTP request timeout (default: 30s)
+	InventorySyncInterval time.Duration `mapstructure:"inventorySyncInterval"` // Inventory sync interval (default: 5m)
+	LCMPollingInterval    time.Duration `mapstructure:"lcmPollingInterval"`    // LCM polling interval (default: 10s)
 
 	// Retry configuration
-	MaxRetries      int           `yaml:"maxRetries"`      // Maximum number of retries (default: 3)
-	RetryDelay      time.Duration `yaml:"retryDelay"`      // Initial retry delay (default: 1s)
-	RetryMaxDelay   time.Duration `yaml:"retryMaxDelay"`   // Maximum retry delay (default: 30s)
-	RetryMultiplier float64       `yaml:"retryMultiplier"` // Retry delay multiplier (default: 2.0)
+	MaxRetries      int           `mapstructure:"maxRetries"`      // Maximum number of retries (default: 3)
+	RetryDelay      time.Duration `mapstructure:"retryDelay"`      // Initial retry delay (default: 1s)
+	RetryMaxDelay   time.Duration `mapstructure:"retryMaxDelay"`   // Maximum retry delay (default: 30s)
+	RetryMultiplier float64       `mapstructure:"retryMultiplier"` // Retry delay multiplier (default: 2.0)
 
 	// Feature flags
-	EnableInventorySync bool `yaml:"enableInventorySync"` // Enable automatic inventory sync (default: true)
-	EnableEventPublish  bool `yaml:"enableEventPublish"`  // Enable event publishing to OSM (default: true)
+	EnableInventorySync bool `mapstructure:"enableInventorySync"` // Enable automatic inventory sync (default: true)
+	EnableEventPublish  bool `mapstructure:"enableEventPublish"`  // Enable event publishing to OSM (default: true)
 }
 
 // DefaultConfig returns a Config with sensible defaults.


### PR DESCRIPTION
## Summary

- **M14 (#524)**: Extract `connectKeycloak` duplicated across `internal/cli/cmd/{users,roles,tenants}` into `internal/cli/cmd/keycloak.go`; shared constants + single entry point.
- **M16 (#526)**: Add `mapstructure` tags to DTIAS adapter and OSM plugin `Config` structs (Viper only respects `mapstructure`), plus regression tests round-tripping YAML through Viper.

## Test plan

- [x] `go build ./...` clean
- [x] New `config_test.go` for DTIAS + OSM verifies every tagged field populates from Viper
- [ ] CI green

Resolves #524, #526