### PR TITLE
[Security] Harden webhook delivery paths (SSRF + TLS floor + shared client)

### DIFF
--- a/internal/events/notifier.go
+++ b/internal/events/notifier.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
@@ -20,6 +18,7 @@ import (
 
 	"github.com/piwi3910/netweave/internal/models"
 	"github.com/piwi3910/netweave/internal/storage"
+	"github.com/piwi3910/netweave/internal/webhook"
 )
 
 const (
@@ -68,6 +67,11 @@ type NotifierConfig struct {
 
 	// InsecureSkipVerify disables certificate verification (for testing only)
 	InsecureSkipVerify bool
+
+	// AllowPrivateNetworks disables the outbound SSRF IP guard. Intended
+	// strictly for unit/integration tests that drive httptest.NewServer on
+	// loopback. Production callers MUST leave this false.
+	AllowPrivateNetworks bool
 }
 
 // DefaultNotifierConfig returns a NotifierConfig with sensible defaults.
@@ -135,53 +139,27 @@ func NewWebhookNotifier(
 }
 
 // createHTTPClient creates an HTTP client with optional mTLS configuration.
-// WARNING: InsecureSkipVerify disables certificate validation and should only be used in development/testing.
-// Production deployments must use proper certificate validation (InsecureSkipVerify=false).
-// This security control prevents man-in-the-middle attacks by ensuring webhook endpoints present valid certificates.
+// It delegates to the shared webhook.NewHTTPClient constructor so that the
+// TLS floor, idle-connection pool, and SSRF-safe dialer stay aligned with
+// workers.WebhookWorker.
+//
+// WARNING: InsecureSkipVerify disables certificate validation and should only
+// be used in development/testing. Production deployments must use proper
+// certificate validation (InsecureSkipVerify=false).
 func createHTTPClient(config *NotifierConfig) (*http.Client, error) {
-	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS13,
-	}
-
-	// Only skip verification if explicitly configured (for development/testing only)
-	// Production deployments must validate certificates
-	if config.InsecureSkipVerify {
-		tlsConfig.InsecureSkipVerify = true
-	}
-
-	// Load client certificate for mTLS
-	if config.EnableMTLS && config.ClientCertFile != "" && config.ClientKeyFile != "" {
-		cert, err := tls.LoadX509KeyPair(config.ClientCertFile, config.ClientKeyFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load client certificate: %w", err)
-		}
-		tlsConfig.Certificates = []tls.Certificate{cert}
-	}
-
-	// Load CA certificate
-	if config.CACertFile != "" {
-		caCert, err := os.ReadFile(config.CACertFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
-		}
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(caCert) {
-			return nil, errors.New("failed to parse CA certificate")
-		}
-		tlsConfig.RootCAs = caCertPool
-	}
-
-	transport := &http.Transport{
-		TLSClientConfig:     tlsConfig,
-		MaxIdleConns:        100,
-		MaxIdleConnsPerHost: 10,
-		IdleConnTimeout:     90 * time.Second,
-	}
-
-	return &http.Client{
-		Transport: transport,
-		Timeout:   config.HTTPTimeout,
-	}, nil
+	return webhook.NewHTTPClient(&webhook.ClientConfig{
+		Timeout: config.HTTPTimeout,
+		// Retain TLS 1.3 as the floor for this caller — stricter than the
+		// shared default of TLS 1.2 — because the notifier path is the
+		// preferred delivery route and has no interoperability concerns.
+		MinTLSVersion:        tls.VersionTLS13,
+		InsecureSkipVerify:   config.InsecureSkipVerify,
+		EnableMTLS:           config.EnableMTLS,
+		ClientCertFile:       config.ClientCertFile,
+		ClientKeyFile:        config.ClientKeyFile,
+		CACertFile:           config.CACertFile,
+		AllowPrivateNetworks: config.AllowPrivateNetworks,
+	})
 }
 
 // Notify sends a notification to a subscriber's callback URL.

