### PR TITLE
[Refactor] Unify HTTP error responses via internal/httpx (redo of #543)

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+
+	"github.com/piwi3910/netweave/internal/httpx"
 )
 
 // MaxDNLength is the maximum allowed length for a DN string.
@@ -286,11 +288,7 @@ func (m *Middleware) handleOAuth2AuthenticationFailure(
 	RecordAuthenticationAttempt("failed", "oauth2")
 	RecordAuthenticationDuration("failed", time.Since(authStart).Seconds())
 
-	c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-		"error":   "Unauthorized",
-		"message": "Invalid or expired OAuth2 token",
-		"code":    http.StatusUnauthorized,
-	})
+	httpx.AbortWithError(c, http.StatusUnauthorized, "Unauthorized", "Invalid or expired OAuth2 token")
 }
 
 // handleNoAuthMethod handles cases where no valid authentication method was detected.
@@ -304,11 +302,7 @@ func (m *Middleware) handleNoAuthMethod(c *gin.Context, requestID string, authSt
 	RecordAuthenticationAttempt("failed", "none")
 	RecordAuthenticationDuration("failed", time.Since(authStart).Seconds())
 
-	c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-		"error":   "Unauthorized",
-		"message": "Authentication required (mTLS certificate or OAuth2 Bearer token)",
-		"code":    http.StatusUnauthorized,
-	})
+	httpx.AbortWithError(c, http.StatusUnauthorized, "Unauthorized", "Authentication required (mTLS certificate or OAuth2 Bearer token)")
 }
 
 func (m *Middleware) handleMissingCertificate(c *gin.Context, requestID string, authStart time.Time) {
@@ -325,11 +319,7 @@ func (m *Middleware) handleMissingCertificate(c *gin.Context, requestID string, 
 	m.logAuthFailure(c.Request.Context(), c, "", "no client certificate")
 	RecordAuthenticationAttempt("failed", "mtls")
 	RecordAuthenticationDuration("failed", time.Since(authStart).Seconds())
-	c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-		"error":   "Unauthorized",
-		"message": "Client certificate required",
-		"code":    http.StatusUnauthorized,
-	})
+	httpx.AbortWithError(c, http.StatusUnauthorized, "Unauthorized", "Client certificate required")
 }
 
 func (m *Middleware) authenticateAndLoadContext(
@@ -384,9 +374,7 @@ func (m *Middleware) handleAuthenticationError(
 	var aErr *authError
 	if !errors.As(err, &aErr) {
 		RecordAuthenticationDuration("error", time.Since(authStart).Seconds())
-		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-			"error": "InternalError", "message": "Authentication failed", "code": http.StatusInternalServerError,
-		})
+		httpx.AbortWithError(c, http.StatusInternalServerError, "InternalError", "Authentication failed")
 		return
 	}
 
@@ -401,10 +389,7 @@ func (m *Middleware) handleAuthenticationError(
 			m.logAuthFailure(c.Request.Context(), c, subject, "user not found")
 			RecordAuthenticationAttempt("failed", "mtls")
 			RecordAuthenticationDuration("failed", time.Since(authStart).Seconds())
-			c.AbortWithStatusJSON(
-				http.StatusForbidden,
-				gin.H{"error": "Forbidden", "message": "Authentication failed", "code": http.StatusForbidden},
-			)
+			httpx.AbortWithError(c, http.StatusForbidden, "Forbidden", "Authentication failed")
 		} else {
 			m.Logger.Error("failed to lookup user",
 				zap.String("subject", SanitizeForLogging(subject, 200)),
@@ -412,10 +397,7 @@ func (m *Middleware) handleAuthenticationError(
 				zap.String("request_id", requestID),
 			)
 			RecordAuthenticationDuration("error", time.Since(authStart).Seconds())
-			c.AbortWithStatusJSON(
-				http.StatusInternalServerError,
-				gin.H{"error": "InternalError", "message": "Authentication failed", "code": http.StatusInternalServerError},
-			)
+			httpx.AbortWithError(c, http.StatusInternalServerError, "InternalError", "Authentication failed")
 		}
 	case "user_inactive":
 		m.Logger.Warn("inactive user attempted access",
@@ -426,10 +408,7 @@ func (m *Middleware) handleAuthenticationError(
 		m.logAuthFailure(c.Request.Context(), c, subject, "user inactive")
 		RecordAuthenticationAttempt("failed", "mtls")
 		RecordAuthenticationDuration("failed", time.Since(authStart).Seconds())
-		c.AbortWithStatusJSON(
-			http.StatusForbidden,
-			gin.H{"error": "Forbidden", "message": "Authentication failed", "code": http.StatusForbidden},
-		)
+		httpx.AbortWithError(c, http.StatusForbidden, "Forbidden", "Authentication failed")
 	case "role_lookup":
 		m.Logger.Error("failed to get user role",
 			zap.String("user_id", aErr.userID),
@@ -438,13 +417,11 @@ func (m *Middleware) handleAuthenticationError(
 			zap.String("request_id", requestID),
 		)
 		RecordAuthenticationDuration("error", time.Since(authStart).Seconds())
-		c.AbortWithStatusJSON(
+		httpx.AbortWithError(
+			c,
 			http.StatusInternalServerError,
-			gin.H{
-				"error":   "InternalError",
-				"message": "Authentication service temporarily unavailable",
-				"code":    http.StatusInternalServerError,
-			},
+			"InternalError",
+			"Authentication service temporarily unavailable",
 		)
 	case "tenant_lookup":
 		if errors.Is(aErr.err, ErrTenantNotFound) {
@@ -455,10 +432,7 @@ func (m *Middleware) handleAuthenticationError(
 			)
 			RecordAuthenticationAttempt("failed", "mtls")
 			RecordAuthenticationDuration("failed", time.Since(authStart).Seconds())
-			c.AbortWithStatusJSON(
-				http.StatusForbidden,
-				gin.H{"error": "Forbidden", "message": "Authentication failed", "code": http.StatusForbidden},
-			)
+			httpx.AbortWithError(c, http.StatusForbidden, "Forbidden", "Authentication failed")
 		} else {
 			m.Logger.Error("failed to get tenant",
 				zap.String("tenant_id", aErr.tenantID),
@@ -466,13 +440,11 @@ func (m *Middleware) handleAuthenticationError(
 				zap.String("request_id", requestID),
 			)
 			RecordAuthenticationDuration("error", time.Since(authStart).Seconds())
-			c.AbortWithStatusJSON(
+			httpx.AbortWithError(
+				c,
 				http.StatusInternalServerError,
-				gin.H{
-					"error":   "InternalError",
-					"message": "Authentication service temporarily unavailable",
-					"code":    http.StatusInternalServerError,
-				},
+				"InternalError",
+				"Authentication service temporarily unavailable",
 			)
 		}
 	case "tenant_inactive":
@@ -484,10 +456,7 @@ func (m *Middleware) handleAuthenticationError(
 		m.logAuthFailure(c.Request.Context(), c, subject, "tenant suspended")
 		RecordAuthenticationAttempt("failed", "mtls")
 		RecordAuthenticationDuration("failed", time.Since(authStart).Seconds())
-		c.AbortWithStatusJSON(
-			http.StatusForbidden,
-			gin.H{"error": "Forbidden", "message": "Tenant is suspended", "code": http.StatusForbidden},
-		)
+		httpx.AbortWithError(c, http.StatusForbidden, "Forbidden", "Tenant is suspended")
 	}
 }
 
@@ -556,11 +525,7 @@ func (m *Middleware) RequirePermission(permission string) gin.HandlerFunc {
 				zap.String("path", c.Request.URL.Path),
 				zap.String("request_id", requestID),
 			)
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"error":   "Unauthorized",
-				"message": "Authentication required",
-				"code":    http.StatusUnauthorized,
-			})
+			httpx.AbortWithError(c, http.StatusUnauthorized, "Unauthorized", "Authentication required")
 			return
 		}
 
@@ -576,11 +541,7 @@ func (m *Middleware) RequirePermission(permission string) gin.HandlerFunc {
 
 			m.logAccessDenied(ctx, c, user, Permission(permission))
 			RecordAuthorizationCheck("denied", Permission(permission))
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error":   "Forbidden",
-				"message": "Insufficient permissions for this operation",
-				"code":    http.StatusForbidden,
-			})
+			httpx.AbortWithError(c, http.StatusForbidden, "Forbidden", "Insufficient permissions for this operation")
 			return
 		}
 
@@ -597,11 +558,7 @@ func (m *Middleware) RequireAnyPermission(permissions ...Permission) gin.Handler
 
 		user := UserFromContext(c.Request.Context())
 		if user == nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"error":   "Unauthorized",
-				"message": "Authentication required",
-				"code":    http.StatusUnauthorized,
-			})
+			httpx.AbortWithError(c, http.StatusUnauthorized, "Unauthorized", "Authentication required")
 			return
 		}
 
@@ -619,11 +576,7 @@ func (m *Middleware) RequireAnyPermission(permissions ...Permission) gin.Handler
 			zap.String("request_id", requestID),
 		)
 
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-			"error":   "Forbidden",
-			"message": "Insufficient permissions",
-			"code":    http.StatusForbidden,
-		})
+		httpx.AbortWithError(c, http.StatusForbidden, "Forbidden", "Insufficient permissions")
 	}
 }
 
@@ -634,11 +587,7 @@ func (m *Middleware) RequirePlatformAdmin() gin.HandlerFunc {
 
 		user := UserFromContext(c.Request.Context())
 		if user == nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"error":   "Unauthorized",
-				"message": "Authentication required",
-				"code":    http.StatusUnauthorized,
-			})
+			httpx.AbortWithError(c, http.StatusUnauthorized, "Unauthorized", "Authentication required")
 			return
 		}
 
@@ -650,11 +599,7 @@ func (m *Middleware) RequirePlatformAdmin() gin.HandlerFunc {
 				zap.String("request_id", requestID),
 			)
 
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error":   "Forbidden",
-				"message": "Platform administrator access required",
-				"code":    http.StatusForbidden,
-			})
+			httpx.AbortWithError(c, http.StatusForbidden, "Forbidden", "Platform administrator access required")
 			return
 		}
 
@@ -671,11 +616,7 @@ func (m *Middleware) RequireTenantAccess(tenantIDParam string) gin.HandlerFunc {
 
 		user := UserFromContext(c.Request.Context())
 		if user == nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"error":   "Unauthorized",
-				"message": "Authentication required",
-				"code":    http.StatusUnauthorized,
-			})
+			httpx.AbortWithError(c, http.StatusUnauthorized, "Unauthorized", "Authentication required")
 			return
 		}
 
@@ -695,11 +636,7 @@ func (m *Middleware) RequireTenantAccess(tenantIDParam string) gin.HandlerFunc {
 				zap.String("request_id", requestID),
 			)
 
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error":   "Forbidden",
-				"message": "Access to other tenants is not allowed",
-				"code":    http.StatusForbidden,
-			})
+			httpx.AbortWithError(c, http.StatusForbidden, "Forbidden", "Access to other tenants is not allowed")
 			return
 		}
 

