### PR TITLE
[Refactor] Unify Prometheus metric namespaces under netweave_*

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -2,6 +2,107 @@
 
 This document tracks breaking changes in the O2-IMS Gateway implementation.
 
+## Unify Prometheus Metric Namespace to `netweave_*` (2026-04-20)
+
+Resolves #490 (H17: metric naming unification) and #497 (I6: bound label cardinality).
+
+### Summary
+
+All Prometheus metrics emitted by the gateway now use the canonical
+`Namespace: "netweave"` with a meaningful `Subsystem` label. Previously the
+codebase emitted metrics under **four different** schemes (`netweave_*`,
+`o2ims_*` via Namespace, flat `o2ims_*` via Name, and unprefixed
+`api_request_duration_seconds`). Operators can now query every series with a
+single `{__name__=~"netweave_.*"}` filter.
+
+In the same change, label cardinality on notification delivery metrics has
+been bounded: raw `subscription_id` values are hashed to a 16-bit bucket, and
+`callback_url` is reduced to its host portion.
+
+### Breaking Change Details
+
+**Metric name renames** (non-exhaustive — every `o2ims_*` series is affected):
+
+| Old series name                                 | New series name                                    |
+| ----------------------------------------------- | -------------------------------------------------- |
+| `o2ims_adapter_operations_total`                | `netweave_adapter_operations_total`                |
+| `o2ims_adapter_operation_duration_seconds`      | `netweave_adapter_operation_duration_seconds`      |
+| `o2ims_adapter_backend_latency_seconds`         | `netweave_adapter_backend_latency_seconds`         |
+| `o2ims_adapter_health_check_status`             | `netweave_adapter_health_check_status`             |
+| `o2ims_events_generated_total`                  | `netweave_events_generated_total`                  |
+| `o2ims_events_queue_depth`                      | `netweave_events_queue_depth`                      |
+| `o2ims_notifications_delivered_total`           | `netweave_notifications_delivered_total`           |
+| `o2ims_notifications_circuit_breaker_state`     | `netweave_notifications_circuit_breaker_state`    |
+| `o2ims_certificates_issuances_total`            | `netweave_certificates_issuances_total`            |
+| `o2ims_webhook_deliveries_total`                | `netweave_webhook_deliveries_total`                |
+| `o2ims_webhook_latency_seconds`                 | `netweave_webhook_latency_seconds`                 |
+| `o2ims_webhook_dlq_total`                       | `netweave_webhook_dlq_total`                       |
+| `o2ims_active_webhook_workers`                  | `netweave_webhook_active_workers`                  |
+| `o2ims_event_stream_length`                     | `netweave_events_stream_length`                    |
+| `o2ims_subscription_events_processed_total`     | `netweave_controller_events_processed_total`       |
+| `o2ims_subscription_events_queued_total`        | `netweave_controller_events_queued_total`          |
+| `o2ims_active_subscriptions`                    | `netweave_controller_active_subscriptions`         |
+| `o2ims_informer_sync_duration_seconds`          | `netweave_controller_informer_sync_duration_seconds` |
+| `o2ims_resource_rate_limit_hits_total`          | `netweave_ratelimit_resource_hits_total`           |
+| `o2ims_resource_rate_limit_fail_open_total`     | `netweave_ratelimit_resource_fail_open_total`      |
+| `o2ims_smo_api_request_duration_seconds`        | `netweave_smo_api_request_duration_seconds`        |
+| `o2ims_smo_workflow_executions_total`           | `netweave_smo_workflow_executions_total`           |
+| `o2ims_http_requests_total`                     | `netweave_http_requests_total`                     |
+| `o2ims_http_request_duration_seconds`           | `netweave_http_request_duration_seconds`           |
+| `o2ims_redis_operations_total`                  | `netweave_redis_operations_total`                  |
+| `o2ims_k8s_operations_total`                    | `netweave_k8s_operations_total`                    |
+| `o2ims_batch_operations_total`                  | `netweave_batch_operations_total`                  |
+
+**Label changes (cardinality bound):**
+
+| Metric                                         | Old label(s)                         | New label(s)                     |
+| ---------------------------------------------- | ------------------------------------ | -------------------------------- |
+| `netweave_notifications_delivered_total`       | `status`, `subscription_id`          | `status`, `subscription_bucket` |
+| `netweave_notifications_delivery_duration_seconds` | `status`, `subscription_id`     | `status`                         |
+| `netweave_notifications_attempts`              | `status`, `subscription_id`          | `status`                         |
+| `netweave_notifications_response_time_seconds` | `subscription_id`, `http_status`     | `http_status`                    |
+| `netweave_notifications_circuit_breaker_state` | `callback_url`                       | `callback_host`                  |
+| `netweave_webhook_deliveries_total`            | `subscription_id`, `status`          | `subscription_bucket`, `status` |
+| `netweave_webhook_latency_seconds`             | `subscription_id`                    | `subscription_bucket`            |
+| `netweave_webhook_retries_total`               | `subscription_id`, `attempt`         | `subscription_bucket`, `attempt`|
+| `netweave_webhook_dlq_total`                   | `subscription_id`                    | `subscription_bucket`            |
+| `netweave_controller_events_queued_total`      | `subscription_id`, `resource_type`   | `subscription_bucket`, `resource_type` |
+
+`subscription_bucket` is a deterministic 4-char lowercase hex value (SHA-256
+of the subscription ID, first 16 bits), bounding cardinality to 65536 series
+max per metric regardless of how many subscriptions exist.
+
+`callback_host` is the host-and-port portion of the callback URL; unparseable
+URLs fall back to a stable 8-char hash prefix (`hash:<xxxxxxxx>`).
+
+### Impact
+
+**Affected consumers:**
+- Prometheus recording rules and alert expressions matching `o2ims_*`.
+- Grafana dashboards with `o2ims_*` queries.
+- Downstream tooling scraping `/metrics` and matching by name or label.
+- Any operator tooling grouping by `subscription_id` or `callback_url`.
+
+### Migration
+
+1. Update PromQL in your recording rules, alerts, and dashboards:
+   `o2ims_` → `netweave_`. The canonical in-repo dashboard
+   (`deployments/monitoring/grafana-dashboard-adapters.json`) and alert rules
+   (`deployments/monitoring/prometheus-alerts-adapters.yaml`) have been
+   updated to the new names.
+2. If you group by `subscription_id` to identify a specific subscription,
+   switch to grouping by `subscription_bucket` (you can still correlate
+   individual subscriptions back to buckets offline via
+   `sha256(id)[:4] & 0xffff`, but the metrics will no longer expose raw IDs
+   for DoS-hardening and privacy reasons — see #497).
+3. If you group by `callback_url`, switch to `callback_host`. Path tokens
+   (which may have embedded tenant or customer identifiers) are no longer
+   exposed.
+
+There is no Prometheus-native rename: the old series names will simply stop
+being emitted after upgrade and new series names will start. Plan a
+maintenance window and update all consumers atomically with the deployment.
+
 ## PR #194: Resource ID Format Change (2026-01-12)
 
 ### Summary

--- a/deployments/monitoring/README.md
+++ b/deployments/monitoring/README.md
@@ -35,26 +35,26 @@ curl -X POST http://prometheus:9090/-/reload
 ## Metrics Available
 
 ### Adapter Operations
-- `o2ims_adapter_operations_total` - Total operations by adapter/operation/status
-- `o2ims_adapter_operation_duration_seconds` - Operation latency distribution
-- `o2ims_adapter_operation_errors_total` - Error counts by type
+- `netweave_adapter_operations_total` - Total operations by adapter/operation/status
+- `netweave_adapter_operation_duration_seconds` - Operation latency distribution
+- `netweave_adapter_operation_errors_total` - Error counts by type
 
 ### Cache Metrics
-- `o2ims_adapter_cache_hits_total` - Cache hits by adapter/operation
-- `o2ims_adapter_cache_misses_total` - Cache misses by adapter/operation
+- `netweave_adapter_cache_hits_total` - Cache hits by adapter/operation
+- `netweave_adapter_cache_misses_total` - Cache misses by adapter/operation
 
 ### Resource Metrics
-- `o2ims_adapter_resources_total` - Resource counts by adapter/type
-- `o2ims_adapter_resource_pools_total` - Resource pool counts
+- `netweave_adapter_resources` - Resource counts by adapter/type
+- `netweave_adapter_resource_pools` - Resource pool counts
 
 ### Backend API Metrics
-- `o2ims_adapter_backend_requests_total` - Backend API requests
-- `o2ims_adapter_backend_latency_seconds` - Backend API latency
-- `o2ims_adapter_backend_errors_total` - Backend API errors
+- `netweave_adapter_backend_requests_total` - Backend API requests
+- `netweave_adapter_backend_latency_seconds` - Backend API latency
+- `netweave_adapter_backend_errors_total` - Backend API errors
 
 ### Health Metrics
-- `o2ims_adapter_health_check_status` - Health status (1=healthy, 0=unhealthy)
-- `o2ims_adapter_health_check_duration_seconds` - Health check duration
+- `netweave_adapter_health_check_status` - Health status (1=healthy, 0=unhealthy)
+- `netweave_adapter_health_check_duration_seconds` - Health check duration
 
 ## SLO Targets
 

--- a/deployments/monitoring/grafana-dashboard-adapters.json
+++ b/deployments/monitoring/grafana-dashboard-adapters.json
@@ -2,7 +2,7 @@
   "dashboard": {
     "title": "O2-IMS Adapter Observability",
     "description": "Comprehensive observability dashboard for O2-IMS adapter operations, performance, and health",
-    "tags": ["o2ims", "adapters", "observability"],
+    "tags": ["netweave", "adapters", "observability"],
     "timezone": "browser",
     "editable": true,
     "fiscalYearStartMonth": 0,
@@ -15,7 +15,7 @@
         "title": "Adapter Operation Rate",
         "targets": [
           {
-            "expr": "sum(rate(o2ims_adapter_operations_total[5m])) by (adapter, operation)",
+            "expr": "sum(rate(netweave_adapter_operations_total[5m])) by (adapter, operation)",
             "legendFormat": "{{adapter}}/{{operation}}"
           }
         ],
@@ -32,11 +32,11 @@
         "title": "Adapter Operation Latency (p95, p99)",
         "targets": [
           {
-            "expr": "histogram_quantile(0.95, sum(rate(o2ims_adapter_operation_duration_seconds_bucket[5m])) by (adapter, operation, le))",
+            "expr": "histogram_quantile(0.95, sum(rate(netweave_adapter_operation_duration_seconds_bucket[5m])) by (adapter, operation, le))",
             "legendFormat": "{{adapter}}/{{operation}} p95"
           },
           {
-            "expr": "histogram_quantile(0.99, sum(rate(o2ims_adapter_operation_duration_seconds_bucket[5m])) by (adapter, operation, le))",
+            "expr": "histogram_quantile(0.99, sum(rate(netweave_adapter_operation_duration_seconds_bucket[5m])) by (adapter, operation, le))",
             "legendFormat": "{{adapter}}/{{operation}} p99"
           }
         ],
@@ -73,7 +73,7 @@
         "title": "Adapter Error Rate",
         "targets": [
           {
-            "expr": "sum(rate(o2ims_adapter_operations_total{status=\"error\"}[5m])) by (adapter, operation)",
+            "expr": "sum(rate(netweave_adapter_operations_total{status=\"error\"}[5m])) by (adapter, operation)",
             "legendFormat": "{{adapter}}/{{operation}} errors"
           }
         ],
@@ -96,7 +96,7 @@
         "title": "Adapter Success Rate (%)",
         "targets": [
           {
-            "expr": "sum(rate(o2ims_adapter_operations_total{status=\"success\"}[5m])) by (adapter) / sum(rate(o2ims_adapter_operations_total[5m])) by (adapter) * 100",
+            "expr": "sum(rate(netweave_adapter_operations_total{status=\"success\"}[5m])) by (adapter) / sum(rate(netweave_adapter_operations_total[5m])) by (adapter) * 100",
             "legendFormat": "{{adapter}}"
           }
         ],
@@ -115,7 +115,7 @@
         "title": "Cache Hit Ratio",
         "targets": [
           {
-            "expr": "sum(rate(o2ims_adapter_cache_hits_total[5m])) by (adapter, operation) / (sum(rate(o2ims_adapter_cache_hits_total[5m])) by (adapter, operation) + sum(rate(o2ims_adapter_cache_misses_total[5m])) by (adapter, operation)) * 100",
+            "expr": "sum(rate(netweave_adapter_cache_hits_total[5m])) by (adapter, operation) / (sum(rate(netweave_adapter_cache_hits_total[5m])) by (adapter, operation) + sum(rate(netweave_adapter_cache_misses_total[5m])) by (adapter, operation)) * 100",
             "legendFormat": "{{adapter}}/{{operation}}"
           }
         ],
@@ -151,7 +151,7 @@
         "title": "Active Resources by Adapter",
         "targets": [
           {
-            "expr": "sum(o2ims_adapter_resources_total) by (adapter, resource_type)",
+            "expr": "sum(netweave_adapter_resources) by (adapter, resource_type)",
             "legendFormat": "{{adapter}}/{{resource_type}}"
           }
         ],
@@ -180,7 +180,7 @@
         "title": "Backend API Latency by Endpoint",
         "targets": [
           {
-            "expr": "histogram_quantile(0.95, sum(rate(o2ims_adapter_backend_latency_seconds_bucket[5m])) by (adapter, endpoint, le))",
+            "expr": "histogram_quantile(0.95, sum(rate(netweave_adapter_backend_latency_seconds_bucket[5m])) by (adapter, endpoint, le))",
             "legendFormat": "{{adapter}}/{{endpoint}} p95"
           }
         ],
@@ -196,7 +196,7 @@
         "title": "Backend API Error Rate",
         "targets": [
           {
-            "expr": "sum(rate(o2ims_adapter_backend_errors_total[5m])) by (adapter, endpoint, error_type)",
+            "expr": "sum(rate(netweave_adapter_backend_errors_total[5m])) by (adapter, endpoint, error_type)",
             "legendFormat": "{{adapter}}/{{endpoint}}: {{error_type}}"
           }
         ],
@@ -212,7 +212,7 @@
         "title": "Health Check Status",
         "targets": [
           {
-            "expr": "o2ims_adapter_health_check_status",
+            "expr": "netweave_adapter_health_check_status",
             "legendFormat": "{{adapter}}"
           }
         ],
@@ -244,7 +244,7 @@
         "title": "Active Subscriptions by Adapter",
         "targets": [
           {
-            "expr": "o2ims_adapter_subscriptions_active",
+            "expr": "netweave_adapter_subscriptions_active",
             "legendFormat": "{{adapter}}"
           }
         ],
@@ -261,7 +261,7 @@
         "title": "Adapter Operation Statistics (5m)",
         "targets": [
           {
-            "expr": "topk(20, sum(rate(o2ims_adapter_operations_total[5m])) by (adapter, operation, status))",
+            "expr": "topk(20, sum(rate(netweave_adapter_operations_total[5m])) by (adapter, operation, status))",
             "format": "table",
             "instant": true
           }

--- a/deployments/monitoring/prometheus-alerts-adapters.yaml
+++ b/deployments/monitoring/prometheus-alerts-adapters.yaml
@@ -13,7 +13,7 @@ groups:
       - alert: AdapterOperationP95LatencyHigh
         expr: |
           histogram_quantile(0.95,
-            sum(rate(o2ims_adapter_operation_duration_seconds_bucket[5m]))
+            sum(rate(netweave_adapter_operation_duration_seconds_bucket[5m]))
             by (adapter, operation, le)
           ) > 0.1
         for: 5m
@@ -30,7 +30,7 @@ groups:
       - alert: AdapterOperationP99LatencyCritical
         expr: |
           histogram_quantile(0.99,
-            sum(rate(o2ims_adapter_operation_duration_seconds_bucket[5m]))
+            sum(rate(netweave_adapter_operation_duration_seconds_bucket[5m]))
             by (adapter, operation, le)
           ) > 0.5
         for: 5m
@@ -47,9 +47,9 @@ groups:
       - alert: AdapterErrorRateHigh
         expr: |
           (
-            sum(rate(o2ims_adapter_operations_total{status="error"}[5m])) by (adapter, operation)
+            sum(rate(netweave_adapter_operations_total{status="error"}[5m])) by (adapter, operation)
             /
-            sum(rate(o2ims_adapter_operations_total[5m])) by (adapter, operation)
+            sum(rate(netweave_adapter_operations_total[5m])) by (adapter, operation)
           ) * 100 > 5
         for: 5m
         labels:
@@ -65,9 +65,9 @@ groups:
       - alert: AdapterErrorRateCritical
         expr: |
           (
-            sum(rate(o2ims_adapter_operations_total{status="error"}[5m])) by (adapter, operation)
+            sum(rate(netweave_adapter_operations_total{status="error"}[5m])) by (adapter, operation)
             /
-            sum(rate(o2ims_adapter_operations_total[5m])) by (adapter, operation)
+            sum(rate(netweave_adapter_operations_total[5m])) by (adapter, operation)
           ) * 100 > 10
         for: 5m
         labels:
@@ -83,12 +83,12 @@ groups:
       - alert: AdapterCacheHitRatioLow
         expr: |
           (
-            sum(rate(o2ims_adapter_cache_hits_total[5m])) by (adapter, operation)
+            sum(rate(netweave_adapter_cache_hits_total[5m])) by (adapter, operation)
             /
             (
-              sum(rate(o2ims_adapter_cache_hits_total[5m])) by (adapter, operation)
+              sum(rate(netweave_adapter_cache_hits_total[5m])) by (adapter, operation)
               +
-              sum(rate(o2ims_adapter_cache_misses_total[5m])) by (adapter, operation)
+              sum(rate(netweave_adapter_cache_misses_total[5m])) by (adapter, operation)
             )
           ) * 100 < 90
         for: 10m
@@ -105,7 +105,7 @@ groups:
       - alert: AdapterBackendLatencyHigh
         expr: |
           histogram_quantile(0.95,
-            sum(rate(o2ims_adapter_backend_latency_seconds_bucket[5m]))
+            sum(rate(netweave_adapter_backend_latency_seconds_bucket[5m]))
             by (adapter, endpoint, method, le)
           ) > 0.5
         for: 5m
@@ -121,7 +121,7 @@ groups:
       # Alert: Backend API errors
       - alert: AdapterBackendErrorsHigh
         expr: |
-          sum(rate(o2ims_adapter_backend_errors_total[5m])) by (adapter, endpoint, error_type) > 0.1
+          sum(rate(netweave_adapter_backend_errors_total[5m])) by (adapter, endpoint, error_type) > 0.1
         for: 5m
         labels:
           severity: warning
@@ -133,7 +133,7 @@ groups:
 
       # Alert: Adapter health check failing
       - alert: AdapterUnhealthy
-        expr: o2ims_adapter_health_check_status == 0
+        expr: netweave_adapter_health_check_status == 0
         for: 2m
         labels:
           severity: critical
@@ -146,7 +146,7 @@ groups:
       # Alert: No operations in last 5 minutes (adapter might be stuck)
       - alert: AdapterNoOperations
         expr: |
-          sum(rate(o2ims_adapter_operations_total[5m])) by (adapter) == 0
+          sum(rate(netweave_adapter_operations_total[5m])) by (adapter) == 0
         for: 5m
         labels:
           severity: warning
@@ -163,10 +163,10 @@ groups:
       - alert: AdapterResourcePoolCountDrop
         expr: |
           (
-            o2ims_adapter_resource_pools_total
+            netweave_adapter_resource_pools
             -
-            o2ims_adapter_resource_pools_total offset 10m
-          ) / o2ims_adapter_resource_pools_total offset 10m * 100 < -20
+            netweave_adapter_resource_pools offset 10m
+          ) / netweave_adapter_resource_pools offset 10m * 100 < -20
         for: 5m
         labels:
           severity: warning
@@ -180,10 +180,10 @@ groups:
       - alert: AdapterResourceCountDrop
         expr: |
           (
-            sum(o2ims_adapter_resources_total) by (adapter, resource_type)
+            sum(netweave_adapter_resources) by (adapter, resource_type)
             -
-            sum(o2ims_adapter_resources_total offset 10m) by (adapter, resource_type)
-          ) / sum(o2ims_adapter_resources_total offset 10m) by (adapter, resource_type) * 100 < -20
+            sum(netweave_adapter_resources offset 10m) by (adapter, resource_type)
+          ) / sum(netweave_adapter_resources offset 10m) by (adapter, resource_type) * 100 < -20
         for: 5m
         labels:
           severity: warning
@@ -198,7 +198,7 @@ groups:
     rules:
       # Alert: No active subscriptions (might indicate sync issue)
       - alert: AdapterNoActiveSubscriptions
-        expr: o2ims_adapter_subscriptions_active == 0
+        expr: netweave_adapter_subscriptions_active == 0
         for: 10m
         labels:
           severity: info

--- a/internal/adapter/metrics.go
+++ b/internal/adapter/metrics.go
@@ -54,7 +54,7 @@ var Metrics = struct {
 }{
 	OperationDuration: promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "operation_duration_seconds",
 			Help:      "Duration of adapter operations in seconds",
@@ -65,7 +65,7 @@ var Metrics = struct {
 
 	OperationTotal: promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "operations_total",
 			Help:      "Total number of adapter operations",
@@ -75,7 +75,7 @@ var Metrics = struct {
 
 	OperationErrors: promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "operation_errors_total",
 			Help:      "Total number of adapter operation errors",
@@ -85,7 +85,7 @@ var Metrics = struct {
 
 	HealthCheckDuration: promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "health_check_duration_seconds",
 			Help:      "Duration of adapter health checks in seconds",
@@ -96,7 +96,7 @@ var Metrics = struct {
 
 	HealthCheckStatus: promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "health_check_status",
 			Help:      "Status of adapter health check (1 = healthy, 0 = unhealthy)",
@@ -106,7 +106,7 @@ var Metrics = struct {
 
 	SubscriptionCount: promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "subscriptions_active",
 			Help:      "Number of active subscriptions per adapter",
@@ -116,7 +116,7 @@ var Metrics = struct {
 
 	CacheHits: promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "cache_hits_total",
 			Help:      "Total number of cache hits",
@@ -126,7 +126,7 @@ var Metrics = struct {
 
 	CacheMisses: promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "cache_misses_total",
 			Help:      "Total number of cache misses",
@@ -136,7 +136,7 @@ var Metrics = struct {
 
 	ResourcesTotal: promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "resources",
 			Help:      "Current number of resources managed by adapter",
@@ -146,7 +146,7 @@ var Metrics = struct {
 
 	ResourcePoolsTotal: promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "resource_pools",
 			Help:      "Current number of resource pools per adapter",
@@ -156,7 +156,7 @@ var Metrics = struct {
 
 	BackendRequestsTotal: promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "backend_requests_total",
 			Help:      "Total number of backend API requests",
@@ -166,7 +166,7 @@ var Metrics = struct {
 
 	BackendLatency: promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "backend_latency_seconds",
 			Help:      "Backend API latency in seconds",
@@ -177,7 +177,7 @@ var Metrics = struct {
 
 	BackendErrors: promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "adapter",
 			Name:      "backend_errors_total",
 			Help:      "Total number of backend API errors",

--- a/internal/certlifecycle/metrics.go
+++ b/internal/certlifecycle/metrics.go
@@ -9,7 +9,7 @@ var (
 	// IssuancesTotal tracks total certificate issuances.
 	IssuancesTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "certificates",
 			Name:      "issuances_total",
 			Help:      "Total number of certificate issuances",
@@ -20,7 +20,7 @@ var (
 	// RevocationsTotal tracks total certificate revocations.
 	RevocationsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "certificates",
 			Name:      "revocations_total",
 			Help:      "Total number of certificate revocations",
@@ -31,7 +31,7 @@ var (
 	// RenewalsTotal tracks total certificate renewals by outcome.
 	RenewalsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "certificates",
 			Name:      "renewals_total",
 			Help:      "Total number of certificate renewals",
@@ -42,7 +42,7 @@ var (
 	// ByStatusGauge tracks the current number of certificates per status.
 	ByStatusGauge = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "certificates",
 			Name:      "by_status",
 			Help:      "Current number of certificates by lifecycle status",
@@ -53,7 +53,7 @@ var (
 	// LifetimeSeconds tracks the observed lifetime of certificates.
 	LifetimeSeconds = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "certificates",
 			Name:      "lifetime_seconds",
 			Help:      "Certificate lifetime from issuance to expiry in seconds",
@@ -65,7 +65,7 @@ var (
 	// RenewalAttempts tracks the number of renewal attempts per certificate.
 	RenewalAttempts = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "certificates",
 			Name:      "renewal_attempts",
 			Help:      "Number of renewal attempts per certificate",
@@ -77,7 +77,7 @@ var (
 	// MonitorLoopDuration tracks the duration of each monitor scan loop.
 	MonitorLoopDuration = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "certificates",
 			Name:      "monitor_loop_duration_seconds",
 			Help:      "Duration of each certificate monitor scan loop in seconds",

--- a/internal/controllers/README.md
+++ b/internal/controllers/README.md
@@ -65,10 +65,10 @@ if err := ctrl.Start(ctx); err != nil {
 
 ## Metrics
 
-- `o2ims_subscription_events_processed_total`: Total events processed
-- `o2ims_subscription_events_queued_total`: Total events queued for delivery
-- `o2ims_active_subscriptions`: Current number of active subscriptions
-- `o2ims_informer_sync_duration_seconds`: Informer cache sync duration
+- `netweave_controller_events_processed_total`: Total events processed
+- `netweave_controller_events_queued_total{subscription_bucket,resource_type}`: Total events queued for delivery
+- `netweave_controller_active_subscriptions`: Current number of active subscriptions
+- `netweave_controller_informer_sync_duration_seconds`: Informer cache sync duration
 
 ## Configuration
 

--- a/internal/controllers/metrics.go
+++ b/internal/controllers/metrics.go
@@ -1,43 +1,75 @@
 package controllers
 
 import (
+	"crypto/sha256"
+	"fmt"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
+
+// All metrics in this file use the canonical Namespace: "netweave",
+// Subsystem: "controller" naming scheme. See internal/observability/doc.go for
+// the project-wide metric naming rule.
+//
+// subscriptionBucketMask bounds the subscription_bucket label to 16 bits
+// (0..65535 = 65536 values max per metric), matching the bucketing used in
+// internal/events and internal/workers. See issue #497.
+const subscriptionBucketMask = 0xffff
+
+// SubscriptionBucket returns a deterministic 16-bit bucket identifier for a
+// subscription ID (4-char lowercase hex), used as a bounded label value.
+func SubscriptionBucket(subscriptionID string) string {
+	if subscriptionID == "" {
+		return "0000"
+	}
+	sum := sha256.Sum256([]byte(subscriptionID))
+	bucket := (uint16(sum[0])<<8 | uint16(sum[1])) & subscriptionBucketMask
+	return fmt.Sprintf("%04x", bucket)
+}
 
 var (
 	// EventsProcessedTotal tracks the total number of events processed by the controller.
 	EventsProcessedTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "o2ims_subscription_events_processed_total",
-			Help: "Total number of subscription events processed",
+			Namespace: "netweave",
+			Subsystem: "controller",
+			Name:      "events_processed_total",
+			Help:      "Total number of subscription events processed",
 		},
 		[]string{"resource_type", "event_type"},
 	)
 
 	// EventsQueuedTotal tracks the total number of events queued for webhook delivery.
+	// The subscription_bucket label is a 16-bit hash of the subscription ID (see #497).
 	EventsQueuedTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "o2ims_subscription_events_queued_total",
-			Help: "Total number of subscription events queued for delivery",
+			Namespace: "netweave",
+			Subsystem: "controller",
+			Name:      "events_queued_total",
+			Help:      "Total number of subscription events queued for delivery",
 		},
-		[]string{"subscription_id", "resource_type"},
+		[]string{"subscription_bucket", "resource_type"},
 	)
 
 	// ActiveSubscriptionsGauge tracks the current number of active subscriptions.
 	ActiveSubscriptionsGauge = promauto.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "o2ims_active_subscriptions",
-			Help: "Current number of active subscriptions",
+			Namespace: "netweave",
+			Subsystem: "controller",
+			Name:      "active_subscriptions",
+			Help:      "Current number of active subscriptions",
 		},
 	)
 
 	// InformerSyncDuration tracks the time taken for informer cache sync.
 	InformerSyncDuration = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "o2ims_informer_sync_duration_seconds",
-			Help:    "Time taken for informer cache sync",
-			Buckets: prometheus.DefBuckets,
+			Namespace: "netweave",
+			Subsystem: "controller",
+			Name:      "informer_sync_duration_seconds",
+			Help:      "Time taken for informer cache sync",
+			Buckets:   prometheus.DefBuckets,
 		},
 	)
 )

--- a/internal/controllers/subscription_controller.go
+++ b/internal/controllers/subscription_controller.go
@@ -404,8 +404,8 @@ func (c *SubscriptionController) ProcessNodeEvent(ctx context.Context, node *cor
 					zap.Error(err),
 					zap.String("subscription", sub.ID))
 			} else {
-				// Track queued event
-				EventsQueuedTotal.WithLabelValues(sub.ID, "k8s-node").Inc()
+				// Track queued event. Subscription ID is hashed to a bounded bucket (#497).
+				EventsQueuedTotal.WithLabelValues(SubscriptionBucket(sub.ID), "k8s-node").Inc()
 			}
 		}
 	}
@@ -448,8 +448,8 @@ func (c *SubscriptionController) ProcessNamespaceEvent(ctx context.Context, ns *
 					zap.Error(err),
 					zap.String("subscription", sub.ID))
 			} else {
-				// Track queued event
-				EventsQueuedTotal.WithLabelValues(sub.ID, "k8s-namespace").Inc()
+				// Track queued event. Subscription ID is hashed to a bounded bucket (#497).
+				EventsQueuedTotal.WithLabelValues(SubscriptionBucket(sub.ID), "k8s-namespace").Inc()
 			}
 		}
 	}

--- a/internal/events/export_test.go
+++ b/internal/events/export_test.go
@@ -1,0 +1,19 @@
+package events
+
+// This file exposes internal helpers to the external-package test files
+// (events_test) via compile-time indirection. The exports only exist under
+// `go test`; they are not part of the public API.
+
+// SubscriptionBucketForTest exposes subscriptionBucket for the external test package.
+// It returns the deterministic 16-bit bucket identifier (4-char lowercase hex)
+// used to bound the cardinality of the notifications_delivered_total label space.
+func SubscriptionBucketForTest(subscriptionID string) string {
+	return subscriptionBucket(subscriptionID)
+}
+
+// CallbackHostForTest exposes callbackHost for the external test package.
+// It returns the host portion of a callback URL, or a stable fallback when
+// the URL is empty or unparseable.
+func CallbackHostForTest(callbackURL string) string {
+	return callbackHost(callbackURL)
+}

--- a/internal/events/metrics.go
+++ b/internal/events/metrics.go
@@ -1,15 +1,41 @@
 package events
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Prometheus metric cardinality bounds for high-risk labels.
+//
+// Subscriptions and callback URLs are attacker-controlled in O2-IMS: a tenant
+// with `subscriptions:create` permission can register arbitrary numbers of
+// subscriptions with unique callback URLs. Without bounds, each new
+// subscription creates a permanent, publicly-scrapable Prometheus series.
+//
+// To bound the label space we replace:
+//   - subscriptionID -> 16-bit bucket (0000..ffff = 65536 series max per metric)
+//   - callbackURL    -> host only (small enumerable set)
+//
+// These transformations are one-way and deterministic: a given subscription
+// always hashes to the same bucket, so rates/counters remain useful for
+// aggregated analysis, but no PII (tenant identifiers embedded in callback
+// path tokens) is exposed via /metrics.
+const (
+	// subscriptionBucketMask bounds subscription_bucket to 16 bits (0..65535).
+	// Expressed as the modulus applied to the first 4 hex chars of sha256(id).
+	subscriptionBucketMask = 0xffff
 )
 
 var (
 	// EventsGeneratedTotal tracks total number of events generated.
 	EventsGeneratedTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "events",
 			Name:      "generated_total",
 			Help:      "Total number of events generated",
@@ -20,7 +46,7 @@ var (
 	// Event queue metrics.
 	eventsQueuedTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "events",
 			Name:      "queued_total",
 			Help:      "Total number of events queued",
@@ -31,7 +57,7 @@ var (
 	// EventsQueueDepth tracks the current depth of the event queue.
 	EventsQueueDepth = promauto.NewGauge(
 		prometheus.GaugeOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "events",
 			Name:      "queue_depth",
 			Help:      "Current depth of the event queue",
@@ -39,64 +65,68 @@ var (
 	)
 
 	// NotificationsDeliveredTotal tracks total number of notifications delivered.
+	// The subscription_bucket label is a 16-bit hash of the subscription ID,
+	// bounding cardinality to 65536 values regardless of tenant subscription count.
 	NotificationsDeliveredTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "notifications",
 			Name:      "delivered_total",
 			Help:      "Total number of notifications delivered",
 		},
-		[]string{"status", "subscription_id"},
+		[]string{"status", "subscription_bucket"},
 	)
 
 	notificationDeliveryDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "notifications",
 			Name:      "delivery_duration_seconds",
 			Help:      "Notification delivery duration in seconds",
 			Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0},
 		},
-		[]string{"status", "subscription_id"},
+		[]string{"status"},
 	)
 
 	notificationAttempts = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "notifications",
 			Name:      "attempts",
 			Help:      "Number of delivery attempts per notification",
 			Buckets:   []float64{1, 2, 3, 4, 5, 10},
 		},
-		[]string{"status", "subscription_id"},
+		[]string{"status"},
 	)
 
 	notificationResponseTime = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "notifications",
 			Name:      "response_time_seconds",
 			Help:      "Webhook endpoint response time in seconds",
 			Buckets:   []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0},
 		},
-		[]string{"subscription_id", "http_status"},
+		[]string{"http_status"},
 	)
 
 	// CircuitBreakerState tracks the state of circuit breakers for notification delivery.
+	// The callback_host label is the host (and port) portion of the callback URL,
+	// stripping query strings and path segments that may contain customer identifiers.
 	CircuitBreakerState = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "notifications",
 			Name:      "circuit_breaker_state",
 			Help:      "Circuit breaker state (0=closed, 1=half-open, 2=open)",
 		},
-		[]string{"callback_url"},
+		[]string{"callback_host"},
 	)
 
 	// Subscription filtering metrics.
 	subscriptionsMatched = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "subscriptions",
 			Name:      "matched",
 			Help:      "Number of subscriptions matched per event",
@@ -108,7 +138,7 @@ var (
 	// NotificationWorkersActive tracks the number of active notification workers.
 	NotificationWorkersActive = promauto.NewGauge(
 		prometheus.GaugeOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "notifications",
 			Name:      "workers_active",
 			Help:      "Number of active notification workers",
@@ -118,13 +148,42 @@ var (
 	// NotificationFailedCurrent tracks the current number of failed notification deliveries.
 	NotificationFailedCurrent = promauto.NewGauge(
 		prometheus.GaugeOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "notifications",
 			Name:      "failed_current",
 			Help:      "Current number of failed deliveries in dead letter queue",
 		},
 	)
 )
+
+// subscriptionBucket returns a deterministic 16-bit bucket identifier for a
+// subscription ID. The result is always a 4-character lowercase hex string,
+// bounding cardinality to 65536 values regardless of subscription count.
+func subscriptionBucket(subscriptionID string) string {
+	if subscriptionID == "" {
+		return "0000"
+	}
+	sum := sha256.Sum256([]byte(subscriptionID))
+	bucket := (uint16(sum[0])<<8 | uint16(sum[1])) & subscriptionBucketMask
+	return fmt.Sprintf("%04x", bucket)
+}
+
+// callbackHost extracts a stable host identifier from a callback URL.
+// Unparseable or empty URLs collapse to the fixed "unknown" label.
+// Query strings and paths (which may embed customer identifiers) are discarded.
+func callbackHost(callbackURL string) string {
+	if callbackURL == "" {
+		return "unknown"
+	}
+	parsed, err := url.Parse(callbackURL)
+	if err != nil || parsed.Host == "" {
+		// Fall back to a stable 8-char hash of the raw input when we cannot
+		// extract a host. This keeps cardinality finite without leaking path.
+		sum := sha256.Sum256([]byte(callbackURL))
+		return "hash:" + hex.EncodeToString(sum[:4])
+	}
+	return parsed.Host
+}
 
 // RecordEventGenerated records an event generation.
 func RecordEventGenerated(eventType, resourceType string) {
@@ -142,22 +201,29 @@ func RecordQueueDepth(depth float64) {
 }
 
 // RecordNotificationDelivered records a notification delivery.
+// The subscription ID is hashed to a bounded 16-bit bucket before being used
+// as a label value; see subscriptionBucket for rationale.
 func RecordNotificationDelivered(status, subscriptionID string, duration float64, attempts int) {
-	NotificationsDeliveredTotal.WithLabelValues(status, subscriptionID).Inc()
-	notificationDeliveryDuration.WithLabelValues(status, subscriptionID).Observe(duration)
-	notificationAttempts.WithLabelValues(status, subscriptionID).Observe(float64(attempts))
+	bucket := subscriptionBucket(subscriptionID)
+	NotificationsDeliveredTotal.WithLabelValues(status, bucket).Inc()
+	notificationDeliveryDuration.WithLabelValues(status).Observe(duration)
+	notificationAttempts.WithLabelValues(status).Observe(float64(attempts))
 }
 
 // RecordNotificationResponseTime records the response time of a webhook endpoint.
 // responseTimeMs is in milliseconds and will be converted to seconds for the metric.
-func RecordNotificationResponseTime(subscriptionID, httpStatus string, responseTimeMs float64) {
-	notificationResponseTime.WithLabelValues(subscriptionID, httpStatus).Observe(responseTimeMs / 1000.0)
+// The subscriptionID is accepted for API compatibility but no longer used as a
+// label value (see issue #497 for cardinality rationale).
+func RecordNotificationResponseTime(_ /* subscriptionID */, httpStatus string, responseTimeMs float64) {
+	notificationResponseTime.WithLabelValues(httpStatus).Observe(responseTimeMs / 1000.0)
 }
 
 // RecordCircuitBreakerState records the state of a circuit breaker.
-// state: 0=closed, 1=half-open, 2=open
+// state: 0=closed, 1=half-open, 2=open. The callback URL is reduced to its
+// host portion before being used as a label value to bound cardinality and
+// prevent leaking customer identifiers embedded in path tokens.
 func RecordCircuitBreakerState(callbackURL string, state float64) {
-	CircuitBreakerState.WithLabelValues(callbackURL).Set(state)
+	CircuitBreakerState.WithLabelValues(callbackHost(callbackURL)).Set(state)
 }
 
 // RecordSubscriptionsMatched records the number of subscriptions matched for an event.

--- a/internal/events/metrics_test.go
+++ b/internal/events/metrics_test.go
@@ -95,26 +95,39 @@ func TestRecordQueueDepth(t *testing.T) {
 }
 
 // TestRecordNotificationDelivered tests the events.RecordNotificationDelivered function.
+// The second label is a bounded 16-bit bucket hash of the subscription ID (see #497);
+// tests assert against hash stability rather than raw IDs.
 func TestRecordNotificationDelivered(t *testing.T) {
 	events.NotificationsDeliveredTotal.Reset()
 
+	sub123Bucket := events.SubscriptionBucketForTest("sub-123")
+	sub456Bucket := events.SubscriptionBucketForTest("sub-456")
+
 	t.Run("records successful delivery", func(t *testing.T) {
 		events.RecordNotificationDelivered("success", "sub-123", 0.5, 1)
-		count := testutil.ToFloat64(events.NotificationsDeliveredTotal.WithLabelValues("success", "sub-123"))
+		count := testutil.ToFloat64(events.NotificationsDeliveredTotal.WithLabelValues("success", sub123Bucket))
 		require.Equal(t, 1.0, count)
 	})
 
 	t.Run("records failed delivery", func(t *testing.T) {
 		events.RecordNotificationDelivered("failed", "sub-123", 1.2, 3)
-		count := testutil.ToFloat64(events.NotificationsDeliveredTotal.WithLabelValues("failed", "sub-123"))
+		count := testutil.ToFloat64(events.NotificationsDeliveredTotal.WithLabelValues("failed", sub123Bucket))
 		require.Equal(t, 1.0, count)
 	})
 
 	t.Run("records multiple deliveries", func(t *testing.T) {
 		events.RecordNotificationDelivered("success", "sub-456", 0.3, 1)
 		events.RecordNotificationDelivered("success", "sub-456", 0.4, 1)
-		count := testutil.ToFloat64(events.NotificationsDeliveredTotal.WithLabelValues("success", "sub-456"))
+		count := testutil.ToFloat64(events.NotificationsDeliveredTotal.WithLabelValues("success", sub456Bucket))
 		require.Equal(t, 2.0, count)
+	})
+
+	t.Run("bucket is deterministic and 16-bit bounded", func(t *testing.T) {
+		// Bucket must be the same for the same input and always 4 hex chars.
+		b1 := events.SubscriptionBucketForTest("sub-stable-id")
+		b2 := events.SubscriptionBucketForTest("sub-stable-id")
+		require.Equal(t, b1, b2)
+		require.Len(t, b1, 4)
 	})
 }
 
@@ -135,34 +148,47 @@ func TestRecordNotificationResponseTime(t *testing.T) {
 }
 
 // TestRecordCircuitBreakerState tests the RecordCircuitBreakerState function.
+// The label is now the host portion of the callback URL (see #497), so URLs
+// sharing a host collapse to a single series while paths (which may embed
+// customer identifiers) are dropped.
 func TestRecordCircuitBreakerState(t *testing.T) {
 	t.Run("records closed state", func(t *testing.T) {
 		events.RecordCircuitBreakerState("http://example.com/callback", 0.0)
-		state := testutil.ToFloat64(events.CircuitBreakerState.WithLabelValues("http://example.com/callback"))
+		state := testutil.ToFloat64(events.CircuitBreakerState.WithLabelValues("example.com"))
 		assert.Equal(t, 0.0, state)
 	})
 
 	t.Run("records half-open state", func(t *testing.T) {
 		events.RecordCircuitBreakerState("http://example.com/callback", 1.0)
-		state := testutil.ToFloat64(events.CircuitBreakerState.WithLabelValues("http://example.com/callback"))
+		state := testutil.ToFloat64(events.CircuitBreakerState.WithLabelValues("example.com"))
 		assert.Equal(t, 1.0, state)
 	})
 
 	t.Run("records open state", func(t *testing.T) {
 		events.RecordCircuitBreakerState("http://example.com/callback", 2.0)
-		state := testutil.ToFloat64(events.CircuitBreakerState.WithLabelValues("http://example.com/callback"))
+		state := testutil.ToFloat64(events.CircuitBreakerState.WithLabelValues("example.com"))
 		assert.Equal(t, 2.0, state)
 	})
 
-	t.Run("tracks multiple callbacks", func(t *testing.T) {
-		events.RecordCircuitBreakerState("http://example.com/callback1", 0.0)
-		events.RecordCircuitBreakerState("http://example.com/callback2", 2.0)
+	t.Run("callbacks with same host collapse to one series", func(t *testing.T) {
+		events.RecordCircuitBreakerState("http://host-a.example.com/callback1", 0.0)
+		events.RecordCircuitBreakerState("http://host-a.example.com/callback2", 2.0)
 
-		state1 := testutil.ToFloat64(events.CircuitBreakerState.WithLabelValues("http://example.com/callback1"))
-		assert.Equal(t, 0.0, state1)
+		// Only one series should exist for host-a.example.com; the second call
+		// overwrites the gauge value set by the first.
+		state := testutil.ToFloat64(events.CircuitBreakerState.WithLabelValues("host-a.example.com"))
+		assert.Equal(t, 2.0, state)
+	})
 
-		state2 := testutil.ToFloat64(events.CircuitBreakerState.WithLabelValues("http://example.com/callback2"))
-		assert.Equal(t, 2.0, state2)
+	t.Run("different hosts produce different series", func(t *testing.T) {
+		events.RecordCircuitBreakerState("http://host-b.example.com/callback", 1.0)
+		events.RecordCircuitBreakerState("http://host-c.example.com/callback", 2.0)
+
+		stateB := testutil.ToFloat64(events.CircuitBreakerState.WithLabelValues("host-b.example.com"))
+		assert.Equal(t, 1.0, stateB)
+
+		stateC := testutil.ToFloat64(events.CircuitBreakerState.WithLabelValues("host-c.example.com"))
+		assert.Equal(t, 2.0, stateC)
 	})
 }
 

--- a/internal/middleware/resource_ratelimit.go
+++ b/internal/middleware/resource_ratelimit.go
@@ -145,8 +145,10 @@ type ResourceRateLimitMetrics struct {
 // ResourceRateLimitHits tracks the total number of resource rate limit hits.
 var ResourceRateLimitHits = promauto.NewCounterVec(
 	prometheus.CounterOpts{
-		Name: "o2ims_resource_rate_limit_hits_total",
-		Help: "Total number of resource rate limit hits",
+		Namespace: "netweave",
+		Subsystem: "ratelimit",
+		Name:      "resource_hits_total",
+		Help:      "Total number of resource rate limit hits",
 	},
 	[]string{"resource_type", "operation", "tenant"},
 )
@@ -154,8 +156,10 @@ var ResourceRateLimitHits = promauto.NewCounterVec(
 // ResourceRateLimitFailOpen tracks when rate limiting fails open due to Redis errors.
 var ResourceRateLimitFailOpen = promauto.NewCounterVec(
 	prometheus.CounterOpts{
-		Name: "o2ims_resource_rate_limit_fail_open_total",
-		Help: "Total number of requests allowed due to rate limit check failures (fail-open behavior)",
+		Namespace: "netweave",
+		Subsystem: "ratelimit",
+		Name:      "resource_fail_open_total",
+		Help:      "Total number of requests allowed due to rate limit check failures (fail-open behavior)",
 	},
 	[]string{"resource_type", "operation", "tenant"},
 )

--- a/internal/observability/README.md
+++ b/internal/observability/README.md
@@ -31,37 +31,37 @@ logger.Info("operation completed",
 Comprehensive metrics for monitoring all gateway operations:
 
 #### HTTP Metrics
-- `o2ims_http_requests_total` - Total HTTP requests by method, path, status
-- `o2ims_http_request_duration_seconds` - Request latency histogram
-- `o2ims_http_requests_in_flight` - Current in-flight requests
-- `o2ims_http_response_size_bytes` - Response size distribution
+- `netweave_http_requests_total` - Total HTTP requests by method, path, status
+- `netweave_http_request_duration_seconds` - Request latency histogram
+- `netweave_http_requests_in_flight` - Current in-flight requests
+- `netweave_http_response_size_bytes` - Response size distribution
 
 #### Adapter Metrics
-- `o2ims_adapter_operations_total` - Total adapter operations by type and status
-- `o2ims_adapter_operation_duration_seconds` - Adapter operation latency
-- `o2ims_adapter_errors_total` - Adapter errors by type
+- `netweave_adapter_operations_total` - Total adapter operations by type and status
+- `netweave_adapter_operation_duration_seconds` - Adapter operation latency
+- `netweave_adapter_errors_total` - Adapter errors by type
 
 #### Subscription Metrics
-- `o2ims_subscriptions_total` - Current active subscriptions (gauge)
-- `o2ims_subscription_events_total` - Subscription events generated
-- `o2ims_webhook_delivery_duration_seconds` - Webhook delivery latency
-- `o2ims_webhook_delivery_total` - Webhook delivery attempts
+- `netweave_subscriptions_total` - Current active subscriptions (gauge)
+- `netweave_subscription_events_total` - Subscription events generated
+- `netweave_webhook_delivery_duration_seconds` - Webhook delivery latency
+- `netweave_webhook_delivery_total` - Webhook delivery attempts
 
 #### Redis Metrics
-- `o2ims_redis_operations_total` - Redis operations by command and status
-- `o2ims_redis_operation_duration_seconds` - Redis operation latency
-- `o2ims_redis_connections_active` - Active Redis connections
-- `o2ims_redis_errors_total` - Redis errors by type
+- `netweave_redis_operations_total` - Redis operations by command and status
+- `netweave_redis_operation_duration_seconds` - Redis operation latency
+- `netweave_redis_connections_active` - Active Redis connections
+- `netweave_redis_errors_total` - Redis errors by type
 
 #### Kubernetes Metrics
-- `o2ims_k8s_operations_total` - Kubernetes API operations
-- `o2ims_k8s_operation_duration_seconds` - K8s API latency
-- `o2ims_k8s_resource_cache_size` - Cached resource counts
-- `o2ims_k8s_errors_total` - K8s API errors
+- `netweave_k8s_operations_total` - Kubernetes API operations
+- `netweave_k8s_operation_duration_seconds` - K8s API latency
+- `netweave_k8s_resource_cache_size` - Cached resource counts
+- `netweave_k8s_errors_total` - K8s API errors
 
 **Usage:**
 ```go
-metrics := observability.InitMetrics("o2ims")
+metrics := observability.InitMetrics("netweave")
 
 // Record HTTP request
 metrics.RecordHTTPRequest("GET", "/api/v1/subscriptions", 200, duration, responseSize)
@@ -161,7 +161,7 @@ func main() {
     }
     defer logger.Sync()
 
-    metrics := observability.InitMetrics("o2ims")
+    metrics := observability.InitMetrics("netweave")
 
     healthChecker := observability.NewHealthChecker(version)
     healthChecker.RegisterReadinessCheck("redis", observability.RedisHealthCheck(pingRedis))

--- a/internal/observability/doc.go
+++ b/internal/observability/doc.go
@@ -27,11 +27,50 @@
 //
 // Initialize metrics once at application startup:
 //
-//	metrics := observability.InitMetrics("o2ims")
+//	metrics := observability.InitMetrics("netweave")
 //
 // Record HTTP request metrics:
 //
 //	metrics.RecordHTTPRequest("GET", "/api/v1/subscriptions", 200, duration, responseSize)
+//
+// # Metric Naming Rule (MANDATORY)
+//
+// All Prometheus metrics emitted by any package in this repository MUST use:
+//
+//	prometheus.CounterOpts{
+//	    Namespace: "netweave",
+//	    Subsystem: "<component>",   // e.g. "auth", "adapter", "webhook", "k8s"
+//	    Name:      "<metric_name>", // lowercase, snake_case, no prefix duplication
+//	    ...
+//	}
+//
+// The resulting exported series name is `netweave_<component>_<metric_name>`.
+//
+// Prohibited:
+//   - Flat names like `Name: "o2ims_webhook_deliveries_total"` without Namespace/Subsystem.
+//   - Unprefixed names like `Name: "api_request_duration_seconds"`.
+//   - Any namespace other than "netweave" in production code.
+//
+// Rationale: a single namespace lets operators query every series with
+// `{__name__=~"netweave_.*"}`, dashboards stay consistent, and naming
+// collisions with third-party exporters are avoided.
+//
+// # Label Cardinality Policy (MANDATORY)
+//
+// Attacker-controlled or high-cardinality values MUST NOT be used as label
+// values. Specifically:
+//
+//   - Subscription IDs → hash to a 16-bit bucket (see events.subscriptionBucket
+//     / workers.SubscriptionBucket / controllers.SubscriptionBucket). Bounded
+//     to 65536 series max per metric.
+//   - Callback URLs → reduce to host portion only (see events.callbackHost).
+//     Path tokens may embed customer identifiers; never expose them via /metrics.
+//   - Tenant IDs → acceptable only where already bounded by authorization
+//     (e.g., small operator-provisioned tenant pool). Avoid for public endpoints.
+//   - Free-form user input (names, URLs, emails) → always reject, hash, or drop.
+//
+// Rationale: Prometheus series are permanent; unbounded label cardinality is
+// both a DoS vector (metrics stack OOM) and a PII leak (public /metrics scrape).
 //
 // Record adapter operations:
 //
@@ -77,7 +116,7 @@
 //	    }
 //	    defer logger.Sync()
 //
-//	    metrics := observability.InitMetrics("o2ims")
+//	    metrics := observability.InitMetrics("netweave")
 //
 //	    healthChecker := observability.NewHealthChecker("v1.0.0")
 //	    healthChecker.RegisterReadinessCheck("redis", observability.RedisHealthCheck(pingRedis))

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -84,11 +84,15 @@ func InitMetricsWithRegistry(namespace string, registerer prometheus.Registerer)
 
 // NewMetrics creates a new Metrics instance with a custom Prometheus registry.
 // This allows tests to create isolated metrics instances without conflicts.
-// The namespace parameter defaults to "o2ims" if empty.
+// The namespace parameter defaults to "netweave" if empty.
 // The registerer parameter should be a prometheus.Registry for tests or prometheus.DefaultRegisterer for production.
+//
+// All metrics constructed here use a meaningful Subsystem so that the final
+// series name is `<namespace>_<subsystem>_<name>` — see
+// internal/observability/doc.go for the project-wide naming rule.
 func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 	if namespace == "" {
-		namespace = "o2ims"
+		namespace = "netweave"
 	}
 
 	factory := promauto.With(registerer)
@@ -98,7 +102,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		HTTPRequestsTotal: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "http_requests_total",
+				Subsystem: "http",
+				Name:      "requests_total",
 				Help:      "Total number of HTTP requests",
 			},
 			[]string{"method", "path", "status"},
@@ -107,7 +112,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		HTTPRequestDuration: factory.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: namespace,
-				Name:      "http_request_duration_seconds",
+				Subsystem: "http",
+				Name:      "request_duration_seconds",
 				Help:      "HTTP request latency in seconds",
 				Buckets:   []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 			},
@@ -117,7 +123,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		HTTPRequestsInFlight: factory.NewGauge(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
-				Name:      "http_requests_in_flight",
+				Subsystem: "http",
+				Name:      "requests_in_flight",
 				Help:      "Number of HTTP requests currently being processed",
 			},
 		),
@@ -125,7 +132,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		HTTPResponseSizeBytes: factory.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: namespace,
-				Name:      "http_response_size_bytes",
+				Subsystem: "http",
+				Name:      "response_size_bytes",
 				Help:      "HTTP response size in bytes",
 				Buckets:   prometheus.ExponentialBuckets(100, 10, 8),
 			},
@@ -136,7 +144,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		AdapterOperationsTotal: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "adapter_operations_total",
+				Subsystem: "adapter",
+				Name:      "operations_total",
 				Help:      "Total number of adapter operations",
 			},
 			[]string{"adapter", "operation", "status"},
@@ -145,7 +154,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		AdapterOperationDuration: factory.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: namespace,
-				Name:      "adapter_operation_duration_seconds",
+				Subsystem: "adapter",
+				Name:      "operation_duration_seconds",
 				Help:      "Adapter operation duration in seconds",
 				Buckets:   []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5},
 			},
@@ -155,7 +165,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		AdapterErrorsTotal: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "adapter_errors_total",
+				Subsystem: "adapter",
+				Name:      "errors_total",
 				Help:      "Total number of adapter errors",
 			},
 			[]string{"adapter", "operation", "error_type"},
@@ -165,7 +176,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		SubscriptionsTotal: factory.NewGauge(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
-				Name:      "subscriptions_total",
+				Subsystem: "subscriptions",
+				Name:      "total",
 				Help:      "Current number of active subscriptions",
 			},
 		),
@@ -173,7 +185,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		SubscriptionEventsTotal: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "subscription_events_total",
+				Subsystem: "subscriptions",
+				Name:      "events_total",
 				Help:      "Total number of subscription events generated",
 			},
 			[]string{"event_type", "resource_type"},
@@ -182,7 +195,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		WebhookDeliveryDuration: factory.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: namespace,
-				Name:      "webhook_delivery_duration_seconds",
+				Subsystem: "webhook",
+				Name:      "delivery_duration_seconds",
 				Help:      "Webhook delivery latency in seconds",
 				Buckets:   []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10, 30},
 			},
@@ -192,7 +206,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		WebhookDeliveryTotal: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "webhook_delivery_total",
+				Subsystem: "webhook",
+				Name:      "delivery_total",
 				Help:      "Total number of webhook delivery attempts",
 			},
 			[]string{"status", "http_status"},
@@ -202,7 +217,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		RedisOperationsTotal: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "redis_operations_total",
+				Subsystem: "redis",
+				Name:      "operations_total",
 				Help:      "Total number of Redis operations",
 			},
 			[]string{"operation", "status"},
@@ -211,7 +227,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		RedisOperationDuration: factory.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: namespace,
-				Name:      "redis_operation_duration_seconds",
+				Subsystem: "redis",
+				Name:      "operation_duration_seconds",
 				Help:      "Redis operation duration in seconds",
 				Buckets:   []float64{.0001, .0005, .001, .005, .01, .025, .05, .1, .25},
 			},
@@ -221,7 +238,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		RedisConnectionsActive: factory.NewGauge(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
-				Name:      "redis_connections_active",
+				Subsystem: "redis",
+				Name:      "connections_active",
 				Help:      "Number of active Redis connections",
 			},
 		),
@@ -229,7 +247,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		RedisErrorsTotal: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "redis_errors_total",
+				Subsystem: "redis",
+				Name:      "errors_total",
 				Help:      "Total number of Redis errors",
 			},
 			[]string{"operation", "error_type"},
@@ -239,7 +258,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		K8sOperationsTotal: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "k8s_operations_total",
+				Subsystem: "k8s",
+				Name:      "operations_total",
 				Help:      "Total number of Kubernetes API operations",
 			},
 			[]string{"operation", "resource", "status"},
@@ -248,7 +268,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		K8sOperationDuration: factory.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: namespace,
-				Name:      "k8s_operation_duration_seconds",
+				Subsystem: "k8s",
+				Name:      "operation_duration_seconds",
 				Help:      "Kubernetes API operation duration in seconds",
 				Buckets:   []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5},
 			},
@@ -258,7 +279,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		K8sResourceCacheSize: factory.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
-				Name:      "k8s_resource_cache_size",
+				Subsystem: "k8s",
+				Name:      "resource_cache_size",
 				Help:      "Number of Kubernetes resources cached",
 			},
 			[]string{"resource_type"},
@@ -267,7 +289,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		K8sErrorsTotal: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "k8s_errors_total",
+				Subsystem: "k8s",
+				Name:      "errors_total",
 				Help:      "Total number of Kubernetes API errors",
 			},
 			[]string{"operation", "resource", "error_type"},
@@ -277,7 +300,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		BatchOperationsTotal: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "batch_operations_total",
+				Subsystem: "batch",
+				Name:      "operations_total",
 				Help:      "Total number of batch operations",
 			},
 			[]string{"operation", "atomic", "status"},
@@ -286,7 +310,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		BatchOperationDuration: factory.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: namespace,
-				Name:      "batch_operation_duration_seconds",
+				Subsystem: "batch",
+				Name:      "operation_duration_seconds",
 				Help:      "Batch operation duration in seconds",
 				Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 10, 30, 60},
 			},
@@ -296,7 +321,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		BatchItemsProcessed: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "batch_items_processed_total",
+				Subsystem: "batch",
+				Name:      "items_processed_total",
 				Help:      "Total number of items processed in batch operations",
 			},
 			[]string{"operation", "status"},
@@ -305,7 +331,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		BatchRollbacksTotal: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "batch_rollbacks_total",
+				Subsystem: "batch",
+				Name:      "rollbacks_total",
 				Help:      "Total number of batch rollbacks",
 			},
 			[]string{"operation", "reason"},
@@ -314,7 +341,8 @@ func NewMetrics(namespace string, registerer prometheus.Registerer) *Metrics {
 		BatchConcurrentWorkers: factory.NewGauge(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
-				Name:      "batch_concurrent_workers",
+				Subsystem: "batch",
+				Name:      "concurrent_workers",
 				Help:      "Number of concurrent workers processing batch items",
 			},
 		),

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -30,7 +30,7 @@ func TestInitMetrics(t *testing.T) {
 func TestInitMetricsDefaultNamespace(t *testing.T) {
 	t.Skip("Skipping TestInitMetricsDefaultNamespace - Prometheus registry conflicts with other tests")
 
-	// Note: This demonstrates that empty namespace defaults to "o2ims"
+	// Note: This demonstrates that empty namespace defaults to "netweave"
 	// metrics := observability.InitMetrics("")
 	// require.NotNil(t, metrics)
 	// assert.NotNil(t, metrics.HTTPRequestsTotal)

--- a/internal/server/smo_routes.go
+++ b/internal/server/smo_routes.go
@@ -24,7 +24,7 @@ var identifierPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$`)
 var (
 	smoWorkflowExecutions = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "smo",
 			Name:      "workflow_executions_total",
 			Help:      "Total number of workflow execution requests",
@@ -34,7 +34,7 @@ var (
 
 	smoAPIRequestDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "smo",
 			Name:      "api_request_duration_seconds",
 			Help:      "Duration of SMO API requests in seconds",
@@ -45,7 +45,7 @@ var (
 
 	smoPluginHealth = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "smo",
 			Name:      "plugin_health",
 			Help:      "Health status of SMO plugins (1=healthy, 0=unhealthy)",
@@ -55,7 +55,7 @@ var (
 
 	smoPluginsRegistered = promauto.NewGauge(
 		prometheus.GaugeOpts{
-			Namespace: "o2ims",
+			Namespace: "netweave",
 			Subsystem: "smo",
 			Name:      "plugins_registered",
 			Help:      "Number of registered SMO plugins",

--- a/internal/workers/README.md
+++ b/internal/workers/README.md
@@ -117,12 +117,15 @@ Failed events are stored in Redis Stream `o2ims:dlq` with:
 
 ## Metrics
 
-- `o2ims_webhook_deliveries_total{subscription_id,status}`: Delivery attempts
-- `o2ims_webhook_latency_seconds{subscription_id}`: Delivery latency
-- `o2ims_webhook_retries_total{subscription_id,attempt}`: Retry count
-- `o2ims_webhook_dlq_total{subscription_id}`: DLQ entries
-- `o2ims_event_stream_length`: Event queue length
-- `o2ims_active_webhook_workers`: Active worker count
+- `netweave_webhook_deliveries_total{subscription_bucket,status}`: Delivery attempts
+- `netweave_webhook_latency_seconds{subscription_bucket}`: Delivery latency
+- `netweave_webhook_retries_total{subscription_bucket,attempt}`: Retry count
+- `netweave_webhook_dlq_total{subscription_bucket}`: DLQ entries
+- `netweave_events_stream_length`: Event queue length
+- `netweave_webhook_active_workers`: Active worker count
+
+`subscription_bucket` is a bounded 16-bit hash of the subscription ID (4
+lowercase hex chars). See `internal/observability/doc.go` for the rationale.
 
 ## HMAC Signature Verification
 

--- a/internal/workers/metrics.go
+++ b/internal/workers/metrics.go
@@ -1,61 +1,100 @@
 package workers
 
 import (
+	"crypto/sha256"
+	"fmt"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// subscriptionBucketMask bounds subscription_bucket to 16 bits (65536 values).
+// The same bucketing function is implemented in internal/events/metrics.go so
+// cross-package series share a label space without introducing an import cycle.
+const subscriptionBucketMask = 0xffff
+
+// SubscriptionBucket returns a deterministic 16-bit bucket identifier for a
+// subscription ID (4-char lowercase hex). This is the label value used for
+// webhook metrics to bound cardinality per issue #497.
+func SubscriptionBucket(subscriptionID string) string {
+	if subscriptionID == "" {
+		return "0000"
+	}
+	sum := sha256.Sum256([]byte(subscriptionID))
+	bucket := (uint16(sum[0])<<8 | uint16(sum[1])) & subscriptionBucketMask
+	return fmt.Sprintf("%04x", bucket)
+}
+
+// All metrics in this file use the canonical Namespace: "netweave", Subsystem:
+// "webhook" (or "events") naming scheme. See internal/observability/doc.go for
+// the project-wide metric naming rule.
+//
+// The subscription_bucket label is a 16-bit hash of the subscription ID (see
+// internal/events/metrics.go:subscriptionBucket); it bounds cardinality to
+// 65536 values regardless of tenant subscription count (#497).
 var (
 	// WebhookDeliveriesTotal tracks the total number of webhook delivery attempts.
 	WebhookDeliveriesTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "o2ims_webhook_deliveries_total",
-			Help: "Total number of webhook delivery attempts",
+			Namespace: "netweave",
+			Subsystem: "webhook",
+			Name:      "deliveries_total",
+			Help:      "Total number of webhook delivery attempts",
 		},
-		[]string{"subscription_id", "status"},
+		[]string{"subscription_bucket", "status"},
 	)
 
 	// WebhookLatency tracks the latency of webhook deliveries.
 	WebhookLatency = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "o2ims_webhook_latency_seconds",
-			Help:    "Webhook delivery latency in seconds",
-			Buckets: []float64{0.1, 0.5, 1, 2, 5, 10},
+			Namespace: "netweave",
+			Subsystem: "webhook",
+			Name:      "latency_seconds",
+			Help:      "Webhook delivery latency in seconds",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10},
 		},
-		[]string{"subscription_id"},
+		[]string{"subscription_bucket"},
 	)
 
 	// WebhookRetriesTotal tracks the total number of webhook delivery retries.
 	WebhookRetriesTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "o2ims_webhook_retries_total",
-			Help: "Total number of webhook delivery retries",
+			Namespace: "netweave",
+			Subsystem: "webhook",
+			Name:      "retries_total",
+			Help:      "Total number of webhook delivery retries",
 		},
-		[]string{"subscription_id", "attempt"},
+		[]string{"subscription_bucket", "attempt"},
 	)
 
 	// DeadLetterQueueTotal tracks the total number of events moved to DLQ.
 	DeadLetterQueueTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "o2ims_webhook_dlq_total",
-			Help: "Total number of events moved to dead letter queue",
+			Namespace: "netweave",
+			Subsystem: "webhook",
+			Name:      "dlq_total",
+			Help:      "Total number of events moved to dead letter queue",
 		},
-		[]string{"subscription_id"},
+		[]string{"subscription_bucket"},
 	)
 
 	// EventStreamLengthGauge tracks the current length of the event stream.
 	EventStreamLengthGauge = promauto.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "o2ims_event_stream_length",
-			Help: "Current length of the event stream in Redis",
+			Namespace: "netweave",
+			Subsystem: "events",
+			Name:      "stream_length",
+			Help:      "Current length of the event stream in Redis",
 		},
 	)
 
 	// ActiveWorkersGauge tracks the current number of active webhook workers.
 	ActiveWorkersGauge = promauto.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "o2ims_active_webhook_workers",
-			Help: "Current number of active webhook worker goroutines",
+			Namespace: "netweave",
+			Subsystem: "webhook",
+			Name:      "active_workers",
+			Help:      "Current number of active webhook worker goroutines",
 		},
 	)
 )

--- a/internal/workers/webhook_worker.go
+++ b/internal/workers/webhook_worker.go
@@ -339,8 +339,10 @@ func (w *WebhookWorker) HandleMessage(ctx context.Context, _ string, msg redis.X
 			zap.String("subscription", event.SubscriptionID),
 			zap.Error(err))
 
-		// Track failed delivery
-		WebhookDeliveriesTotal.WithLabelValues(event.SubscriptionID, "failed").Inc()
+		// Track failed delivery. The subscription ID is hashed to a bounded
+		// 16-bit bucket before being used as a label value; see #497.
+		bucket := SubscriptionBucket(event.SubscriptionID)
+		WebhookDeliveriesTotal.WithLabelValues(bucket, "failed").Inc()
 
 		// Move to dead letter queue
 		if err := w.MoveToDLQ(ctx, &event, msg.ID); err != nil {
@@ -350,8 +352,9 @@ func (w *WebhookWorker) HandleMessage(ctx context.Context, _ string, msg redis.X
 	} else {
 		// Track successful delivery and latency
 		duration := time.Since(startTime).Seconds()
-		WebhookDeliveriesTotal.WithLabelValues(event.SubscriptionID, "success").Inc()
-		WebhookLatency.WithLabelValues(event.SubscriptionID).Observe(duration)
+		bucket := SubscriptionBucket(event.SubscriptionID)
+		WebhookDeliveriesTotal.WithLabelValues(bucket, "success").Inc()
+		WebhookLatency.WithLabelValues(bucket).Observe(duration)
 	}
 
 	// Acknowledge message
@@ -416,8 +419,9 @@ func (w *WebhookWorker) DeliverWithRetries(ctx context.Context, event *controlle
 				zap.Int("attempt", attempt),
 				zap.Duration("backoff", backoff))
 
-			// Track retry
-			WebhookRetriesTotal.WithLabelValues(event.SubscriptionID, fmt.Sprintf("%d", attempt)).Inc()
+			// Track retry. The subscription ID is hashed to a bounded 16-bit bucket.
+			bucket := SubscriptionBucket(event.SubscriptionID)
+			WebhookRetriesTotal.WithLabelValues(bucket, fmt.Sprintf("%d", attempt)).Inc()
 
 			select {
 			case <-time.After(backoff):
@@ -547,8 +551,8 @@ func (w *WebhookWorker) MoveToDLQ(ctx context.Context, event *controllers.Resour
 		zap.String("subscription", event.SubscriptionID),
 		zap.String("message_id", messageID))
 
-	// Track DLQ event
-	DeadLetterQueueTotal.WithLabelValues(event.SubscriptionID).Inc()
+	// Track DLQ event. The subscription ID is hashed to a bounded 16-bit bucket.
+	DeadLetterQueueTotal.WithLabelValues(SubscriptionBucket(event.SubscriptionID)).Inc()
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- All Prometheus metrics renamed to `netweave_{subsystem}_{name}` convention
- Grafana dashboard JSON + Prometheus alert rules updated to match
- `BREAKING_CHANGES.md` documents rename table for operators
- READMEs in observability/workers/controllers packages updated

## Test plan
- [x] `go build ./...`
- [x] Existing metrics tests updated for new names
- [ ] CI green

Resolves #508
Resolves #510
Resolves #522