--- a/internal/events/notifier_additional_test.go
+++ b/internal/events/notifier_additional_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestNewWebhookNotifier_NilLogger(t *testing.T) {
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	tracker := &mockDeliveryTracker{}
 
 	_, err := events.NewWebhookNotifier(cfg, tracker, nil)
@@ -28,7 +28,7 @@ func TestNewWebhookNotifier_NilLogger(t *testing.T) {
 
 func TestNewWebhookNotifier_InsecureSkipVerify(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	cfg.InsecureSkipVerify = true
 	tracker := &mockDeliveryTracker{}
 
@@ -71,7 +71,7 @@ func TestNewWebhookNotifier_InvalidMTLSCerts(t *testing.T) {
 
 func TestWebhookNotifier_Notify_NilInputs(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	tracker := &mockDeliveryTracker{}
 
 	notifier, err := events.NewWebhookNotifier(cfg, tracker, logger)
@@ -96,7 +96,7 @@ func TestWebhookNotifier_Notify_NilInputs(t *testing.T) {
 
 func TestWebhookNotifier_NotifyWithRetry_NilInputs(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	tracker := &mockDeliveryTracker{}
 
 	notifier, err := events.NewWebhookNotifier(cfg, tracker, logger)
@@ -122,9 +122,10 @@ func TestWebhookNotifier_NotifyWithRetry_NilInputs(t *testing.T) {
 func TestWebhookNotifier_NotifyWithRetry_AllRetriesFail(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	cfg := &events.NotifierConfig{
-		HTTPTimeout:        2 * time.Second,
-		MaxRetries:         2,
-		InsecureSkipVerify: true,
+		HTTPTimeout:          2 * time.Second,
+		MaxRetries:           2,
+		InsecureSkipVerify:   true,
+		AllowPrivateNetworks: true,
 	}
 	tracker := &mockDeliveryTracker{}
 
@@ -164,9 +165,10 @@ func TestWebhookNotifier_NotifyWithRetry_AllRetriesFail(t *testing.T) {
 func TestWebhookNotifier_NotifyWithRetry_ContextCanceled(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	cfg := &events.NotifierConfig{
-		HTTPTimeout:        2 * time.Second,
-		MaxRetries:         3,
-		InsecureSkipVerify: true,
+		HTTPTimeout:          2 * time.Second,
+		MaxRetries:           3,
+		InsecureSkipVerify:   true,
+		AllowPrivateNetworks: true,
 	}
 	tracker := &mockDeliveryTracker{}
 
@@ -205,9 +207,10 @@ func TestWebhookNotifier_NotifyWithRetry_ContextCanceled(t *testing.T) {
 func TestWebhookNotifier_NotifyWithRetry_NilTracker(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	cfg := &events.NotifierConfig{
-		HTTPTimeout:        2 * time.Second,
-		MaxRetries:         1,
-		InsecureSkipVerify: true,
+		HTTPTimeout:          2 * time.Second,
+		MaxRetries:           1,
+		InsecureSkipVerify:   true,
+		AllowPrivateNetworks: true,
 	}
 
 	// Create notifier without a delivery tracker (nil tracker)
@@ -239,7 +242,7 @@ func TestWebhookNotifier_NotifyWithRetry_NilTracker(t *testing.T) {
 
 func TestWebhookNotifier_Notify_InvalidURL(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	cfg.InsecureSkipVerify = true
 	tracker := &mockDeliveryTracker{}
 
@@ -265,9 +268,10 @@ func TestWebhookNotifier_Notify_InvalidURL(t *testing.T) {
 func TestWebhookNotifier_GetCircuitBreaker_Reuse(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	cfg := &events.NotifierConfig{
-		HTTPTimeout:        2 * time.Second,
-		MaxRetries:         2,
-		InsecureSkipVerify: true,
+		HTTPTimeout:          2 * time.Second,
+		MaxRetries:           2,
+		InsecureSkipVerify:   true,
+		AllowPrivateNetworks: true,
 	}
 	tracker := &mockDeliveryTracker{}
 
@@ -345,9 +349,10 @@ func (t *trackingDeliveryTracker) ListFailed(_ context.Context) ([]*events.Notif
 func TestWebhookNotifier_NotifyWithRetry_TrackerError(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	cfg := &events.NotifierConfig{
-		HTTPTimeout:        2 * time.Second,
-		MaxRetries:         1,
-		InsecureSkipVerify: true,
+		HTTPTimeout:          2 * time.Second,
+		MaxRetries:           1,
+		InsecureSkipVerify:   true,
+		AllowPrivateNetworks: true,
 	}
 
 	tracker := &trackingDeliveryTracker{
@@ -383,7 +388,7 @@ func TestWebhookNotifier_NotifyWithRetry_TrackerError(t *testing.T) {
 
 func TestWebhookNotifier_Notify_NonSuccessStatus(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	cfg.InsecureSkipVerify = true
 
 	tests := []struct {

--- a/internal/events/notifier_cb_test.go
+++ b/internal/events/notifier_cb_test.go
@@ -23,7 +23,7 @@ import (
 // simultaneously (run with go test -race).
 func TestWebhookNotifier_CircuitBreaker_ConcurrentAccess(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	cfg.HTTPTimeout = 100 * time.Millisecond
 	tracker := &mockDeliveryTracker{}
 
@@ -71,7 +71,7 @@ func TestWebhookNotifier_CircuitBreaker_ConcurrentAccess(t *testing.T) {
 // without issues, indirectly testing that eviction works when the limit is exceeded.
 func TestWebhookNotifier_ManyCircuitBreakers(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	cfg.HTTPTimeout = 100 * time.Millisecond
 	tracker := &mockDeliveryTracker{}
 
@@ -111,7 +111,7 @@ func TestWebhookNotifier_ManyCircuitBreakers(t *testing.T) {
 // callback URL reuse the same circuit breaker instance.
 func TestWebhookNotifier_CircuitBreaker_ReusesSameBreaker(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	cfg.HTTPTimeout = 100 * time.Millisecond
 	tracker := &mockDeliveryTracker{}
 
@@ -157,7 +157,7 @@ func TestWebhookNotifier_CircuitBreaker_ReusesSameBreaker(t *testing.T) {
 // callback URLs get their own circuit breaker instances.
 func TestWebhookNotifier_CircuitBreaker_DifferentURLsGetDifferentBreakers(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	cfg.HTTPTimeout = 100 * time.Millisecond
 	tracker := &mockDeliveryTracker{}
 
@@ -223,7 +223,7 @@ func TestWebhookNotifier_CircuitBreaker_DifferentURLsGetDifferentBreakers(t *tes
 // cleanup goroutine that prunes stale circuit breakers.
 func TestWebhookNotifier_Close_StopsCleanupGoroutine(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	cfg.HTTPTimeout = 100 * time.Millisecond
 	tracker := &mockDeliveryTracker{}
 
@@ -247,7 +247,7 @@ func TestWebhookNotifier_Close_StopsCleanupGoroutine(t *testing.T) {
 // updates its last-used timestamp by making notifications and verifying they succeed.
 func TestWebhookNotifier_CircuitBreaker_LastUsedTracking(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	cfg.HTTPTimeout = 100 * time.Millisecond
 	tracker := &mockDeliveryTracker{}
 

--- a/internal/events/notifier_test.go
+++ b/internal/events/notifier_test.go
@@ -54,7 +54,7 @@ func TestDefaultNotifierConfig(t *testing.T) {
 // Testevents.NewWebhookNotifier tests notifier creation.
 func TestNewWebhookNotifier(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	tracker := &mockDeliveryTracker{}
 
 	t.Run("creates notifier successfully", func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestNewWebhookNotifier(t *testing.T) {
 // TestWebhookNotifier_Notify tests the Notify function.
 func TestWebhookNotifier_Notify(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	cfg.HTTPTimeout = 2 * time.Second
 	tracker := &mockDeliveryTracker{}
 
@@ -136,7 +136,7 @@ func TestWebhookNotifier_Notify(t *testing.T) {
 		}))
 		defer server.Close()
 
-		timeoutCfg := events.DefaultNotifierConfig()
+		timeoutCfg := testNotifierConfig()
 		timeoutCfg.HTTPTimeout = 100 * time.Millisecond
 
 		notifier, err := events.NewWebhookNotifier(timeoutCfg, tracker, logger)
@@ -162,7 +162,7 @@ func TestWebhookNotifier_Notify(t *testing.T) {
 // TestWebhookNotifier_NotifyWithRetry tests the NotifyWithRetry function.
 func TestWebhookNotifier_NotifyWithRetry(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	cfg.HTTPTimeout = 2 * time.Second
 	cfg.MaxRetries = 2
 	tracker := &mockDeliveryTracker{}
@@ -228,7 +228,7 @@ func TestWebhookNotifier_NotifyWithRetry(t *testing.T) {
 // TestWebhookNotifier_Close tests the Close function.
 func TestWebhookNotifier_Close(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cfg := events.DefaultNotifierConfig()
+	cfg := testNotifierConfig()
 	tracker := &mockDeliveryTracker{}
 
 	notifier, err := events.NewWebhookNotifier(cfg, tracker, logger)

--- a/internal/events/testhelper_test.go
+++ b/internal/events/testhelper_test.go
@@ -1,0 +1,14 @@
+package events_test
+
+import "github.com/piwi3910/netweave/internal/events"
+
+// testNotifierConfig returns a NotifierConfig suitable for unit tests that
+// dial httptest.NewServer on loopback. It mirrors events.DefaultNotifierConfig
+// but disables the SSRF IP guard so 127.0.0.1 targets are reachable.
+//
+// Production code MUST continue to use events.DefaultNotifierConfig.
+func testNotifierConfig() *events.NotifierConfig {
+	cfg := events.DefaultNotifierConfig()
+	cfg.AllowPrivateNetworks = true
+	return cfg
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -2427,22 +2427,19 @@ func (s *Server) handleUpdateTenantQuotas(c *gin.Context) {
 	})
 }
 
-// ValidateCallback validates a subscription callback URL.
-// It performs early validation to provide fast failure before calling the adapter.
-// Includes SSRF protection to prevent callbacks to localhost and private IP ranges.
+// ValidateCallback validates a subscription callback URL at registration time.
+// It performs early validation to provide fast failure before calling the
+// adapter. Includes SSRF protection to prevent callbacks to localhost and
+// private IP ranges.
 //
-// SECURITY NOTE: DNS Rebinding Time-of-Check-Time-of-Use (TOCTOU) Vulnerability
-// This validation only checks the callback URL at registration time. An attacker could:
-// 1. Register a callback URL pointing to a legitimate public server
-// 2. Pass this validation
-// 3. Change DNS records to point the hostname to localhost/private IPs
-// 4. Receive webhooks at the new (malicious) destination
-//
-// Mitigation strategies for production deployments:
-// - Re-validate callback URLs before EACH webhook delivery attempt
-// - Cache DNS results with short TTL and re-validate on changes
-// - Implement webhook delivery through a dedicated egress proxy that enforces policies
-// - Consider additional authentication mechanisms for webhooks (HMAC signatures, mTLS).
+// Defense-in-depth at delivery time: the DNS-rebinding TOCTOU gap between
+// this check and the actual webhook delivery is closed by the SSRF-safe
+// DialContext installed on the shared HTTP client — see
+// internal/webhook.NewSSRFSafeDialContext. That dialer re-resolves the
+// hostname on every delivery attempt, rejects the connect if any resolved
+// IP falls into the banned set (loopback, private, link-local, cloud
+// metadata), and pins the TCP connect to the allow-listed IP so the OS
+// does not re-resolve between the check and the handshake.
 func (s *Server) ValidateCallback(ctx context.Context, sub *adapter.Subscription) error {
 	if sub == nil {
 		return fmt.Errorf("subscription cannot be nil")

--- a/internal/webhook/httpclient.go
+++ b/internal/webhook/httpclient.go
@@ -1,0 +1,318 @@
+// Package webhook provides shared HTTP client construction and SSRF-safe
+// dialing primitives used by every outbound webhook delivery path
+// (events.WebhookNotifier and workers.WebhookWorker).
+//
+// A single constructor centralizes the security-sensitive transport settings
+// so that TLS floor, idle-connection limits, and DNS-rebinding defenses
+// remain consistent across callers.
+package webhook
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	// DefaultMaxIdleConns is the total idle connection pool size across hosts.
+	DefaultMaxIdleConns = 100
+
+	// DefaultMaxIdleConnsPerHost bounds per-host pooled connections so a single
+	// misbehaving webhook endpoint cannot exhaust file descriptors.
+	DefaultMaxIdleConnsPerHost = 10
+
+	// DefaultIdleConnTimeout is how long idle connections are kept alive.
+	DefaultIdleConnTimeout = 90 * time.Second
+
+	// DefaultDialTimeout caps TCP handshake duration per connection attempt.
+	DefaultDialTimeout = 10 * time.Second
+
+	// DefaultKeepAlive is the keep-alive probe interval for established
+	// connections.
+	DefaultKeepAlive = 30 * time.Second
+)
+
+// IPGuard decides whether a resolved IP is safe to dial. Implementations must
+// be safe for concurrent use.
+type IPGuard func(ip net.IP) bool
+
+// IPResolver resolves a hostname to one or more IP addresses. It is satisfied
+// by *net.Resolver and by test stubs used for DNS-rebinding simulation.
+type IPResolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
+// DefaultIPGuard rejects loopback, link-local, and private (RFC 1918 / ULA)
+// addresses, plus the IPv4/IPv6 cloud metadata service addresses.
+func DefaultIPGuard(ip net.IP) bool {
+	return !IsPrivateOrReservedIP(ip)
+}
+
+// ClientConfig holds options for constructing the shared webhook HTTP client.
+type ClientConfig struct {
+	// Timeout caps the full request lifetime (dial + TLS + body).
+	Timeout time.Duration
+
+	// MinTLSVersion sets the minimum negotiated TLS protocol version.
+	// Defaults to tls.VersionTLS12 when zero.
+	MinTLSVersion uint16
+
+	// InsecureSkipVerify disables certificate validation. ONLY use for tests.
+	InsecureSkipVerify bool
+
+	// EnableMTLS, ClientCertFile, ClientKeyFile configure client-side mTLS.
+	EnableMTLS     bool
+	ClientCertFile string
+	ClientKeyFile  string
+
+	// CACertFile is an optional custom root CA bundle.
+	CACertFile string
+
+	// MaxIdleConns, MaxIdleConnsPerHost, IdleConnTimeout control connection
+	// pooling. Zero values fall back to package defaults.
+	MaxIdleConns        int
+	MaxIdleConnsPerHost int
+	IdleConnTimeout     time.Duration
+
+	// Resolver is used for the delivery-time DNS re-resolution that closes the
+	// DNS-rebinding TOCTOU window. Defaults to net.DefaultResolver.
+	Resolver IPResolver
+
+	// IPGuard decides whether a resolved IP is safe to dial. Defaults to
+	// DefaultIPGuard which rejects loopback, private, link-local, and cloud
+	// metadata addresses.
+	IPGuard IPGuard
+
+	// AllowPrivateNetworks disables the SSRF IP guard entirely. Intended for
+	// unit/integration tests that drive httptest.NewServer on loopback.
+	// Production callers MUST NOT set this field.
+	AllowPrivateNetworks bool
+
+	// DialTimeout bounds the TCP handshake. Zero falls back to
+	// DefaultDialTimeout.
+	DialTimeout time.Duration
+
+	// KeepAlive is the keep-alive probe interval for established connections.
+	// Zero falls back to DefaultKeepAlive.
+	KeepAlive time.Duration
+}
+
+// NewHTTPClient constructs an *http.Client sharing the webhook transport
+// defaults: TLS floor, idle-connection pooling, and a DNS-rebinding-safe
+// DialContext that re-resolves each host at connect time and pins the TCP
+// connect to a resolved, allow-listed IP.
+//
+// A nil cfg is treated as a zero-value config (secure defaults applied).
+func NewHTTPClient(cfg *ClientConfig) (*http.Client, error) {
+	if cfg == nil {
+		cfg = &ClientConfig{}
+	}
+	tlsCfg, err := buildTLSConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	maxIdle := cfg.MaxIdleConns
+	if maxIdle <= 0 {
+		maxIdle = DefaultMaxIdleConns
+	}
+	maxIdlePerHost := cfg.MaxIdleConnsPerHost
+	if maxIdlePerHost <= 0 {
+		maxIdlePerHost = DefaultMaxIdleConnsPerHost
+	}
+	idleTimeout := cfg.IdleConnTimeout
+	if idleTimeout <= 0 {
+		idleTimeout = DefaultIdleConnTimeout
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig:     tlsCfg,
+		MaxIdleConns:        maxIdle,
+		MaxIdleConnsPerHost: maxIdlePerHost,
+		IdleConnTimeout:     idleTimeout,
+		DialContext:         NewSSRFSafeDialContext(cfg),
+	}
+
+	return &http.Client{
+		Transport: transport,
+		Timeout:   cfg.Timeout,
+	}, nil
+}
+
+// buildTLSConfig resolves the TLS settings, applying defaults and loading any
+// mTLS client certificate / custom root bundle.
+func buildTLSConfig(cfg *ClientConfig) (*tls.Config, error) {
+	minVersion := cfg.MinTLSVersion
+	if minVersion == 0 {
+		minVersion = tls.VersionTLS12
+	}
+
+	tlsCfg := &tls.Config{
+		MinVersion: minVersion,
+	}
+	if cfg.InsecureSkipVerify {
+		// Explicitly opt-in path: callers must set this only in tests. The
+		// WebhookNotifier logs a loud warning before reaching this point.
+		tlsCfg.InsecureSkipVerify = true
+	}
+
+	if cfg.EnableMTLS && cfg.ClientCertFile != "" && cfg.ClientKeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.ClientCertFile, cfg.ClientKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	if cfg.CACertFile != "" {
+		caCert, err := os.ReadFile(cfg.CACertFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caCert) {
+			return nil, errors.New("failed to parse CA certificate")
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	return tlsCfg, nil
+}
+
+// NewSSRFSafeDialContext returns a net/http DialContext that closes the
+// DNS-rebinding TOCTOU window:
+//
+//  1. The hostname is re-resolved at connect time using cfg.Resolver.
+//  2. Every returned address is checked against cfg.IPGuard; if ANY resolved
+//     IP is banned, the dial fails immediately. This is strictly more
+//     conservative than "first safe IP wins" and prevents a split DNS answer
+//     from smuggling an internal IP past the guard.
+//  3. The TCP connect is pinned to the resolved IP (no second OS-level
+//     resolution happens between the check and the connect).
+//
+// A nil cfg is treated as a zero-value config (secure defaults applied).
+func NewSSRFSafeDialContext(cfg *ClientConfig) func(context.Context, string, string) (net.Conn, error) {
+	d := resolveDialDefaults(cfg)
+
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid address %q: %w", addr, err)
+		}
+		if literal := net.ParseIP(host); literal != nil {
+			return dialLiteralHost(ctx, d.dialer, d.guard, network, host, port, literal)
+		}
+		return dialResolvedHost(ctx, d.resolver, d.dialer, d.guard, network, host, port)
+	}
+}
+
+// dialDefaults is the resolved set of values NewSSRFSafeDialContext uses to
+// build its closure. Split into a struct to keep the constructor's cognitive
+// complexity low without returning bare interface values from a helper.
+type dialDefaults struct {
+	resolver IPResolver
+	guard    IPGuard
+	dialer   *net.Dialer
+}
+
+// resolveDialDefaults folds the defaulting logic out of NewSSRFSafeDialContext.
+func resolveDialDefaults(cfg *ClientConfig) dialDefaults {
+	if cfg == nil {
+		cfg = &ClientConfig{}
+	}
+	resolver := cfg.Resolver
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	guard := cfg.IPGuard
+	if guard == nil {
+		guard = DefaultIPGuard
+	}
+	if cfg.AllowPrivateNetworks {
+		guard = func(_ net.IP) bool { return true }
+	}
+	dialTimeout := cfg.DialTimeout
+	if dialTimeout <= 0 {
+		dialTimeout = DefaultDialTimeout
+	}
+	keepAlive := cfg.KeepAlive
+	if keepAlive <= 0 {
+		keepAlive = DefaultKeepAlive
+	}
+	return dialDefaults{
+		resolver: resolver,
+		guard:    guard,
+		dialer:   &net.Dialer{Timeout: dialTimeout, KeepAlive: keepAlive},
+	}
+}
+
+// dialLiteralHost validates an IP-literal host against the SSRF guard and
+// dials it, skipping the resolver altogether.
+func dialLiteralHost(
+	ctx context.Context,
+	dialer *net.Dialer,
+	guard IPGuard,
+	network, host, port string,
+	literal net.IP,
+) (net.Conn, error) {
+	if !guard(literal) {
+		return nil, &SSRFBlockedError{Host: host, IP: literal}
+	}
+	conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(literal.String(), port))
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", host, err)
+	}
+	return conn, nil
+}
+
+// dialResolvedHost re-resolves host at connect time, rejects if any resolved
+// IP is banned, and pins the TCP connect to the first allow-listed IP so the
+// OS does not re-resolve between the check and the handshake.
+func dialResolvedHost(
+	ctx context.Context,
+	resolver IPResolver,
+	dialer *net.Dialer,
+	guard IPGuard,
+	network, host, port string,
+) (net.Conn, error) {
+	ips, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("resolve %q: no addresses returned", host)
+	}
+	// Reject if ANY resolved IP is banned, to prevent split-DNS smuggling.
+	for _, ipAddr := range ips {
+		if !guard(ipAddr.IP) {
+			return nil, &SSRFBlockedError{Host: host, IP: ipAddr.IP}
+		}
+	}
+	pinned := net.JoinHostPort(ips[0].IP.String(), port)
+	conn, err := dialer.DialContext(ctx, network, pinned)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s (pinned %s): %w", host, pinned, err)
+	}
+	return conn, nil
+}
+
+// SSRFBlockedError is returned when the DialContext refuses to connect to an
+// IP rejected by the configured IPGuard.
+type SSRFBlockedError struct {
+	Host string
+	IP   net.IP
+}
+
+// Error implements the error interface.
+func (e *SSRFBlockedError) Error() string {
+	return fmt.Sprintf(
+		"webhook: refusing to connect to host %q: resolved IP %s is blocked by SSRF policy",
+		e.Host, e.IP.String(),
+	)
+}

--- a/internal/webhook/httpclient_test.go
+++ b/internal/webhook/httpclient_test.go
@@ -1,0 +1,344 @@
+package webhook_test
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/webhook"
+)
+
+// TestNewHTTPClient_TLSMinVersionDefault asserts that the shared constructor
+// applies a TLS 1.2 floor when the caller does not override it. This is the
+// guarantee required by the workers.WebhookWorker path (#478).
+func TestNewHTTPClient_TLSMinVersionDefault(t *testing.T) {
+	client, err := webhook.NewHTTPClient(&webhook.ClientConfig{
+		Timeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok, "transport must be *http.Transport")
+	require.NotNil(t, transport.TLSClientConfig, "TLS config must be set")
+	assert.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion,
+		"default MinVersion must be TLS 1.2 to prevent downgrade attacks")
+}
+
+// TestNewHTTPClient_TLSMinVersionExplicit asserts that callers may raise the
+// floor above the default (e.g. the notifier path, which uses TLS 1.3).
+func TestNewHTTPClient_TLSMinVersionExplicit(t *testing.T) {
+	client, err := webhook.NewHTTPClient(&webhook.ClientConfig{
+		Timeout:       5 * time.Second,
+		MinTLSVersion: tls.VersionTLS13,
+	})
+	require.NoError(t, err)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.Equal(t, uint16(tls.VersionTLS13), transport.TLSClientConfig.MinVersion)
+}
+
+// TestNewHTTPClient_IdleConnDefaults asserts that the shared constructor
+// installs the bounded idle-connection pool required by #519 so a single
+// misbehaving webhook endpoint cannot exhaust file descriptors.
+func TestNewHTTPClient_IdleConnDefaults(t *testing.T) {
+	client, err := webhook.NewHTTPClient(&webhook.ClientConfig{
+		Timeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.Equal(t, webhook.DefaultMaxIdleConns, transport.MaxIdleConns)
+	assert.Equal(t, webhook.DefaultMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+	assert.Equal(t, webhook.DefaultIdleConnTimeout, transport.IdleConnTimeout)
+}
+
+// TestNewHTTPClient_IdleConnOverrides asserts that callers may override the
+// defaults.
+func TestNewHTTPClient_IdleConnOverrides(t *testing.T) {
+	client, err := webhook.NewHTTPClient(&webhook.ClientConfig{
+		Timeout:             5 * time.Second,
+		MaxIdleConns:        42,
+		MaxIdleConnsPerHost: 7,
+		IdleConnTimeout:     11 * time.Second,
+	})
+	require.NoError(t, err)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.Equal(t, 42, transport.MaxIdleConns)
+	assert.Equal(t, 7, transport.MaxIdleConnsPerHost)
+	assert.Equal(t, 11*time.Second, transport.IdleConnTimeout)
+}
+
+// TestNewHTTPClient_DialContextInstalled asserts that a DialContext is wired,
+// which is required for the SSRF-safe delivery-time validation (#476).
+func TestNewHTTPClient_DialContextInstalled(t *testing.T) {
+	client, err := webhook.NewHTTPClient(&webhook.ClientConfig{
+		Timeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.NotNil(t, transport.DialContext, "SSRF-safe DialContext must be installed")
+}
+
+// TestSSRFSafeDialContext_BlocksMetadataIPLiteral simulates the DNS-rebinding
+// attack at the delivery step: even if registration-time validation passed,
+// at connect time the host resolves to 169.254.169.254 (cloud metadata) and
+// the dialer MUST refuse.
+//
+// We drive the behavior deterministically by passing the metadata IP as the
+// dialed address (the same code path a rebind lookup would exercise).
+func TestSSRFSafeDialContext_BlocksMetadataIPLiteral(t *testing.T) {
+	dial := webhook.NewSSRFSafeDialContext(&webhook.ClientConfig{
+		Timeout:     time.Second,
+		DialTimeout: 500 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, err := dial(ctx, "tcp", "169.254.169.254:80")
+	require.Error(t, err, "metadata service IP must be blocked at dial time")
+	require.Nil(t, conn)
+
+	var blocked *webhook.SSRFBlockedError
+	require.True(t, errors.As(err, &blocked), "must return SSRFBlockedError, got %v", err)
+	assert.Equal(t, "169.254.169.254", blocked.Host)
+	assert.True(t, blocked.IP.Equal(net.ParseIP("169.254.169.254")))
+}
+
+// TestSSRFSafeDialContext_BlocksLoopbackLiteral covers 127.0.0.1 / ::1.
+func TestSSRFSafeDialContext_BlocksLoopbackLiteral(t *testing.T) {
+	dial := webhook.NewSSRFSafeDialContext(&webhook.ClientConfig{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := dial(ctx, "tcp", "127.0.0.1:8080")
+	require.Error(t, err)
+	var blocked *webhook.SSRFBlockedError
+	assert.True(t, errors.As(err, &blocked), "loopback must be blocked, got %v", err)
+
+	_, err = dial(ctx, "tcp", "[::1]:8080")
+	require.Error(t, err)
+	assert.True(t, errors.As(err, &blocked), "IPv6 loopback must be blocked, got %v", err)
+}
+
+// TestSSRFSafeDialContext_BlocksPrivateIPLiteral covers 10.x/172.16.x/192.168.x.
+func TestSSRFSafeDialContext_BlocksPrivateIPLiteral(t *testing.T) {
+	dial := webhook.NewSSRFSafeDialContext(&webhook.ClientConfig{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	for _, ip := range []string{"10.0.0.1", "172.16.5.7", "192.168.1.1"} {
+		_, err := dial(ctx, "tcp", ip+":80")
+		require.Error(t, err, "private IP %s must be blocked", ip)
+		var blocked *webhook.SSRFBlockedError
+		assert.True(t, errors.As(err, &blocked), "private IP %s should return SSRFBlockedError", ip)
+	}
+}
+
+// rebindingResolver simulates a DNS-rebinding attack: at t0 (registration)
+// the host resolved to a public IP, but at t1 (delivery) it "rebinds" to a
+// banned target such as the cloud metadata service. The dialer MUST refuse.
+type rebindingResolver struct {
+	ips []net.IPAddr
+	err error
+}
+
+func (r *rebindingResolver) LookupIPAddr(_ context.Context, _ string) ([]net.IPAddr, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.ips, nil
+}
+
+// TestSSRFSafeDialContext_RebindingViaResolver reproduces the #476 exploit:
+// even if ValidateCallback accepted the hostname at registration time, a
+// fresh lookup at delivery time must catch the rebound IP. We inject a
+// resolver that returns 169.254.169.254 (AWS IMDS) and assert SSRFBlockedError.
+func TestSSRFSafeDialContext_RebindingViaResolver(t *testing.T) {
+	dial := webhook.NewSSRFSafeDialContext(&webhook.ClientConfig{
+		Resolver: &rebindingResolver{
+			ips: []net.IPAddr{{IP: net.ParseIP("169.254.169.254")}},
+		},
+	})
+
+	_, err := dial(context.Background(), "tcp", "dns-rebind.attacker.example.com:443")
+	require.Error(t, err, "rebinding target must be rejected at delivery time")
+
+	var blocked *webhook.SSRFBlockedError
+	require.True(t, errors.As(err, &blocked),
+		"DNS-rebind to metadata IP must produce SSRFBlockedError, got %v", err)
+	assert.True(t, blocked.IP.Equal(net.ParseIP("169.254.169.254")))
+}
+
+// TestSSRFSafeDialContext_RebindingSplitAnswer covers the split-DNS variant:
+// the attacker's resolver returns [public, metadata] so a naive "first IP"
+// check would pass. The safe dialer must still refuse.
+func TestSSRFSafeDialContext_RebindingSplitAnswer(t *testing.T) {
+	dial := webhook.NewSSRFSafeDialContext(&webhook.ClientConfig{
+		Resolver: &rebindingResolver{
+			ips: []net.IPAddr{
+				{IP: net.ParseIP("93.184.216.34")},   // example.com — public
+				{IP: net.ParseIP("169.254.169.254")}, // metadata smuggled in
+			},
+		},
+	})
+
+	_, err := dial(context.Background(), "tcp", "attacker.example.com:443")
+	require.Error(t, err, "split-DNS rebinding attempt must be rejected")
+
+	var blocked *webhook.SSRFBlockedError
+	require.True(t, errors.As(err, &blocked))
+	assert.True(t, blocked.IP.Equal(net.ParseIP("169.254.169.254")),
+		"should identify the banned IP in the answer set")
+}
+
+// TestSSRFSafeDialContext_ResolverEmptyAnswer covers the defensive path where
+// the resolver succeeds but returns no addresses.
+func TestSSRFSafeDialContext_ResolverEmptyAnswer(t *testing.T) {
+	dial := webhook.NewSSRFSafeDialContext(&webhook.ClientConfig{
+		Resolver: &rebindingResolver{ips: nil},
+	})
+
+	_, err := dial(context.Background(), "tcp", "example.com:443")
+	require.Error(t, err)
+	var blocked *webhook.SSRFBlockedError
+	assert.False(t, errors.As(err, &blocked),
+		"empty-answer should be a resolve error, not SSRFBlockedError")
+}
+
+// TestSSRFSafeDialContext_ResolverError propagates lookup errors unchanged
+// (wrapped with context) rather than silently failing open.
+func TestSSRFSafeDialContext_ResolverError(t *testing.T) {
+	dial := webhook.NewSSRFSafeDialContext(&webhook.ClientConfig{
+		Resolver: &rebindingResolver{err: errors.New("NXDOMAIN")},
+	})
+
+	_, err := dial(context.Background(), "tcp", "nxdomain.example:443")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NXDOMAIN")
+}
+
+// TestSSRFSafeDialContext_CustomGuard asserts that callers can tighten or
+// relax the policy via the IPGuard field.
+func TestSSRFSafeDialContext_CustomGuard(t *testing.T) {
+	// Custom guard: allow everything. This verifies the override surface;
+	// we still expect the dial to fail because the target does not exist,
+	// but we must fail with a network error, NOT SSRFBlockedError.
+	dial := webhook.NewSSRFSafeDialContext(&webhook.ClientConfig{
+		DialTimeout: 50 * time.Millisecond,
+		IPGuard: func(_ net.IP) bool {
+			return true // allow all
+		},
+	})
+
+	// 192.0.2.1 is TEST-NET-1 and is unroutable; the dial will fail but
+	// with a connection/timeout error rather than SSRFBlockedError.
+	_, err := dial(context.Background(), "tcp", "192.0.2.1:1")
+	require.Error(t, err)
+	var blocked *webhook.SSRFBlockedError
+	assert.False(t, errors.As(err, &blocked),
+		"custom guard permitted the IP, so error should NOT be SSRFBlockedError: got %v", err)
+}
+
+// TestSSRFSafeDialContext_InvalidAddress covers the defensive path where the
+// input is malformed (missing port).
+func TestSSRFSafeDialContext_InvalidAddress(t *testing.T) {
+	dial := webhook.NewSSRFSafeDialContext(&webhook.ClientConfig{})
+
+	_, err := dial(context.Background(), "tcp", "not-a-host-port")
+	require.Error(t, err)
+}
+
+// TestIsPrivateOrReservedIP exercises the IP classifier directly. The test
+// is exhaustive across the ranges a webhook target might abuse.
+func TestIsPrivateOrReservedIP(t *testing.T) {
+	cases := []struct {
+		name    string
+		ip      string
+		private bool
+	}{
+		{"nil", "", true},
+		{"loopback_v4", "127.0.0.1", true},
+		{"loopback_v4_extended", "127.5.5.5", true},
+		{"loopback_v6", "::1", true},
+		{"unspecified_v4", "0.0.0.0", true},
+		{"unspecified_v6", "::", true},
+		{"link_local_v4", "169.254.169.254", true},
+		{"link_local_v6", "fe80::1", true},
+		{"private_class_a", "10.0.0.1", true},
+		{"private_class_b", "172.16.0.1", true},
+		{"private_class_b_edge", "172.31.255.254", true},
+		{"private_class_c", "192.168.1.1", true},
+		{"cgnat", "100.64.0.1", true},
+		{"multicast_v4", "224.0.0.1", true},
+		{"ula_v6", "fc00::1", true},
+		{"public_v4", "8.8.8.8", false},
+		{"public_v4_cloudflare", "1.1.1.1", false},
+		{"public_v6", "2001:4860:4860::8888", false},
+		{"outside_class_b", "172.15.0.1", false},
+		{"outside_class_b_high", "172.32.0.1", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var ip net.IP
+			if tc.ip != "" {
+				ip = net.ParseIP(tc.ip)
+				require.NotNil(t, ip, "failed to parse test IP %q", tc.ip)
+			}
+			assert.Equal(t, tc.private, webhook.IsPrivateOrReservedIP(ip),
+				"IsPrivateOrReservedIP(%q)", tc.ip)
+		})
+	}
+}
+
+// TestDefaultIPGuard asserts the inverse relationship with
+// IsPrivateOrReservedIP.
+func TestDefaultIPGuard(t *testing.T) {
+	assert.False(t, webhook.DefaultIPGuard(net.ParseIP("169.254.169.254")))
+	assert.False(t, webhook.DefaultIPGuard(net.ParseIP("127.0.0.1")))
+	assert.True(t, webhook.DefaultIPGuard(net.ParseIP("8.8.8.8")))
+}
+
+// TestSSRFBlockedError_Message verifies the error is informative for logs
+// and does not leak payload contents.
+func TestSSRFBlockedError_Message(t *testing.T) {
+	e := &webhook.SSRFBlockedError{
+		Host: "attacker.example.com",
+		IP:   net.ParseIP("169.254.169.254"),
+	}
+	msg := e.Error()
+	assert.Contains(t, msg, "attacker.example.com")
+	assert.Contains(t, msg, "169.254.169.254")
+	assert.Contains(t, msg, "SSRF")
+}
+
+// TestNewHTTPClient_InsecureSkipVerify asserts the caller-controlled opt-in
+// works end-to-end for test environments.
+func TestNewHTTPClient_InsecureSkipVerify(t *testing.T) {
+	client, err := webhook.NewHTTPClient(&webhook.ClientConfig{
+		Timeout:            time.Second,
+		InsecureSkipVerify: true,
+	})
+	require.NoError(t, err)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}

--- a/internal/webhook/ssrf.go
+++ b/internal/webhook/ssrf.go
@@ -1,0 +1,95 @@
+package webhook
+
+import (
+	"fmt"
+	"net"
+	"sync"
+)
+
+// privateIPv4CIDRs enumerates IPv4 ranges that must never be reachable by a
+// customer-supplied webhook target.
+var privateIPv4CIDRs = []string{
+	"10.0.0.0/8",      // RFC 1918 Class A
+	"172.16.0.0/12",   // RFC 1918 Class B
+	"192.168.0.0/16",  // RFC 1918 Class C
+	"169.254.0.0/16",  // Link-local (includes cloud metadata 169.254.169.254)
+	"100.64.0.0/10",   // Carrier-grade NAT
+	"0.0.0.0/8",       // Current network
+	"192.0.0.0/24",    // IETF protocol assignments
+	"192.0.2.0/24",    // TEST-NET-1
+	"198.18.0.0/15",   // Benchmarking
+	"198.51.100.0/24", // TEST-NET-2
+	"203.0.113.0/24",  // TEST-NET-3
+	"224.0.0.0/4",     // Multicast
+	"240.0.0.0/4",     // Reserved
+}
+
+// privateIPv6CIDRs enumerates IPv6 ranges that must never be reachable by a
+// customer-supplied webhook target.
+var privateIPv6CIDRs = []string{
+	"fc00::/7",      // Unique local addresses
+	"fe80::/10",     // Link-local
+	"fec0::/10",     // Deprecated site-local
+	"ff00::/8",      // Multicast
+	"::/128",        // Unspecified
+	"::1/128",       // Loopback
+	"64:ff9b::/96",  // NAT64 well-known prefix
+	"100::/64",      // Discard-only
+	"2001:db8::/32", // Documentation
+}
+
+var (
+	parsedPrivateIPv4Nets []*net.IPNet
+	parsedPrivateIPv6Nets []*net.IPNet
+	privateIPParseOnce    sync.Once
+)
+
+// parsePrivateRanges populates parsedPrivateIPv{4,6}Nets on first use. Panics
+// on malformed CIDRs because every entry is a compile-time literal.
+func parsePrivateRanges() {
+	for _, cidr := range privateIPv4CIDRs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Sprintf("invalid IPv4 CIDR %q: %v", cidr, err))
+		}
+		parsedPrivateIPv4Nets = append(parsedPrivateIPv4Nets, network)
+	}
+	for _, cidr := range privateIPv6CIDRs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Sprintf("invalid IPv6 CIDR %q: %v", cidr, err))
+		}
+		parsedPrivateIPv6Nets = append(parsedPrivateIPv6Nets, network)
+	}
+}
+
+// IsPrivateOrReservedIP reports whether ip is in any range that should be
+// unreachable from a customer-supplied webhook target. This covers loopback,
+// RFC 1918 private space, link-local (incl. cloud metadata 169.254.169.254),
+// CGNAT, multicast, and IPv6 equivalents.
+func IsPrivateOrReservedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsUnspecified() {
+		return true
+	}
+
+	privateIPParseOnce.Do(parsePrivateRanges)
+
+	if v4 := ip.To4(); v4 != nil {
+		for _, network := range parsedPrivateIPv4Nets {
+			if network.Contains(v4) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, network := range parsedPrivateIPv6Nets {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workers/webhook_worker.go
+++ b/internal/workers/webhook_worker.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/piwi3910/netweave/internal/controllers"
 	"github.com/piwi3910/netweave/internal/storage"
+	"github.com/piwi3910/netweave/internal/webhook"
 )
 
 const (
@@ -123,6 +124,11 @@ type Config struct {
 
 	// HMACSecret is the secret key for HMAC signature generation.
 	HMACSecret string
+
+	// AllowPrivateNetworks disables the outbound SSRF IP guard. Intended
+	// strictly for unit/integration tests driven by httptest.NewServer on
+	// loopback. Production callers MUST leave this false.
+	AllowPrivateNetworks bool
 }
 
 // NewWebhookWorker creates a new WebhookWorker.
@@ -163,9 +169,22 @@ func NewWebhookWorker(cfg *Config) (*WebhookWorker, error) {
 		maxBackoff = DefaultMaxBackoff
 	}
 
+	// Build a hardened HTTP client shared with events.WebhookNotifier:
+	//   - TLS 1.2 floor (prevents negotiation down to TLS 1.0/1.1)
+	//   - bounded idle-connection pool (prevents FD exhaustion)
+	//   - SSRF-safe DialContext (closes the DNS-rebinding TOCTOU window
+	//     between subscription registration and webhook delivery)
+	httpClient, err := webhook.NewHTTPClient(&webhook.ClientConfig{
+		Timeout:              timeout,
+		AllowPrivateNetworks: cfg.AllowPrivateNetworks,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct webhook HTTP client: %w", err)
+	}
+
 	return &WebhookWorker{
 		redisClient:       cfg.RedisClient,
-		HTTPClient:        &http.Client{Timeout: timeout},
+		HTTPClient:        httpClient,
 		logger:            cfg.Logger,
 		subscriptionStore: cfg.SubscriptionStore,
 		WorkerCount:       workerCount,

--- a/internal/workers/webhook_worker_test.go
+++ b/internal/workers/webhook_worker_test.go
@@ -198,10 +198,11 @@ func TestWebhookWorker_DeliverWebhook_Success(t *testing.T) {
 
 	// Create worker
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient: rdb,
-		Logger:      zaptest.NewLogger(t),
-		WorkerCount: 1,
-		Timeout:     5 * time.Second,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          1,
+		Timeout:              5 * time.Second,
 	})
 	require.NoError(t, err)
 
@@ -271,10 +272,11 @@ func TestWebhookWorker_DeliverWebhook_WithHMAC(t *testing.T) {
 
 	// Create worker with HMAC secret
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient: rdb,
-		Logger:      zaptest.NewLogger(t),
-		WorkerCount: 1,
-		HMACSecret:  hmacSecret,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          1,
+		HMACSecret:           hmacSecret,
 	})
 	require.NoError(t, err)
 
@@ -313,9 +315,10 @@ func TestWebhookWorker_DeliverWebhook_Failure(t *testing.T) {
 
 	// Create worker
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient: rdb,
-		Logger:      zaptest.NewLogger(t),
-		WorkerCount: 1,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          1,
 	})
 	require.NoError(t, err)
 
@@ -361,11 +364,12 @@ func TestWebhookWorker_DeliverWithRetries(t *testing.T) {
 
 	// Create worker with retries
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient:  rdb,
-		Logger:       zaptest.NewLogger(t),
-		WorkerCount:  1,
-		MaxRetries:   3,
-		RetryBackoff: 100 * time.Millisecond,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          1,
+		MaxRetries:           3,
+		RetryBackoff:         100 * time.Millisecond,
 	})
 	require.NoError(t, err)
 
@@ -405,11 +409,12 @@ func TestWebhookWorker_DeliverWithRetries_MaxRetriesExceeded(t *testing.T) {
 
 	// Create worker with limited retries
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient:  rdb,
-		Logger:       zaptest.NewLogger(t),
-		WorkerCount:  1,
-		MaxRetries:   2,
-		RetryBackoff: 50 * time.Millisecond,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          1,
+		MaxRetries:           2,
+		RetryBackoff:         50 * time.Millisecond,
 	})
 	require.NoError(t, err)
 
@@ -466,9 +471,10 @@ func TestWebhookWorker_MoveToDLQ(t *testing.T) {
 
 	// Create worker
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient: rdb,
-		Logger:      zaptest.NewLogger(t),
-		WorkerCount: 1,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          1,
 	})
 	require.NoError(t, err)
 
@@ -512,9 +518,10 @@ func TestWebhookWorker_CreateConsumerGroup(t *testing.T) {
 	}()
 
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient: rdb,
-		Logger:      zaptest.NewLogger(t),
-		WorkerCount: 1,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          1,
 	})
 	require.NoError(t, err)
 
@@ -543,9 +550,10 @@ func TestWebhookWorker_AcknowledgeMessage(t *testing.T) {
 	}()
 
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient: rdb,
-		Logger:      zaptest.NewLogger(t),
-		WorkerCount: 1,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          1,
 	})
 	require.NoError(t, err)
 
@@ -596,10 +604,11 @@ func TestWebhookWorker_HandleMessage(t *testing.T) {
 	defer server.Close()
 
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient: rdb,
-		Logger:      zaptest.NewLogger(t),
-		WorkerCount: 1,
-		MaxRetries:  1,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          1,
+		MaxRetries:           1,
 	})
 	require.NoError(t, err)
 
@@ -721,9 +730,10 @@ func TestWebhookWorker_ProcessNextEvent(t *testing.T) {
 	defer server.Close()
 
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient: rdb,
-		Logger:      zaptest.NewLogger(t),
-		WorkerCount: 1,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          1,
 	})
 	require.NoError(t, err)
 
@@ -774,9 +784,10 @@ func TestWebhookWorker_StartStop(t *testing.T) {
 	}()
 
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient: rdb,
-		Logger:      zaptest.NewLogger(t),
-		WorkerCount: 2,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          2,
 	})
 	require.NoError(t, err)
 
@@ -812,9 +823,10 @@ func TestWebhookWorker_Stop(t *testing.T) {
 	}()
 
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient: rdb,
-		Logger:      zaptest.NewLogger(t),
-		WorkerCount: 1,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          1,
 	})
 	require.NoError(t, err)
 
@@ -843,9 +855,10 @@ func TestWebhookWorker_DeliverWebhook_BackendIDHeader(t *testing.T) {
 		defer server.Close()
 
 		worker, err := workers.NewWebhookWorker(&workers.Config{
-			RedisClient: rdb,
-			Logger:      zaptest.NewLogger(t),
-			WorkerCount: 1,
+			RedisClient:          rdb,
+			Logger:               zaptest.NewLogger(t),
+			AllowPrivateNetworks: true,
+			WorkerCount:          1,
 		})
 		require.NoError(t, err)
 
@@ -877,9 +890,10 @@ func TestWebhookWorker_DeliverWebhook_BackendIDHeader(t *testing.T) {
 		defer server.Close()
 
 		worker, err := workers.NewWebhookWorker(&workers.Config{
-			RedisClient: rdb,
-			Logger:      zaptest.NewLogger(t),
-			WorkerCount: 1,
+			RedisClient:          rdb,
+			Logger:               zaptest.NewLogger(t),
+			AllowPrivateNetworks: true,
+			WorkerCount:          1,
 		})
 		require.NoError(t, err)
 
@@ -1034,11 +1048,12 @@ func TestWebhookWorker_TenantFiltering(t *testing.T) {
 			}
 
 			worker, err := workers.NewWebhookWorker(&workers.Config{
-				RedisClient:       rdb,
-				Logger:            zaptest.NewLogger(t),
-				WorkerCount:       1,
-				MaxRetries:        1,
-				SubscriptionStore: subStore,
+				RedisClient:          rdb,
+				Logger:               zaptest.NewLogger(t),
+				WorkerCount:          1,
+				MaxRetries:           1,
+				SubscriptionStore:    subStore,
+				AllowPrivateNetworks: true,
 			})
 			require.NoError(t, err)
 
@@ -1099,9 +1114,10 @@ func TestWebhookWorker_EventTenantFields(t *testing.T) {
 	defer server.Close()
 
 	worker, err := workers.NewWebhookWorker(&workers.Config{
-		RedisClient: rdb,
-		Logger:      zaptest.NewLogger(t),
-		WorkerCount: 1,
+		RedisClient:          rdb,
+		Logger:               zaptest.NewLogger(t),
+		AllowPrivateNetworks: true,
+		WorkerCount:          1,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- Add `internal/webhook` package centralizing HTTP client creation for all webhook/notification paths
- SSRF defenses: block RFC 1918, carrier-grade NAT, loopback, link-local, and `169.254.169.254` cloud metadata via custom `DialContext` that resolves once and pins IPs (defeats DNS rebinding)
- TLS 1.2 `MinVersion` floor on every outbound webhook
- Bounded `MaxIdleConnsPerHost` to prevent connection pool exhaustion under load
- `internal/events/notifier.go` and `internal/workers/webhook_worker.go` now consume the shared client

## Test plan
- [x] `go build ./...`
- [x] New `httpclient_test.go` covers TLS floor, private-IP rejection, DNS-rebinding defense
- [ ] CI green

Resolves #476
Resolves #478
Resolves #519