--- a/internal/certlifecycle/handler.go
+++ b/internal/certlifecycle/handler.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
+
+	"github.com/piwi3910/netweave/internal/httpx"
 )
 
 // Handler provides HTTP endpoints for certificate lifecycle queries.
@@ -56,9 +58,7 @@ func (h *Handler) listCertificates(c *gin.Context) {
 	if err != nil {
 		h.logger.Error("failed to list certificates",
 			zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "failed to list certificates",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "failed to list certificates")
 		return
 	}
 
@@ -76,9 +76,7 @@ func (h *Handler) monitoringStats(c *gin.Context) {
 	if err != nil {
 		h.logger.Error("failed to get monitoring stats",
 			zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "failed to get monitoring stats",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "failed to get monitoring stats")
 		return
 	}
 
@@ -95,17 +93,13 @@ func (h *Handler) getCertificate(c *gin.Context) {
 	meta, err := h.store.Get(ctx, serial)
 	if err != nil {
 		if errors.Is(err, ErrCertificateNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error": "certificate not found",
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "certificate not found")
 			return
 		}
 		h.logger.Error("failed to get certificate",
 			zap.String("serial", serial),
 			zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "failed to get certificate",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "failed to get certificate")
 		return
 	}
 

--- a/internal/certlifecycle/handler_test.go
+++ b/internal/certlifecycle/handler_test.go
@@ -179,7 +179,8 @@ func TestHandler_GetCertificate_NotFound(t *testing.T) {
 	var resp map[string]interface{}
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	assert.Equal(t, "certificate not found", resp["error"])
+	assert.Equal(t, "NotFound", resp["error"])
+	assert.Equal(t, "certificate not found", resp["message"])
 }
 
 func TestHandler_MonitoringStats(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,12 @@ const (
 	DefaultConfigPath = "config/config.yaml"
 )
 
+// Storage mode identifiers.
+const (
+	storageModePostgres = "postgres"
+	storageModeDual     = "dual"
+)
+
 // Config represents the complete configuration for the O2-IMS Gateway.
 // It includes server settings, Redis configuration, Kubernetes client config,
 // TLS/mTLS settings, and observability options.
@@ -1206,7 +1212,7 @@ func (c *Config) validateProductionRules() error {
 	}
 
 	// Postgres must not fall through to plaintext in production.
-	if c.StorageMode == "postgres" || c.StorageMode == "dual" {
+	if c.StorageMode == storageModePostgres || c.StorageMode == storageModeDual {
 		if err := c.Postgres.ValidateForProduction(); err != nil {
 			return fmt.Errorf("postgres config invalid for production: %w", err)
 		}
@@ -1514,7 +1520,7 @@ func (c *Config) validateStorageMode() error {
 		return fmt.Errorf("storage_mode: '%s' (must be 'redis', 'postgres', or 'dual')", c.StorageMode)
 	}
 
-	if c.StorageMode == "postgres" || c.StorageMode == "dual" {
+	if c.StorageMode == storageModePostgres || c.StorageMode == storageModeDual {
 		if err := c.Postgres.Validate(); err != nil {
 			return fmt.Errorf("postgres config: %w", err)
 		}

--- a/internal/controllers/subscription_controller_cancel_test.go
+++ b/internal/controllers/subscription_controller_cancel_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -18,7 +19,7 @@ import (
 )
 
 // cancelBlockingStore is a storage.Store whose List blocks until its own
-// context is cancelled. It exposes channels so tests can synchronize on
+// context is canceled. It exposes channels so tests can synchronize on
 // "in-flight work started" and "work released".
 type cancelBlockingStore struct {
 	entered  chan struct{}
@@ -53,7 +54,7 @@ func (b *cancelBlockingStore) List(ctx context.Context) ([]*storage.Subscription
 	case <-ctx.Done():
 		b.listErr = ctx.Err()
 		close(b.released)
-		return nil, ctx.Err()
+		return nil, fmt.Errorf("cancelBlockingStore List: %w", ctx.Err())
 	case <-time.After(10 * time.Second):
 		// Safety net: if cancellation never arrives we still return so
 		// the test fails deterministically rather than hangs.
@@ -78,7 +79,7 @@ func (b *cancelBlockingStore) Close() error { return nil }
 
 func (b *cancelBlockingStore) Ping(_ context.Context) error { return nil }
 
-// TestHandleNodeAddUnwindsOnCancel verifies the fix for H14: cancelling the
+// TestHandleNodeAddUnwindsOnCancel verifies the fix for H14: canceling the
 // controller-scoped context unwinds in-flight informer-handler work promptly
 // instead of blocking until pod termination.
 func TestHandleNodeAddUnwindsOnCancel(t *testing.T) {
@@ -114,7 +115,7 @@ func TestHandleNodeAddUnwindsOnCancel(t *testing.T) {
 
 	// Kick off the informer handler. It derives a bounded child of the
 	// controller ctx and calls Store.List, which blocks until ctx is
-	// cancelled.
+	// canceled.
 	handlerDone := make(chan struct{})
 	go func() {
 		ctrl.handleNodeAdd(&corev1.Node{

--- a/internal/database/config.go
+++ b/internal/database/config.go
@@ -30,7 +30,8 @@ const DefaultSSLMode = SSLModeVerifyFull
 // Both modes allow the client to fall through to a plaintext connection, which
 // is unacceptable for production data.
 var ErrInsecureSSLModeInProduction = errors.New(
-	"postgres sslmode 'disable' and 'prefer' are not permitted in production; use 'require', 'verify-ca', or 'verify-full'",
+	"postgres sslmode 'disable' and 'prefer' are not permitted in production; " +
+		"use 'require', 'verify-ca', or 'verify-full'",
 )
 
 // PostgresConfig holds PostgreSQL connection parameters.

--- a/internal/database/coverage_test.go
+++ b/internal/database/coverage_test.go
@@ -96,9 +96,9 @@ func TestConnectionString_AllDefaults(t *testing.T) {
 		Database: "mydb",
 		User:     "myuser",
 	}
-	// Port defaults to 5432, SSLMode defaults to "prefer".
+	// Port defaults to 5432, SSLMode defaults to "verify-full".
 	result := cfg.ConnectionString("pw")
-	assert.Equal(t, "postgres://myuser:pw@myhost:5432/mydb?sslmode=prefer", result)
+	assert.Equal(t, "postgres://myuser:pw@myhost:5432/mydb?sslmode=verify-full", result)
 }
 
 // TestConnectionString_CustomPort tests ConnectionString with a custom port.

--- a/internal/database/postgres_test.go
+++ b/internal/database/postgres_test.go
@@ -223,7 +223,7 @@ func TestConnectionString(t *testing.T) {
 				User:     "admin",
 			},
 			password: "pw",
-			want:     "postgres://admin:pw@localhost:5432/netweave?sslmode=prefer",
+			want:     "postgres://admin:pw@localhost:5432/netweave?sslmode=verify-full",
 		},
 	}
 

--- a/internal/events/generator_race_test.go
+++ b/internal/events/generator_race_test.go
@@ -57,7 +57,7 @@ func TestK8sEventGeneratorStartStopNoRace(t *testing.T) {
 		// the pre-fix race would panic on close.
 		time.Sleep(5 * time.Millisecond)
 
-		// Stop before cancelling the ctx. This is the critical order
+		// Stop before canceling the ctx. This is the critical order
 		// for the regression: Stop must wait for the goroutine to exit
 		// before closing eventChannel.
 		if err := gen.Stop(); err != nil {

--- a/internal/handlers/plugin_handler.go
+++ b/internal/handlers/plugin_handler.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
+
+	"github.com/piwi3910/netweave/internal/httpx"
 )
 
 // FrontendPluginInfo represents a frontend plugin for API responses.
@@ -56,10 +58,7 @@ func (h *PluginHandler) GetPlugin(c *gin.Context) {
 
 	plugin, err := h.registry.Get(name)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{
-			"error":   "NotFound",
-			"message": "Plugin not found: " + name,
-		})
+		httpx.WriteError(c, http.StatusNotFound, "NotFound", "Plugin not found: "+name)
 		return
 	}
 
@@ -78,28 +77,19 @@ func (h *PluginHandler) UpdatePlugin(c *gin.Context) {
 
 	var req pluginUpdateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": "Invalid request body",
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", "Invalid request body")
 		return
 	}
 
 	if req.Enabled {
 		if err := h.registry.Enable(name); err != nil {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Plugin not found: " + name,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Plugin not found: "+name)
 			return
 		}
 		h.logger.Info("frontend plugin enabled", zap.String("plugin", name))
 	} else {
 		if err := h.registry.Disable(name); err != nil {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Plugin not found: " + name,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Plugin not found: "+name)
 			return
 		}
 		h.logger.Info("frontend plugin disabled", zap.String("plugin", name))
@@ -108,10 +98,7 @@ func (h *PluginHandler) UpdatePlugin(c *gin.Context) {
 	// Return the updated plugin state.
 	plugin, err := h.registry.Get(name)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to retrieve plugin after update",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve plugin after update")
 		return
 	}
 

--- a/internal/handlers/tmforum_handler.go
+++ b/internal/handlers/tmforum_handler.go
@@ -10,6 +10,7 @@ import (
 	imsadapter "github.com/piwi3910/netweave/internal/adapter"
 	dmsadapter "github.com/piwi3910/netweave/internal/dms/adapter"
 	"github.com/piwi3910/netweave/internal/dms/registry"
+	"github.com/piwi3910/netweave/internal/httpx"
 	"github.com/piwi3910/netweave/internal/models"
 	"github.com/piwi3910/netweave/internal/storage"
 	"go.uber.org/zap"
@@ -101,10 +102,7 @@ func (h *TMForumHandler) ListTMF639Resources(c *gin.Context) {
 			h.logger.Error("failed to list resource pools",
 				zap.Error(err),
 			)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":   "InternalError",
-				"message": "Failed to retrieve resource pools",
-			})
+			httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve resource pools")
 			return
 		}
 
@@ -121,10 +119,7 @@ func (h *TMForumHandler) ListTMF639Resources(c *gin.Context) {
 			h.logger.Error("failed to list resources",
 				zap.Error(err),
 			)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":   "InternalError",
-				"message": "Failed to retrieve resources",
-			})
+			httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve resources")
 			return
 		}
 
@@ -158,10 +153,7 @@ func (h *TMForumHandler) GetTMF639Resource(c *gin.Context) {
 	resource, err := adp.GetResource(ctx, resourceID)
 	if err != nil {
 		if errors.Is(err, imsadapter.ErrResourceNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": fmt.Sprintf("Resource with ID '%s' not found", resourceID),
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Resource with ID '%s' not found", resourceID))
 			return
 		}
 
@@ -169,10 +161,7 @@ func (h *TMForumHandler) GetTMF639Resource(c *gin.Context) {
 			zap.String("resource_id", resourceID),
 			zap.Error(err),
 		)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to retrieve resource",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve resource")
 		return
 	}
 
@@ -188,10 +177,7 @@ func (h *TMForumHandler) CreateTMF639Resource(c *gin.Context) {
 
 	var createReq models.TMF639ResourceCreate
 	if err := c.ShouldBindJSON(&createReq); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": fmt.Sprintf("Invalid request body: %v", err),
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", fmt.Sprintf("Invalid request body: %v", err))
 		return
 	}
 
@@ -226,10 +212,7 @@ func (h *TMForumHandler) CreateTMF639Resource(c *gin.Context) {
 			h.logger.Error("failed to create resource pool",
 				zap.Error(err),
 			)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":   "InternalError",
-				"message": "Failed to create resource pool",
-			})
+			httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to create resource pool")
 			return
 		}
 
@@ -244,10 +227,7 @@ func (h *TMForumHandler) CreateTMF639Resource(c *gin.Context) {
 			h.logger.Error("failed to create resource",
 				zap.Error(err),
 			)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":   "InternalError",
-				"message": "Failed to create resource",
-			})
+			httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to create resource")
 			return
 		}
 
@@ -265,10 +245,7 @@ func (h *TMForumHandler) UpdateTMF639Resource(c *gin.Context) {
 
 	var updateReq models.TMF639ResourceUpdate
 	if err := c.ShouldBindJSON(&updateReq); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": fmt.Sprintf("Invalid request body: %v", err),
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", fmt.Sprintf("Invalid request body: %v", err))
 		return
 	}
 
@@ -285,10 +262,7 @@ func (h *TMForumHandler) UpdateTMF639Resource(c *gin.Context) {
 				zap.String("category_resource_pool_id", resourceID),
 				zap.Error(err),
 			)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":   "InternalError",
-				"message": "Failed to update resource pool",
-			})
+			httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to update resource pool")
 			return
 		}
 
@@ -298,10 +272,7 @@ func (h *TMForumHandler) UpdateTMF639Resource(c *gin.Context) {
 	}
 
 	// Resource pool not found, return 404
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "NotFound",
-		"message": fmt.Sprintf("Resource with ID '%s' not found", resourceID),
-	})
+	httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Resource with ID '%s' not found", resourceID))
 }
 
 // DeleteTMF639Resource deletes a TMF639 resource.
@@ -322,10 +293,7 @@ func (h *TMForumHandler) DeleteTMF639Resource(c *gin.Context) {
 	err = adp.DeleteResource(ctx, resourceID)
 	if err != nil {
 		if errors.Is(err, imsadapter.ErrResourceNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": fmt.Sprintf("Resource with ID '%s' not found", resourceID),
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Resource with ID '%s' not found", resourceID))
 			return
 		}
 
@@ -333,10 +301,7 @@ func (h *TMForumHandler) DeleteTMF639Resource(c *gin.Context) {
 			zap.String("resource_id", resourceID),
 			zap.Error(err),
 		)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to delete resource",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to delete resource")
 		return
 	}
 
@@ -398,10 +363,7 @@ func (h *TMForumHandler) GetTMF638Service(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "NotFound",
-		"message": fmt.Sprintf("Service with ID '%s' not found", serviceID),
-	})
+	httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Service with ID '%s' not found", serviceID))
 }
 
 // CreateTMF638Service creates a new TMF638 service (deploys via O2-DMS).
@@ -412,10 +374,7 @@ func (h *TMForumHandler) CreateTMF638Service(c *gin.Context) {
 
 	var createReq models.TMF638ServiceCreate
 	if err := c.ShouldBindJSON(&createReq); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": fmt.Sprintf("Invalid request body: %v", err),
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", fmt.Sprintf("Invalid request body: %v", err))
 		return
 	}
 
@@ -428,10 +387,7 @@ func (h *TMForumHandler) CreateTMF638Service(c *gin.Context) {
 	dmsAdapter := dmsReg.GetDefault()
 	if dmsAdapter == nil {
 		h.logger.Error("no default DMS adapter available")
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "No DMS adapter available for deployment",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "No DMS adapter available for deployment")
 		return
 	}
 
@@ -440,10 +396,7 @@ func (h *TMForumHandler) CreateTMF638Service(c *gin.Context) {
 		h.logger.Error("failed to create deployment",
 			zap.Error(err),
 		)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to create service",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to create service")
 		return
 	}
 
@@ -460,10 +413,7 @@ func (h *TMForumHandler) UpdateTMF638Service(c *gin.Context) {
 
 	var updateReq models.TMF638ServiceUpdate
 	if err := c.ShouldBindJSON(&updateReq); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": fmt.Sprintf("Invalid request body: %v", err),
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", fmt.Sprintf("Invalid request body: %v", err))
 		return
 	}
 
@@ -488,10 +438,7 @@ func (h *TMForumHandler) UpdateTMF638Service(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "NotFound",
-		"message": fmt.Sprintf("Service with ID '%s' not found", serviceID),
-	})
+	httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Service with ID '%s' not found", serviceID))
 }
 
 // DeleteTMF638Service deletes a TMF638 service (undeploys via O2-DMS).
@@ -511,10 +458,7 @@ func (h *TMForumHandler) DeleteTMF638Service(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "NotFound",
-		"message": fmt.Sprintf("Service with ID '%s' not found", serviceID),
-	})
+	httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Service with ID '%s' not found", serviceID))
 }
 
 // ========================================
@@ -585,10 +529,7 @@ func (h *TMForumHandler) GetTMF641ServiceOrder(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "NotFound",
-		"message": fmt.Sprintf("Service order with ID '%s' not found", orderID),
-	})
+	httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Service order with ID '%s' not found", orderID))
 }
 
 // CreateTMF641ServiceOrder creates a new TMF641 service order.
@@ -599,10 +540,7 @@ func (h *TMForumHandler) CreateTMF641ServiceOrder(c *gin.Context) {
 
 	var createReq models.TMF641ServiceOrderCreate
 	if err := c.ShouldBindJSON(&createReq); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": fmt.Sprintf("Invalid request body: %v", err),
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", fmt.Sprintf("Invalid request body: %v", err))
 		return
 	}
 
@@ -610,10 +548,7 @@ func (h *TMForumHandler) CreateTMF641ServiceOrder(c *gin.Context) {
 
 	// Validate service order items
 	if len(createReq.ServiceOrderItem) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": "Service order must contain at least one item",
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", "Service order must contain at least one item")
 		return
 	}
 
@@ -621,10 +556,7 @@ func (h *TMForumHandler) CreateTMF641ServiceOrder(c *gin.Context) {
 	dmsAdapter := dmsReg.GetDefault()
 	if dmsAdapter == nil {
 		h.logger.Error("no default DMS adapter available")
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "No DMS adapter available for service ordering",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "No DMS adapter available for service ordering")
 		return
 	}
 
@@ -639,10 +571,7 @@ func (h *TMForumHandler) CreateTMF641ServiceOrder(c *gin.Context) {
 		h.logger.Error("failed to create deployment for service order",
 			zap.Error(err),
 		)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to create service order",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to create service order")
 		return
 	}
 
@@ -659,10 +588,7 @@ func (h *TMForumHandler) UpdateTMF641ServiceOrder(c *gin.Context) {
 
 	var updateReq models.TMF641ServiceOrderUpdate
 	if err := c.ShouldBindJSON(&updateReq); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": fmt.Sprintf("Invalid request body: %v", err),
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", fmt.Sprintf("Invalid request body: %v", err))
 		return
 	}
 
@@ -685,10 +611,7 @@ func (h *TMForumHandler) UpdateTMF641ServiceOrder(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "NotFound",
-		"message": fmt.Sprintf("Service order with ID '%s' not found", orderID),
-	})
+	httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Service order with ID '%s' not found", orderID))
 }
 
 // DeleteTMF641ServiceOrder deletes (cancels) a TMF641 service order.
@@ -708,10 +631,7 @@ func (h *TMForumHandler) DeleteTMF641ServiceOrder(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "NotFound",
-		"message": fmt.Sprintf("Service order with ID '%s' not found", orderID),
-	})
+	httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Service order with ID '%s' not found", orderID))
 }
 
 // ========================================
@@ -733,10 +653,7 @@ func (h *TMForumHandler) GetTMF688Event(c *gin.Context) {
 	eventID := c.Param("id")
 
 	// Events are typically not stored
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "NotFound",
-		"message": fmt.Sprintf("Event with ID '%s' not found", eventID),
-	})
+	httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Event with ID '%s' not found", eventID))
 }
 
 // CreateTMF688Event creates a new TMF688 event (typically for testing).
@@ -744,19 +661,13 @@ func (h *TMForumHandler) GetTMF688Event(c *gin.Context) {
 func (h *TMForumHandler) CreateTMF688Event(c *gin.Context) {
 	var createReq models.TMF688EventCreate
 	if err := c.ShouldBindJSON(&createReq); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": fmt.Sprintf("Invalid request body: %v", err),
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", fmt.Sprintf("Invalid request body: %v", err))
 		return
 	}
 
 	// In a real implementation, this would publish the event to subscribers
 	// For now, return 501 Not Implemented
-	c.JSON(http.StatusNotImplemented, gin.H{
-		"error":   "NotImplemented",
-		"message": "Event creation not yet implemented",
-	})
+	httpx.WriteError(c, http.StatusNotImplemented, "NotImplemented", "Event creation not yet implemented")
 }
 
 // RegisterTMF688Hub registers a hub for event notifications.
@@ -767,10 +678,7 @@ func (h *TMForumHandler) RegisterTMF688Hub(c *gin.Context) {
 
 	var hubReq models.TMF688HubCreate
 	if err := c.ShouldBindJSON(&hubReq); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": fmt.Sprintf("Invalid request body: %v", err),
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", fmt.Sprintf("Invalid request body: %v", err))
 		return
 	}
 
@@ -780,10 +688,7 @@ func (h *TMForumHandler) RegisterTMF688Hub(c *gin.Context) {
 		h.logger.Warn("invalid TMF688 query",
 			zap.String("query", hubReq.Query),
 			zap.Error(err))
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": fmt.Sprintf("Invalid query format: %v", err),
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", fmt.Sprintf("Invalid query format: %v", err))
 		return
 	}
 
@@ -799,10 +704,7 @@ func (h *TMForumHandler) RegisterTMF688Hub(c *gin.Context) {
 		h.logger.Error("failed to create O2-IMS subscription",
 			zap.String("callback", hubReq.Callback),
 			zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to create subscription",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to create subscription")
 		return
 	}
 
@@ -831,10 +733,7 @@ func (h *TMForumHandler) RegisterTMF688Hub(c *gin.Context) {
 				zap.Error(delErr))
 		}
 
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to save hub registration",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to save hub registration")
 		return
 	}
 
@@ -866,18 +765,12 @@ func (h *TMForumHandler) UnregisterTMF688Hub(c *gin.Context) {
 	registration, err := h.hubStore.Get(ctx, hubID)
 	if err != nil {
 		if errors.Is(err, storage.ErrHubNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": fmt.Sprintf("Hub with ID '%s' not found", hubID),
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Hub with ID '%s' not found", hubID))
 		} else {
 			h.logger.Error("failed to retrieve hub registration",
 				zap.String("hub_id", hubID),
 				zap.Error(err))
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":   "InternalError",
-				"message": "Failed to retrieve hub registration",
-			})
+			httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve hub registration")
 		}
 		return
 	}
@@ -896,10 +789,7 @@ func (h *TMForumHandler) UnregisterTMF688Hub(c *gin.Context) {
 		h.logger.Error("failed to delete hub registration",
 			zap.String("hub_id", hubID),
 			zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to delete hub registration",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to delete hub registration")
 		return
 	}
 
@@ -938,10 +828,7 @@ func (h *TMForumHandler) GetTMF642Alarm(c *gin.Context) {
 	alarmID := c.Param("id")
 
 	// In a real implementation, this would fetch the alarm from monitoring
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "NotFound",
-		"message": fmt.Sprintf("Alarm with ID '%s' not found", alarmID),
-	})
+	httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Alarm with ID '%s' not found", alarmID))
 }
 
 // AcknowledgeTMF642Alarm acknowledges an alarm.
@@ -953,10 +840,7 @@ func (h *TMForumHandler) AcknowledgeTMF642Alarm(c *gin.Context) {
 		State string `json:"state"`
 	}
 	if err := c.ShouldBindJSON(&updateReq); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": fmt.Sprintf("Invalid request body: %v", err),
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", fmt.Sprintf("Invalid request body: %v", err))
 		return
 	}
 
@@ -965,10 +849,7 @@ func (h *TMForumHandler) AcknowledgeTMF642Alarm(c *gin.Context) {
 		zap.String("state", updateReq.State),
 	)
 
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "NotFound",
-		"message": fmt.Sprintf("Alarm with ID '%s' not found", alarmID),
-	})
+	httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Alarm with ID '%s' not found", alarmID))
 }
 
 // ClearTMF642Alarm clears an alarm.
@@ -1038,19 +919,13 @@ func (h *TMForumHandler) GetTMF640ServiceActivation(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "NotFound",
-		"message": fmt.Sprintf("Service activation with ID '%s' not found", activationID),
-	})
+	httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Service activation with ID '%s' not found", activationID))
 }
 
 // CreateTMF640ServiceActivation creates a new service activation request.
 // POST /tmf-api/serviceActivation/v4/serviceActivation.
 func (h *TMForumHandler) CreateTMF640ServiceActivation(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, gin.H{
-		"error":   "NotImplemented",
-		"message": "Service activation creation not yet implemented",
-	})
+	httpx.WriteError(c, http.StatusNotImplemented, "NotImplemented", "Service activation creation not yet implemented")
 }
 
 // ========================================
@@ -1108,10 +983,7 @@ func (h *TMForumHandler) GetTMF620ProductOffering(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusNotFound, gin.H{
-		"error":   "NotFound",
-		"message": fmt.Sprintf("Product offering with ID '%s' not found", offeringID),
-	})
+	httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Product offering with ID '%s' not found", offeringID))
 }
 
 // ========================================

--- a/internal/httpx/doc.go
+++ b/internal/httpx/doc.go
@@ -1,0 +1,48 @@
+// Package httpx provides HTTP response helpers for the O2-IMS Gateway.
+//
+// # Standard Error Response Contract
+//
+// All HTTP error responses across the gateway MUST use the shape defined by
+// [github.com/piwi3910/netweave/internal/o2ims/models.ErrorResponse]. Helpers
+// in this package are the canonical way to produce that shape; handlers should
+// never build error bodies ad-hoc via [gin.H] literals.
+//
+// The on-the-wire JSON shape is:
+//
+//	{
+//	  "error":   "<short machine-readable code>",
+//	  "message": "<human-readable description>",
+//	  "code":    <numeric HTTP status>
+//	}
+//
+// Fields:
+//   - error:   A short PascalCase code such as "NotFound", "BadRequest",
+//     "Unauthorized", "Forbidden", "Conflict", "InternalError",
+//     "ServiceUnavailable", "ValidationError", "NotImplemented".
+//     Clients may rely on this value for programmatic branching.
+//   - message: A human-readable description safe to display to operators.
+//     Callers MUST NOT include secrets, tokens, or PII.
+//   - code:    The numeric HTTP status code, duplicated in the body for
+//     O2-IMS spec compliance and to ease client-side logging.
+//
+// # Usage
+//
+// Prefer [WriteError] for ordinary error responses:
+//
+//	httpx.WriteError(c, http.StatusNotFound, "NotFound", "resource not found")
+//
+// Use [AbortWithError] from middleware or when the gin chain must be halted:
+//
+//	httpx.AbortWithError(c, http.StatusUnauthorized, "Unauthorized", "invalid token")
+//
+// Both helpers emit [models.ErrorResponse] with the HTTP status copied into
+// the body's Code field, guaranteeing the canonical shape.
+//
+// # Rationale
+//
+// Prior to the introduction of this package, some call sites emitted
+// [gin.H]{"error": ..., "message": ...} while others emitted
+// [models.ErrorResponse]{Error, Message, Code}. This divergence forced
+// clients to special-case certain endpoints and broke OpenAPI contract
+// compliance. Centralizing error generation eliminates that drift.
+package httpx

--- a/internal/httpx/error.go
+++ b/internal/httpx/error.go
@@ -1,0 +1,41 @@
+package httpx
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/piwi3910/netweave/internal/o2ims/models"
+)
+
+// WriteError sends a standardized JSON error response using the canonical
+// models.ErrorResponse shape and sets the HTTP status to status.
+//
+// The status argument is the HTTP status code (e.g. http.StatusNotFound) and
+// will be copied into the body's Code field; callers do not need to specify
+// it twice. The code argument is the short machine-readable error code (e.g.
+// "NotFound", "BadRequest"). The msg argument is a human-readable description
+// that must not contain secrets.
+//
+// See the package-level documentation for the full contract.
+func WriteError(c *gin.Context, status int, code, msg string) {
+	c.JSON(status, models.ErrorResponse{
+		Error:   code,
+		Message: msg,
+		Code:    status,
+	})
+}
+
+// AbortWithError aborts the gin handler chain and sends a standardized JSON
+// error response using the canonical models.ErrorResponse shape.
+//
+// It behaves like WriteError but additionally calls c.AbortWithStatusJSON so
+// subsequent handlers in the chain are skipped. Use this from middleware or
+// whenever rejecting a request that must not reach downstream handlers.
+//
+// See the package-level documentation for the full contract.
+func AbortWithError(c *gin.Context, status int, code, msg string) {
+	c.AbortWithStatusJSON(status, models.ErrorResponse{
+		Error:   code,
+		Message: msg,
+		Code:    status,
+	})
+}

--- a/internal/httpx/error_test.go
+++ b/internal/httpx/error_test.go
@@ -1,0 +1,154 @@
+package httpx_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/httpx"
+	"github.com/piwi3910/netweave/internal/o2ims/models"
+)
+
+// newTestContext returns a gin context with a recorder, keeping gin in
+// TestMode so we don't pollute stdout with debug logs.
+func newTestContext() (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	return c, rec
+}
+
+// errorCase describes one expected (status, code, message) triple.
+type errorCase struct {
+	name    string
+	status  int
+	code    string
+	message string
+}
+
+// standardErrorCases covers the full range of HTTP statuses emitted by the
+// gateway. The golden-file test below asserts that every status produces the
+// canonical models.ErrorResponse shape.
+func standardErrorCases() []errorCase {
+	return []errorCase{
+		{"bad request", http.StatusBadRequest, "BadRequest", "invalid input"},
+		{"unauthorized", http.StatusUnauthorized, "Unauthorized", "missing credentials"},
+		{"forbidden", http.StatusForbidden, "Forbidden", "insufficient permissions"},
+		{"not found", http.StatusNotFound, "NotFound", "resource not found"},
+		{"conflict", http.StatusConflict, "Conflict", "resource already exists"},
+		{"too many requests", http.StatusTooManyRequests, "TooManyRequests", "rate limit exceeded"},
+		{"request entity too large", http.StatusRequestEntityTooLarge, "RequestEntityTooLarge", "body too big"},
+		{"internal error", http.StatusInternalServerError, "InternalError", "unexpected failure"},
+		{"not implemented", http.StatusNotImplemented, "NotImplemented", "not yet supported"},
+		{"service unavailable", http.StatusServiceUnavailable, "ServiceUnavailable", "backend down"},
+	}
+}
+
+// TestWriteError_GoldenShape asserts that WriteError produces exactly the
+// canonical models.ErrorResponse body for every standard status, with no
+// extra or missing JSON fields.
+func TestWriteError_GoldenShape(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range standardErrorCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, rec := newTestContext()
+
+			httpx.WriteError(c, tc.status, tc.code, tc.message)
+
+			require.Equal(t, tc.status, rec.Code, "HTTP status must match")
+			require.Equal(t,
+				"application/json; charset=utf-8",
+				rec.Header().Get("Content-Type"),
+				"Content-Type must be application/json",
+			)
+
+			// Decode into the canonical model and confirm fields.
+			var got models.ErrorResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+			assert.Equal(t, tc.code, got.Error)
+			assert.Equal(t, tc.message, got.Message)
+			assert.Equal(t, tc.status, got.Code)
+
+			// Golden-file assertion: the JSON body must contain exactly the
+			// three canonical fields, in exactly this order, with lowercase
+			// keys. Any drift (extra fields, renamed keys, different casing)
+			// will fail this check.
+			assertGoldenErrorShape(t, rec.Body.Bytes(), tc.code, tc.message, tc.status)
+		})
+	}
+}
+
+// TestAbortWithError_GoldenShape asserts AbortWithError emits the same
+// canonical shape and additionally flags the gin context as aborted so
+// downstream handlers are skipped.
+func TestAbortWithError_GoldenShape(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range standardErrorCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, rec := newTestContext()
+
+			httpx.AbortWithError(c, tc.status, tc.code, tc.message)
+
+			require.True(t, c.IsAborted(), "context must be aborted")
+			require.Equal(t, tc.status, rec.Code)
+
+			var got models.ErrorResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+			assert.Equal(t, tc.code, got.Error)
+			assert.Equal(t, tc.message, got.Message)
+			assert.Equal(t, tc.status, got.Code)
+
+			assertGoldenErrorShape(t, rec.Body.Bytes(), tc.code, tc.message, tc.status)
+		})
+	}
+}
+
+// assertGoldenErrorShape verifies the JSON body is a top-level object with
+// exactly the three canonical fields (error, message, code) and no extras.
+// This is the "golden-file" invariant that unifies all error responses.
+func assertGoldenErrorShape(t *testing.T, body []byte, code, message string, status int) {
+	t.Helper()
+
+	var generic map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(body, &generic), "body must be a JSON object")
+
+	// Exactly three keys, no more no less.
+	assert.Len(t, generic, 3, "error response must have exactly 3 fields; got %v", keys(generic))
+
+	// Keys must be the canonical lowercase names.
+	assert.Contains(t, generic, "error")
+	assert.Contains(t, generic, "message")
+	assert.Contains(t, generic, "code")
+
+	// Values must match exactly.
+	var gotError string
+	require.NoError(t, json.Unmarshal(generic["error"], &gotError))
+	assert.Equal(t, code, gotError)
+
+	var gotMessage string
+	require.NoError(t, json.Unmarshal(generic["message"], &gotMessage))
+	assert.Equal(t, message, gotMessage)
+
+	var gotCode int
+	require.NoError(t, json.Unmarshal(generic["code"], &gotCode))
+	assert.Equal(t, status, gotCode)
+}
+
+func keys(m map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/middleware/openapi_validation.go
+++ b/internal/middleware/openapi_validation.go
@@ -18,6 +18,8 @@ import (
 	"github.com/getkin/kin-openapi/routers/gorillamux"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
+
+	"github.com/piwi3910/netweave/internal/httpx"
 )
 
 // DefaultMaxBodySize is the default maximum request body size (1MB).
@@ -254,11 +256,7 @@ func (v *OpenAPIValidator) validateRequest(c *gin.Context) error {
 				zap.Int64("content_length", c.Request.ContentLength),
 				zap.Int64("max_body_size", maxBodySize),
 			)
-			c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{
-				"error":   "RequestEntityTooLarge",
-				"message": fmt.Sprintf("Request body exceeds maximum size of %d bytes", maxBodySize),
-				"code":    http.StatusRequestEntityTooLarge,
-			})
+			httpx.AbortWithError(c, http.StatusRequestEntityTooLarge, "RequestEntityTooLarge", fmt.Sprintf("Request body exceeds maximum size of %d bytes", maxBodySize))
 			return fmt.Errorf("request body too large: %d > %d", c.Request.ContentLength, maxBodySize)
 		}
 
@@ -272,19 +270,11 @@ func (v *OpenAPIValidator) validateRequest(c *gin.Context) error {
 				v.logger.Warn("request body too large",
 					zap.Int64("max_body_size", maxBodySize),
 				)
-				c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{
-					"error":   "RequestEntityTooLarge",
-					"message": fmt.Sprintf("Request body exceeds maximum size of %d bytes", maxBodySize),
-					"code":    http.StatusRequestEntityTooLarge,
-				})
+				httpx.AbortWithError(c, http.StatusRequestEntityTooLarge, "RequestEntityTooLarge", fmt.Sprintf("Request body exceeds maximum size of %d bytes", maxBodySize))
 				return fmt.Errorf("request body too large: limit %d", maxBodySize)
 			}
 			v.logger.Error("failed to read request body", zap.Error(err))
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error":   "InternalError",
-				"message": "Failed to read request body",
-				"code":    http.StatusInternalServerError,
-			})
+			httpx.AbortWithError(c, http.StatusInternalServerError, "InternalError", "Failed to read request body")
 			return fmt.Errorf("failed to read request body: %w", err)
 		}
 
@@ -300,11 +290,7 @@ func (v *OpenAPIValidator) validateRequest(c *gin.Context) error {
 		)
 
 		errorMessage := FormatValidationError(err)
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
-			"error":   "ValidationError",
-			"message": errorMessage,
-			"code":    http.StatusBadRequest,
-		})
+		httpx.AbortWithError(c, http.StatusBadRequest, "ValidationError", errorMessage)
 		return fmt.Errorf("request validation failed: %w", err)
 	}
 

--- a/internal/server/docs.go
+++ b/internal/server/docs.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"gopkg.in/yaml.v3"
+
+	"github.com/piwi3910/netweave/internal/httpx"
 )
 
 // Swagger UI version and CDN configuration with SRI hashes for security.
@@ -61,11 +63,7 @@ func (s *Server) SetupDocsRoutes() {
 // are removed from the spec before serving.
 func (s *Server) HandleOpenAPIYAML(c *gin.Context) {
 	if len(s.openAPISpec) == 0 {
-		c.JSON(http.StatusNotFound, gin.H{
-			"error":   "NotFound",
-			"message": "OpenAPI specification not loaded",
-			"code":    http.StatusNotFound,
-		})
+		httpx.WriteError(c, http.StatusNotFound, "NotFound", "OpenAPI specification not loaded")
 		return
 	}
 

--- a/internal/server/dynamic_routing.go
+++ b/internal/server/dynamic_routing.go
@@ -13,6 +13,7 @@ import (
 	"github.com/piwi3910/netweave/internal/adapter"
 	"github.com/piwi3910/netweave/internal/auth"
 	dmsregistry "github.com/piwi3910/netweave/internal/dms/registry"
+	"github.com/piwi3910/netweave/internal/httpx"
 	"github.com/piwi3910/netweave/internal/smo"
 )
 
@@ -200,8 +201,5 @@ func SMORegistryFromContext(c *gin.Context) *smo.Registry {
 // handleAdapterUnavailable sends a 503 response when no adapter could be resolved.
 // Used by handlers that require an adapter and cannot proceed without one.
 func handleAdapterUnavailable(c *gin.Context) {
-	c.JSON(http.StatusServiceUnavailable, gin.H{
-		"error":   "ServiceUnavailable",
-		"message": "No backend adapter available for this request. Ensure backend instances are configured.",
-	})
+	httpx.WriteError(c, http.StatusServiceUnavailable, "ServiceUnavailable", "No backend adapter available for this request. Ensure backend instances are configured.")
 }

--- a/internal/server/plugin_registry.go
+++ b/internal/server/plugin_registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/piwi3910/netweave/internal/config"
 	"github.com/piwi3910/netweave/internal/handlers"
+	"github.com/piwi3910/netweave/internal/httpx"
 )
 
 // ErrPluginNotFound is returned when a plugin name is not recognized.
@@ -211,10 +212,7 @@ func PluginGuard(registry *FrontendPluginRegistry, pluginName string) gin.Handle
 		}
 
 		if !registry.IsEnabled(pluginName) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": fmt.Sprintf("The %s API is not enabled. Contact your platform administrator.", pluginName),
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("The %s API is not enabled. Contact your platform administrator.", pluginName))
 			c.Abort()
 			return
 		}

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/piwi3910/netweave/internal/auth"
+	"github.com/piwi3910/netweave/internal/httpx"
 )
 
 const (
@@ -105,11 +106,12 @@ func (rl *RateLimiter) Middleware() gin.HandlerFunc {
 				zap.Int("limit", limit),
 				zap.Int("current", currentCount))
 
-			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
-				"error":   "RateLimitExceeded",
-				"message": "Rate limit exceeded. Try again later.",
-				"code":    http.StatusTooManyRequests,
-			})
+			httpx.AbortWithError(
+				c,
+				http.StatusTooManyRequests,
+				"RateLimitExceeded",
+				"Rate limit exceeded. Try again later.",
+			)
 			return
 		}
 

--- a/internal/server/resourcetype_integration_test.go
+++ b/internal/server/resourcetype_integration_test.go
@@ -146,7 +146,8 @@ func TestResourceTypeHandler_Integration(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Contains(t, response, "error")
-		assert.Contains(t, response["error"], "not found")
+		assert.Equal(t, "NotFound", response["error"])
+		assert.Contains(t, response["message"], "not found")
 	})
 
 	t.Run("list_with_invalid_pagination", func(t *testing.T) {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -19,6 +19,7 @@ import (
 	"github.com/piwi3910/netweave/internal/adapter"
 	"github.com/piwi3910/netweave/internal/auth"
 	"github.com/piwi3910/netweave/internal/backend"
+	"github.com/piwi3910/netweave/internal/httpx"
 	"github.com/piwi3910/netweave/internal/models"
 	"github.com/piwi3910/netweave/internal/storage"
 )
@@ -128,10 +129,7 @@ func (s *Server) resolveAdapter(c *gin.Context) adapter.Adapter {
 		if s.adapter != nil {
 			return s.adapter
 		}
-		c.JSON(http.StatusServiceUnavailable, gin.H{
-			"error":   "ServiceUnavailable",
-			"message": "No backend adapters configured. Create backend instances via the admin API.",
-		})
+		httpx.WriteError(c, http.StatusServiceUnavailable, "ServiceUnavailable", "No backend adapters configured. Create backend instances via the admin API.")
 		return nil
 	}
 
@@ -140,10 +138,7 @@ func (s *Server) resolveAdapter(c *gin.Context) adapter.Adapter {
 	if backendID != "" && auth.IsPlatformAdminFromContext(ctx) {
 		adp, err := s.adapterRegistry.GetAdapter(backendID)
 		if err != nil {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": fmt.Sprintf("Backend %q not found in registry", backendID),
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", fmt.Sprintf("Backend %q not found in registry", backendID))
 			return nil
 		}
 		return adp
@@ -154,52 +149,34 @@ func (s *Server) resolveAdapter(c *gin.Context) adapter.Adapter {
 	if tenantID == "" {
 		// Platform admins must specify X-Backend-ID
 		if auth.IsPlatformAdminFromContext(ctx) {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   "BadRequest",
-				"message": "Platform admins must specify X-Backend-ID header to select a backend",
-			})
+			httpx.WriteError(c, http.StatusBadRequest, "BadRequest", "Platform admins must specify X-Backend-ID header to select a backend")
 			return nil
 		}
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"error":   "Unauthorized",
-			"message": "No tenant context available",
-		})
+		httpx.WriteError(c, http.StatusUnauthorized, "Unauthorized", "No tenant context available")
 		return nil
 	}
 
 	// Platform admins without X-Backend-ID header
 	if auth.IsPlatformAdminFromContext(ctx) {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": "Platform admins must specify X-Backend-ID header to select a backend",
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", "Platform admins must specify X-Backend-ID header to select a backend")
 		return nil
 	}
 
 	adp, err := s.adapterRegistry.GetAdapterForTenant(ctx, tenantID, s.backendStore)
 	if err != nil {
 		if errors.Is(err, backend.ErrNoBackendAccess) {
-			c.JSON(http.StatusForbidden, gin.H{
-				"error":   "Forbidden",
-				"message": "No backend access configured for this tenant",
-			})
+			httpx.WriteError(c, http.StatusForbidden, "Forbidden", "No backend access configured for this tenant")
 			return nil
 		}
 		if errors.Is(err, backend.ErrAdapterNotFound) {
-			c.JSON(http.StatusServiceUnavailable, gin.H{
-				"error":   "ServiceUnavailable",
-				"message": "Assigned backend is not currently available",
-			})
+			httpx.WriteError(c, http.StatusServiceUnavailable, "ServiceUnavailable", "Assigned backend is not currently available")
 			return nil
 		}
 		s.logger.Warn("failed to resolve adapter for tenant",
 			zap.String("tenant_id", tenantID),
 			zap.Error(err),
 		)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalServerError",
-			"message": "Failed to resolve backend adapter",
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalServerError", "Failed to resolve backend adapter")
 		return nil
 	}
 
@@ -493,11 +470,7 @@ func (s *Server) handleListSubscriptions(c *gin.Context) {
 
 	if err != nil {
 		s.logger.Error("failed to list subscriptions", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to retrieve subscriptions",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve subscriptions")
 		return
 	}
 
@@ -535,21 +508,13 @@ func (s *Server) handleCreateSubscription(c *gin.Context) {
 
 	var req adapter.Subscription
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": "Invalid request body: " + err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", "Invalid request body: "+err.Error())
 		return
 	}
 
 	// Validate callback URL early for fast failure (SSRF protection)
 	if err := s.ValidateCallback(ctx, &req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", err.Error())
 		return
 	}
 
@@ -559,21 +524,13 @@ func (s *Server) handleCreateSubscription(c *gin.Context) {
 			if errors.Is(err, auth.ErrQuotaExceeded) {
 				s.logger.Warn("subscription quota exceeded",
 					zap.String("tenant_id", tenantID))
-				c.JSON(http.StatusTooManyRequests, gin.H{
-					"error":   "QuotaExceeded",
-					"message": "Subscription quota exceeded for tenant",
-					"code":    http.StatusTooManyRequests,
-				})
+				httpx.WriteError(c, http.StatusTooManyRequests, "QuotaExceeded", "Subscription quota exceeded for tenant")
 				return
 			}
 			s.logger.Error("failed to check subscription quota",
 				zap.String("tenant_id", tenantID),
 				zap.Error(err))
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":   "InternalError",
-				"message": "Failed to check subscription quota",
-				"code":    http.StatusInternalServerError,
-			})
+			httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to check subscription quota")
 			return
 		}
 	}
@@ -617,20 +574,12 @@ func (s *Server) handleCreateSubscription(c *gin.Context) {
 
 		// Check for conflict error (subscription already exists)
 		if errors.Is(err, adapter.ErrSubscriptionExists) {
-			c.JSON(http.StatusConflict, gin.H{
-				"error":   "Conflict",
-				"message": "Subscription already exists",
-				"code":    http.StatusConflict,
-			})
+			httpx.WriteError(c, http.StatusConflict, "Conflict", "Subscription already exists")
 			return
 		}
 
 		s.logger.Error("failed to create subscription", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to create subscription",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to create subscription")
 		return
 	}
 
@@ -661,11 +610,7 @@ func (s *Server) handleCreateSubscription(c *gin.Context) {
 					zap.Error(decErr))
 			}
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to store subscription",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to store subscription")
 		return
 	}
 
@@ -709,20 +654,12 @@ func (s *Server) handleGetSubscription(c *gin.Context) {
 	sub, err := s.store.Get(ctx, subscriptionID)
 	if err != nil {
 		if errors.Is(err, storage.ErrSubscriptionNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Subscription not found: " + subscriptionID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Subscription not found: "+subscriptionID)
 			return
 		}
 
 		s.logger.Error("failed to get subscription", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to retrieve subscription",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve subscription")
 		return
 	}
 
@@ -733,11 +670,7 @@ func (s *Server) handleGetSubscription(c *gin.Context) {
 			zap.String("tenant_id", tenantID),
 			zap.String("subscription_tenant_id", sub.TenantID),
 			zap.String("subscription_id", subscriptionID))
-		c.JSON(http.StatusNotFound, gin.H{
-			"error":   "NotFound",
-			"message": "Subscription not found: " + subscriptionID,
-			"code":    http.StatusNotFound,
-		})
+		httpx.WriteError(c, http.StatusNotFound, "NotFound", "Subscription not found: "+subscriptionID)
 		return
 	}
 
@@ -776,19 +709,11 @@ func (s *Server) handleUpdateSubscription(c *gin.Context) {
 		sub, err := s.store.Get(ctx, subscriptionID)
 		if err != nil {
 			if errors.Is(err, storage.ErrSubscriptionNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{
-					"error":   "NotFound",
-					"message": "Subscription not found: " + subscriptionID,
-					"code":    http.StatusNotFound,
-				})
+				httpx.WriteError(c, http.StatusNotFound, "NotFound", "Subscription not found: "+subscriptionID)
 				return
 			}
 			s.logger.Error("failed to get subscription for tenant check", zap.Error(err))
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":   "InternalError",
-				"message": "Failed to verify subscription ownership",
-				"code":    http.StatusInternalServerError,
-			})
+			httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to verify subscription ownership")
 			return
 		}
 
@@ -799,32 +724,20 @@ func (s *Server) handleUpdateSubscription(c *gin.Context) {
 				zap.String("tenant_id", tenantID),
 				zap.String("subscription_tenant_id", sub.TenantID),
 				zap.String("subscription_id", subscriptionID))
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Subscription not found: " + subscriptionID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Subscription not found: "+subscriptionID)
 			return
 		}
 	}
 
 	var req adapter.Subscription
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": "Invalid request body: " + err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", "Invalid request body: "+err.Error())
 		return
 	}
 
 	// Validate callback URL early for fast failure
 	if err := s.ValidateCallback(ctx, &req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", err.Error())
 		return
 	}
 
@@ -840,20 +753,12 @@ func (s *Server) handleUpdateSubscription(c *gin.Context) {
 	if err != nil {
 		// Check for not found error using sentinel error
 		if errors.Is(err, adapter.ErrSubscriptionNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Subscription not found: " + subscriptionID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Subscription not found: "+subscriptionID)
 			return
 		}
 
 		s.logger.Error("failed to update subscription", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to update subscription",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to update subscription")
 		return
 	}
 
@@ -904,19 +809,11 @@ func (s *Server) handleDeleteSubscription(c *gin.Context) {
 					zap.String("tenant_id", tenantID),
 					zap.String("subscription_tenant_id", sub.TenantID),
 					zap.String("subscription_id", subscriptionID))
-				c.JSON(http.StatusNotFound, gin.H{
-					"error":   "NotFound",
-					"message": "Subscription not found: " + subscriptionID,
-					"code":    http.StatusNotFound,
-				})
+				httpx.WriteError(c, http.StatusNotFound, "NotFound", "Subscription not found: "+subscriptionID)
 				return
 			}
 		} else if errors.Is(err, storage.ErrSubscriptionNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Subscription not found: " + subscriptionID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Subscription not found: "+subscriptionID)
 			return
 		}
 	}
@@ -946,11 +843,7 @@ func (s *Server) handleDeleteSubscription(c *gin.Context) {
 		}
 
 		s.logger.Error("failed to delete subscription from adapter", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to delete subscription",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to delete subscription")
 		return
 	}
 
@@ -973,20 +866,12 @@ func (s *Server) handleDeleteSubscription(c *gin.Context) {
 		}
 
 		if errors.Is(err, storage.ErrSubscriptionNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Subscription not found: " + subscriptionID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Subscription not found: "+subscriptionID)
 			return
 		}
 
 		s.logger.Error("failed to delete subscription from storage", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to delete subscription",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to delete subscription")
 		return
 	}
 
@@ -1075,11 +960,7 @@ func (s *Server) handleListResourcePools(c *gin.Context) {
 	filter, err := s.parseFilterFromRequest(c)
 	if err != nil {
 		s.logger.Error("failed to parse filter", zap.Error(err))
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "InvalidParameter",
-			"message": err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "InvalidParameter", err.Error())
 		return
 	}
 
@@ -1093,11 +974,7 @@ func (s *Server) handleListResourcePools(c *gin.Context) {
 	pools, err := adp.ListResourcePools(c.Request.Context(), filter)
 	if err != nil {
 		s.logger.Error("failed to list resource pools", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to retrieve resource pools",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve resource pools")
 		return
 	}
 
@@ -1123,11 +1000,7 @@ func (s *Server) handleGetResourcePool(c *gin.Context) {
 	pool, err := adp.GetResourcePool(c.Request.Context(), resourcePoolID)
 	if err != nil {
 		s.logger.Error("failed to get resource pool", zap.Error(err))
-		c.JSON(http.StatusNotFound, gin.H{
-			"error":   "NotFound",
-			"message": "Resource pool not found: " + resourcePoolID,
-			"code":    http.StatusNotFound,
-		})
+		httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource pool not found: "+resourcePoolID)
 		return
 	}
 
@@ -1143,11 +1016,7 @@ func (s *Server) handleGetResourcePool(c *gin.Context) {
 			zap.String("tenant_id", auth.TenantIDFromContext(ctx)),
 			zap.String("pool_tenant_id", pool.TenantID),
 			zap.String("resource_pool_id", resourcePoolID))
-		c.JSON(http.StatusNotFound, gin.H{
-			"error":   "NotFound",
-			"message": "Resource pool not found: " + resourcePoolID,
-			"code":    http.StatusNotFound,
-		})
+		httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource pool not found: "+resourcePoolID)
 		return
 	}
 
@@ -1182,11 +1051,7 @@ func (s *Server) handleListResourcesInPool(c *gin.Context) {
 	resources, err := adp.ListResources(ctx, filter)
 	if err != nil {
 		s.logger.Error("failed to list resources in pool", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to retrieve resources",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve resources")
 		return
 	}
 
@@ -1331,21 +1196,13 @@ func (s *Server) handleCreateResourcePool(c *gin.Context) {
 
 	var req adapter.ResourcePool
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": "Invalid request body: " + err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", "Invalid request body: "+err.Error())
 		return
 	}
 
 	// Validate resource pool fields
 	if err := ValidateResourcePoolFields(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", err.Error())
 		return
 	}
 
@@ -1357,21 +1214,13 @@ func (s *Server) handleCreateResourcePool(c *gin.Context) {
 			if errors.Is(err, auth.ErrQuotaExceeded) {
 				s.logger.Warn("resource pool quota exceeded",
 					zap.String("tenant_id", tenantID))
-				c.JSON(http.StatusTooManyRequests, gin.H{
-					"error":   "QuotaExceeded",
-					"message": "Resource pool quota exceeded for tenant",
-					"code":    http.StatusTooManyRequests,
-				})
+				httpx.WriteError(c, http.StatusTooManyRequests, "QuotaExceeded", "Resource pool quota exceeded for tenant")
 				return
 			}
 			s.logger.Error("failed to check resource pool quota",
 				zap.String("tenant_id", tenantID),
 				zap.Error(err))
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":   "InternalError",
-				"message": "Failed to check resource pool quota",
-				"code":    http.StatusInternalServerError,
-			})
+			httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to check resource pool quota")
 			return
 		}
 	}
@@ -1438,20 +1287,12 @@ func (s *Server) handleCreateResourcePool(c *gin.Context) {
 
 		// Check for duplicate resource pool using sentinel error
 		if errors.Is(err, adapter.ErrResourcePoolExists) {
-			c.JSON(http.StatusConflict, gin.H{
-				"error":   "Conflict",
-				"message": "Resource pool with ID " + SanitizeForLogging(req.ResourcePoolID) + " already exists",
-				"code":    http.StatusConflict,
-			})
+			httpx.WriteError(c, http.StatusConflict, "Conflict", "Resource pool with ID "+SanitizeForLogging(req.ResourcePoolID)+" already exists")
 			return
 		}
 
 		s.logger.Error("failed to create resource pool", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to create resource pool",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to create resource pool")
 		return
 	}
 
@@ -1488,21 +1329,13 @@ func (s *Server) handleUpdateResourcePool(c *gin.Context) {
 
 	var req adapter.ResourcePool
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": "Invalid request body: " + err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", "Invalid request body: "+err.Error())
 		return
 	}
 
 	// Validate field constraints
 	if err := ValidateResourcePoolFields(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", err.Error())
 		return
 	}
 
@@ -1571,20 +1404,12 @@ func (s *Server) handleUpdateResourcePool(c *gin.Context) {
 
 		// Check for not found error using sentinel error
 		if errors.Is(err, adapter.ErrResourcePoolNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Resource pool not found: " + resourcePoolID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource pool not found: "+resourcePoolID)
 			return
 		}
 
 		s.logger.Error("failed to update resource pool", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to update resource pool",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to update resource pool")
 		return
 	}
 
@@ -1636,11 +1461,7 @@ func (s *Server) handleDeleteResourcePool(c *gin.Context) {
 	if user := auth.UserFromContext(ctx); user != nil && !user.IsPlatformAdmin {
 		pool, err := adp.GetResourcePool(ctx, resourcePoolID)
 		if err != nil {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Resource pool not found: " + resourcePoolID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource pool not found: "+resourcePoolID)
 			return
 		}
 		if !auth.AuthorizeTenantResource(ctx, pool.TenantID) {
@@ -1648,11 +1469,7 @@ func (s *Server) handleDeleteResourcePool(c *gin.Context) {
 				zap.String("tenant_id", tenantID),
 				zap.String("pool_tenant_id", pool.TenantID),
 				zap.String("resource_pool_id", resourcePoolID))
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Resource pool not found: " + resourcePoolID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource pool not found: "+resourcePoolID)
 			return
 		}
 	}
@@ -1675,19 +1492,11 @@ func (s *Server) handleDeleteResourcePool(c *gin.Context) {
 		}
 
 		if errors.Is(err, adapter.ErrResourcePoolNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Resource pool not found: " + resourcePoolID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource pool not found: "+resourcePoolID)
 			return
 		}
 		s.logger.Error("failed to delete resource pool", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to delete resource pool",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to delete resource pool")
 		return
 	}
 
@@ -1833,11 +1642,7 @@ func (s *Server) handleListResources(c *gin.Context) {
 	filter, err := s.parseFilterFromRequest(c)
 	if err != nil {
 		s.logger.Error("failed to parse filter", zap.Error(err))
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "InvalidParameter",
-			"message": err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "InvalidParameter", err.Error())
 		return
 	}
 
@@ -1851,11 +1656,7 @@ func (s *Server) handleListResources(c *gin.Context) {
 	resources, err := adp.ListResources(c.Request.Context(), filter)
 	if err != nil {
 		s.logger.Error("failed to list resources", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to retrieve resources",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve resources")
 		return
 	}
 
@@ -1882,20 +1683,12 @@ func (s *Server) handleGetResource(c *gin.Context) {
 	if err != nil {
 		// Use sentinel error for better error detection
 		if errors.Is(err, adapter.ErrResourceNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Resource not found: " + resourceID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource not found: "+resourceID)
 			return
 		}
 
 		s.logger.Error("failed to get resource", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to retrieve resource",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve resource")
 		return
 	}
 
@@ -1907,11 +1700,7 @@ func (s *Server) handleGetResource(c *gin.Context) {
 			zap.String("tenant_id", auth.TenantIDFromContext(ctx)),
 			zap.String("resource_tenant_id", resource.TenantID),
 			zap.String("resource_id", resourceID))
-		c.JSON(http.StatusNotFound, gin.H{
-			"error":   "NotFound",
-			"message": "Resource not found: " + resourceID,
-			"code":    http.StatusNotFound,
-		})
+		httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource not found: "+resourceID)
 		return
 	}
 
@@ -1938,21 +1727,13 @@ func (s *Server) handleCreateResource(c *gin.Context) {
 
 	var req adapter.Resource
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": "Invalid request body: " + err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", "Invalid request body: "+err.Error())
 		return
 	}
 
 	// Validate required fields and constraints
 	if err := validateCreateRequest(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", err.Error())
 		return
 	}
 
@@ -1964,21 +1745,13 @@ func (s *Server) handleCreateResource(c *gin.Context) {
 			if errors.Is(err, auth.ErrQuotaExceeded) {
 				s.logger.Warn("resource quota exceeded",
 					zap.String("tenant_id", tenantID))
-				c.JSON(http.StatusTooManyRequests, gin.H{
-					"error":   "QuotaExceeded",
-					"message": "Resource quota exceeded for tenant",
-					"code":    http.StatusTooManyRequests,
-				})
+				httpx.WriteError(c, http.StatusTooManyRequests, "QuotaExceeded", "Resource quota exceeded for tenant")
 				return
 			}
 			s.logger.Error("failed to check resource quota",
 				zap.String("tenant_id", tenantID),
 				zap.Error(err))
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":   "InternalError",
-				"message": "Failed to check resource quota",
-				"code":    http.StatusInternalServerError,
-			})
+			httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to check resource quota")
 			return
 		}
 	}
@@ -1997,11 +1770,7 @@ func (s *Server) handleCreateResource(c *gin.Context) {
 		if _, err := uuid.Parse(req.ResourceID); err != nil {
 			s.logger.Warn("invalid resource ID format",
 				zap.String("resource_id", SanitizeForLogging(req.ResourceID)))
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   "BadRequest",
-				"message": "resourceId must be a valid UUID",
-				"code":    http.StatusBadRequest,
-			})
+			httpx.WriteError(c, http.StatusBadRequest, "BadRequest", "resourceId must be a valid UUID")
 			return
 		}
 	}
@@ -2042,20 +1811,12 @@ func (s *Server) handleCreateResource(c *gin.Context) {
 
 		// Check if error indicates duplicate resource
 		if errors.Is(err, adapter.ErrResourceExists) {
-			c.JSON(http.StatusConflict, gin.H{
-				"error":   "Conflict",
-				"message": "Resource with ID " + SanitizeForLogging(req.ResourceID) + " already exists",
-				"code":    http.StatusConflict,
-			})
+			httpx.WriteError(c, http.StatusConflict, "Conflict", "Resource with ID "+SanitizeForLogging(req.ResourceID)+" already exists")
 			return
 		}
 
 		s.logger.Error("failed to create resource", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to create resource",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to create resource")
 		return
 	}
 
@@ -2092,11 +1853,7 @@ func (s *Server) handleUpdateResource(c *gin.Context) {
 
 	var req adapter.Resource
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": "Invalid request body: " + err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", "Invalid request body: "+err.Error())
 		return
 	}
 
@@ -2166,11 +1923,7 @@ func (s *Server) handleDeleteResource(c *gin.Context) {
 	// (dev/test) continue to work.
 	if user := auth.UserFromContext(ctx); user != nil && !user.IsPlatformAdmin {
 		if err != nil {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Resource not found: " + resourceID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource not found: "+resourceID)
 			return
 		}
 		if !auth.AuthorizeTenantResource(ctx, existing.TenantID) {
@@ -2178,11 +1931,7 @@ func (s *Server) handleDeleteResource(c *gin.Context) {
 				zap.String("tenant_id", tenantID),
 				zap.String("resource_tenant_id", existing.TenantID),
 				zap.String("resource_id", resourceID))
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Resource not found: " + resourceID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource not found: "+resourceID)
 			return
 		}
 	}
@@ -2205,19 +1954,11 @@ func (s *Server) handleDeleteResource(c *gin.Context) {
 		}
 
 		if errors.Is(err, adapter.ErrResourceNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Resource not found: " + resourceID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource not found: "+resourceID)
 			return
 		}
 		s.logger.Error("failed to delete resource", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to delete resource",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to delete resource")
 		return
 	}
 
@@ -2257,20 +1998,12 @@ func (s *Server) getExistingResource(c *gin.Context, resourceID string) (*adapte
 	existing, err := adp.GetResource(c.Request.Context(), resourceID)
 	if err != nil {
 		if errors.Is(err, adapter.ErrResourceNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "Resource not found: " + resourceID,
-				"code":    http.StatusNotFound,
-			})
+			httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource not found: "+resourceID)
 			return nil, fmt.Errorf("failed to get resource %s: %w", resourceID, err)
 		}
 
 		s.logger.Error("failed to get resource", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to retrieve resource",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve resource")
 		return nil, fmt.Errorf("failed to get resource %s: %w", resourceID, err)
 	}
 	return existing, nil
@@ -2280,21 +2013,13 @@ func (s *Server) getExistingResource(c *gin.Context, resourceID string) (*adapte
 func (s *Server) validateUpdateRequest(c *gin.Context, req, existing *adapter.Resource) error {
 	// Validate field constraints
 	if err := validateResourceFields(req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", err.Error())
 		return err
 	}
 
 	// Check immutable fields
 	if err := checkImmutableFields(req, existing); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", err.Error())
 		return err
 	}
 
@@ -2349,11 +2074,7 @@ func (s *Server) applyResourceUpdate(c *gin.Context, resourceID string, req, exi
 		}
 
 		s.logger.Error("failed to update resource", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to update resource",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to update resource")
 		return
 	}
 
@@ -2391,11 +2112,7 @@ func (s *Server) handleListResourceTypes(c *gin.Context) {
 	filter, err := s.parseFilterFromRequest(c)
 	if err != nil {
 		s.logger.Error("failed to parse filter", zap.Error(err))
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "InvalidParameter",
-			"message": err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "InvalidParameter", err.Error())
 		return
 	}
 
@@ -2409,11 +2126,7 @@ func (s *Server) handleListResourceTypes(c *gin.Context) {
 	types, err := adp.ListResourceTypes(c.Request.Context(), filter)
 	if err != nil {
 		s.logger.Error("failed to list resource types", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to retrieve resource types",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve resource types")
 		return
 	}
 
@@ -2439,11 +2152,7 @@ func (s *Server) handleGetResourceType(c *gin.Context) {
 	resType, err := adp.GetResourceType(c.Request.Context(), resourceTypeID)
 	if err != nil {
 		s.logger.Error("failed to get resource type", zap.Error(err))
-		c.JSON(http.StatusNotFound, gin.H{
-			"error":   "NotFound",
-			"message": "Resource type not found: " + resourceTypeID,
-			"code":    http.StatusNotFound,
-		})
+		httpx.WriteError(c, http.StatusNotFound, "NotFound", "Resource type not found: "+resourceTypeID)
 		return
 	}
 
@@ -2465,11 +2174,7 @@ func (s *Server) handleListDeploymentManagers(c *gin.Context) {
 	dms, err := adp.ListDeploymentManagers(c.Request.Context(), nil)
 	if err != nil {
 		s.logger.Error("failed to list deployment managers", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to retrieve deployment managers",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve deployment managers")
 		return
 	}
 
@@ -2495,11 +2200,7 @@ func (s *Server) handleGetDeploymentManager(c *gin.Context) {
 	dm, err := adp.GetDeploymentManager(c.Request.Context(), deploymentManagerID)
 	if err != nil {
 		s.logger.Error("failed to get deployment manager", zap.Error(err))
-		c.JSON(http.StatusNotFound, gin.H{
-			"error":   "NotFound",
-			"message": "Deployment manager not found: " + deploymentManagerID,
-			"code":    http.StatusNotFound,
-		})
+		httpx.WriteError(c, http.StatusNotFound, "NotFound", "Deployment manager not found: "+deploymentManagerID)
 		return
 	}
 
@@ -2523,21 +2224,13 @@ func (s *Server) handleGetOCloudInfrastructure(c *gin.Context) {
 	dms, err := adp.ListDeploymentManagers(c.Request.Context(), nil)
 	if err != nil {
 		s.logger.Error("failed to list deployment managers for O-Cloud info", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "Failed to retrieve O-Cloud information",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "Failed to retrieve O-Cloud information")
 		return
 	}
 
 	if len(dms) == 0 {
 		s.logger.Error("no deployment managers registered")
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":   "InternalError",
-			"message": "No deployment managers available",
-			"code":    http.StatusInternalServerError,
-		})
+		httpx.WriteError(c, http.StatusInternalServerError, "InternalError", "No deployment managers available")
 		return
 	}
 
@@ -2588,11 +2281,7 @@ func (s *Server) handleUpdateTenantQuotas(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "BadRequest",
-			"message": "Invalid request body: " + err.Error(),
-			"code":    http.StatusBadRequest,
-		})
+		httpx.WriteError(c, http.StatusBadRequest, "BadRequest", "Invalid request body: "+err.Error())
 		return
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ import (
 	dmsregistry "github.com/piwi3910/netweave/internal/dms/registry"
 	dmsstorage "github.com/piwi3910/netweave/internal/dms/storage"
 	"github.com/piwi3910/netweave/internal/handlers"
+	"github.com/piwi3910/netweave/internal/httpx"
 	"github.com/piwi3910/netweave/internal/middleware"
 	"github.com/piwi3910/netweave/internal/observability"
 	"github.com/piwi3910/netweave/internal/smo"
@@ -1080,9 +1081,7 @@ func (s *Server) RecoveryMiddleware() gin.HandlerFunc {
 					zap.String("client_ip", c.ClientIP()),
 				)
 
-				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-					"error": "Internal server error",
-				})
+				httpx.AbortWithError(c, http.StatusInternalServerError, "InternalError", "Internal server error")
 			}
 		}()
 		c.Next()

--- a/internal/server/server_bind_test.go
+++ b/internal/server/server_bind_test.go
@@ -19,7 +19,7 @@ import (
 // reservePort opens a TCP listener on a free local port, returns the port
 // number, and keeps the listener open so the port stays occupied until the
 // test cleans up. The returned cleanup closes the listener.
-func reservePort(t *testing.T) (port int, cleanup func()) {
+func reservePort(t *testing.T) (int, func()) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)

--- a/internal/server/tenant_isolation_test.go
+++ b/internal/server/tenant_isolation_test.go
@@ -1250,12 +1250,12 @@ func buildTenantAdminRouter(t *testing.T, user *auth.AuthenticatedUser, seeded m
 	// the full redis-backed store for determinism; miniredis is already set
 	// up by setupTestStore.
 	authStore := auth.NewRedisStore(&auth.RedisConfig{
-		Addr:      mr.Addr(),
-		MaxRetries: 1,
-		DialTimeout: 1 * time.Second,
-		ReadTimeout: 1 * time.Second,
+		Addr:         mr.Addr(),
+		MaxRetries:   1,
+		DialTimeout:  1 * time.Second,
+		ReadTimeout:  1 * time.Second,
 		WriteTimeout: 1 * time.Second,
-		PoolSize: 5,
+		PoolSize:     5,
 	})
 
 	for _, tenant := range seeded {
@@ -1670,26 +1670,16 @@ func TestTenantOwnedRoutes_CoveredByIsolationTests(t *testing.T) {
 	// tenant-owned route is added to tenantOwnedRoutes, append the test
 	// function name here. The architectural test is a compile-time reminder.
 	isolationTestsByRoute := map[string]string{
-		"GET /o2ims-infrastructureInventory/v1/subscriptions/:subscriptionId":
-			"TestTenantIsolation_GetSubscription",
-		"PUT /o2ims-infrastructureInventory/v1/subscriptions/:subscriptionId":
-			"TestTenantIsolation_UpdateSubscription",
-		"DELETE /o2ims-infrastructureInventory/v1/subscriptions/:subscriptionId":
-			"TestTenantIsolation_DeleteSubscription",
-		"GET /o2ims-infrastructureInventory/v1/resourcePools/:resourcePoolId":
-			"TestTenantIsolation_GetResourcePool",
-		"DELETE /o2ims-infrastructureInventory/v1/resourcePools/:resourcePoolId":
-			"TestTenantIsolation_DeleteResourcePool",
-		"GET /o2ims-infrastructureInventory/v1/resources/:resourceId":
-			"TestTenantIsolation_GetResource",
-		"DELETE /o2ims-infrastructureInventory/v1/resources/:resourceId":
-			"TestTenantIsolation_DeleteResource",
-		"GET /o2ims-infrastructureInventory/v1/tenants/:tenantId":
-			"TestTenantIsolation_AdminRoutes_CrossTenantRejected",
-		"PUT /o2ims-infrastructureInventory/v1/tenants/:tenantId":
-			"TestTenantIsolation_AdminRoutes_CrossTenantRejected",
-		"DELETE /o2ims-infrastructureInventory/v1/tenants/:tenantId":
-			"TestTenantIsolation_AdminRoutes_CrossTenantRejected",
+		"GET /o2ims-infrastructureInventory/v1/subscriptions/:subscriptionId":    "TestTenantIsolation_GetSubscription",
+		"PUT /o2ims-infrastructureInventory/v1/subscriptions/:subscriptionId":    "TestTenantIsolation_UpdateSubscription",
+		"DELETE /o2ims-infrastructureInventory/v1/subscriptions/:subscriptionId": "TestTenantIsolation_DeleteSubscription",
+		"GET /o2ims-infrastructureInventory/v1/resourcePools/:resourcePoolId":    "TestTenantIsolation_GetResourcePool",
+		"DELETE /o2ims-infrastructureInventory/v1/resourcePools/:resourcePoolId": "TestTenantIsolation_DeleteResourcePool",
+		"GET /o2ims-infrastructureInventory/v1/resources/:resourceId":            "TestTenantIsolation_GetResource",
+		"DELETE /o2ims-infrastructureInventory/v1/resources/:resourceId":         "TestTenantIsolation_DeleteResource",
+		"GET /o2ims-infrastructureInventory/v1/tenants/:tenantId":                "TestTenantIsolation_AdminRoutes_CrossTenantRejected",
+		"PUT /o2ims-infrastructureInventory/v1/tenants/:tenantId":                "TestTenantIsolation_AdminRoutes_CrossTenantRejected",
+		"DELETE /o2ims-infrastructureInventory/v1/tenants/:tenantId":             "TestTenantIsolation_AdminRoutes_CrossTenantRejected",
 	}
 
 	// Assert every tenant-owned route has at least one associated isolation

--- a/internal/server/tmforum_routes.go
+++ b/internal/server/tmforum_routes.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/piwi3910/netweave/internal/handlers"
+	"github.com/piwi3910/netweave/internal/httpx"
 )
 
 // setupTMForumRoutesEarly configures TMForum API route structure during server initialization.
@@ -192,10 +193,7 @@ func (s *Server) setupTMForumRoutesEarly() {
 func (s *Server) tmfHandlerOrUnavailable(getHandler func(*handlers.TMForumHandler) gin.HandlerFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if s.tmfHandler == nil {
-			c.JSON(http.StatusServiceUnavailable, gin.H{
-				"error":   "TMForum API not available",
-				"message": "DMS subsystem not initialized",
-			})
+			httpx.WriteError(c, http.StatusServiceUnavailable, "TMForum API not available", "DMS subsystem not initialized")
 			return
 		}
 

--- a/internal/server/versioning.go
+++ b/internal/server/versioning.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/piwi3910/netweave/internal/httpx"
 )
 
 // APIVersion represents an API version configuration.
@@ -72,12 +74,7 @@ func VersioningMiddleware(config *VersionConfig) gin.HandlerFunc {
 
 		versionInfo, exists := config.Versions[version]
 		if !exists {
-			c.JSON(http.StatusNotFound, gin.H{
-				"error":   "NotFound",
-				"message": "API version not found: " + version,
-				"code":    http.StatusNotFound,
-			})
-			c.Abort()
+			httpx.AbortWithError(c, http.StatusNotFound, "NotFound", "API version not found: "+version)
 			return
 		}
 
@@ -98,12 +95,12 @@ func VersioningMiddleware(config *VersionConfig) gin.HandlerFunc {
 
 		// Handle sunset versions (completely removed)
 		if versionInfo.Status == VersionStatusSunset {
-			c.JSON(http.StatusGone, gin.H{
-				"error":   "Gone",
-				"message": "API version " + version + " has been removed. Please upgrade to a newer version.",
-				"code":    http.StatusGone,
-			})
-			c.Abort()
+			httpx.AbortWithError(
+				c,
+				http.StatusGone,
+				"Gone",
+				"API version "+version+" has been removed. Please upgrade to a newer version.",
+			)
 			return
 		}
 
@@ -200,12 +197,12 @@ func RequireVersion(minVersion string) gin.HandlerFunc {
 		}
 
 		if !IsVersionAtLeast(currentVersion, minVersion) {
-			c.JSON(http.StatusNotImplemented, gin.H{
-				"error":   "NotImplemented",
-				"message": "This feature requires API version " + minVersion + " or higher",
-				"code":    http.StatusNotImplemented,
-			})
-			c.Abort()
+			httpx.AbortWithError(
+				c,
+				http.StatusNotImplemented,
+				"NotImplemented",
+				"This feature requires API version "+minVersion+" or higher",
+			)
 			return
 		}
 


### PR DESCRIPTION
## Summary
- Introduces `internal/httpx` package with unified `Problem`-style HTTP error response helper
- Replaces ~400 scattered `c.JSON(status, gin.H{...})` error literals across routes, handlers, and middleware with `httpx.WriteError`
- Preserves fail-closed tenant isolation checks using `auth.AuthorizeTenantResource` (from #470)
- Reconciles sslmode test expectations with the new `verify-full` default from #548

This is a re-do of #543, which was closed due to unresolvable cascading merge conflicts after #536–#548 landed. Rebased onto current `main` and the residual semantic conflicts (startListener signature from #538, tenant-isolation predicate from #470, sslmode default from #548) were resolved manually.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./...` all green (including `TestTenantIsolation_EmptyTenantID_FailClosed`)
- [ ] CI pipeline green