### PR TITLE
[Security] I5: Wire Vault CRL into mTLS with fail-closed refresh

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -967,6 +967,24 @@ func initializeCertLifecycle(
 			return nil, fmt.Errorf("failed to create vault client: %w", vaultErr)
 		}
 		vaultPKI = vaultClient
+
+		// Wire Vault-backed CRL verification into mTLS peer checking
+		// (issue #496 / I5). The verifier is disabled by default if the
+		// config flag is false; otherwise it refreshes the CRL from
+		// Vault at the configured interval and fails closed after
+		// MaxFailures consecutive errors.
+		if cfg.TLS.CRL.Enabled {
+			crlVerifier := server.NewCRLVerifier(
+				context.Background(),
+				vaultClient,
+				cfg.TLS.CRL.RefreshInterval,
+				cfg.TLS.CRL.MaxFailures,
+				logger,
+			)
+			srv.SetupCRLVerifier(crlVerifier)
+		} else {
+			logger.Info("CRL verification disabled via config")
+		}
 	}
 
 	// Resolve HMAC secret from environment.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -511,6 +511,33 @@ type TLSConfig struct {
 	// Names must match Go's crypto/tls names exactly (see tls.CipherSuites()).
 	// Only honored for TLS 1.2; TLS 1.3 cipher suites are fixed by Go.
 	CipherSuites []string `mapstructure:"cipher_suites"`
+
+	// CRL configures periodic Certificate Revocation List checking for
+	// mTLS peer verification. When enabled and a Vault client is
+	// configured, the server fetches the CRL from Vault at
+	// RefreshInterval and rejects peers whose certificate serial
+	// appears in the list. After MaxFailures consecutive refresh
+	// errors the verifier fails closed and rejects all peers.
+	CRL CRLConfig `mapstructure:"crl"`
+}
+
+// CRLConfig configures Vault-backed CRL checking for mTLS peer verification.
+// See issue #496 (I5).
+type CRLConfig struct {
+	// Enabled turns CRL verification on. When a Vault client is available
+	// and this is true, the server attaches a VerifyPeerCertificate
+	// callback to every TLS listener that performs client auth.
+	// Defaults to true (enforced by viper defaults).
+	Enabled bool `mapstructure:"enabled"`
+
+	// RefreshInterval controls how often the CRL is fetched from Vault.
+	// Defaults to 5 minutes.
+	RefreshInterval time.Duration `mapstructure:"refresh_interval"`
+
+	// MaxFailures is the number of consecutive refresh errors that will
+	// cause the verifier to enter a fail-closed "stale" state in which
+	// every TLS peer is rejected. Defaults to 3.
+	MaxFailures int `mapstructure:"max_failures"`
 }
 
 // ObservabilityConfig contains logging, metrics, and tracing configuration.
@@ -1013,6 +1040,9 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("tls.enabled", false)
 	v.SetDefault("tls.client_auth", "none")
 	v.SetDefault("tls.min_version", "1.3")
+	v.SetDefault("tls.crl.enabled", true)
+	v.SetDefault("tls.crl.refresh_interval", "5m")
+	v.SetDefault("tls.crl.max_failures", 3)
 
 	// Logging defaults
 	v.SetDefault("observability.logging.level", "info")

--- a/internal/server/crl_verifier.go
+++ b/internal/server/crl_verifier.go
@@ -1,0 +1,306 @@
+// Package server: CRL verifier for mTLS peer verification.
+//
+// This file implements periodic retrieval of the Certificate Revocation List
+// (CRL) from HashiCorp Vault's PKI engine and exposes an IsRevoked helper
+// used by tls.Config.VerifyPeerCertificate.
+//
+// Design notes (see issue #496 / I5):
+//   - CRL is refreshed in the background by a single goroutine.
+//   - The parsed CRL is stored behind an atomic pointer so reads are
+//     lock-free on the hot mTLS verification path.
+//   - After N consecutive refresh failures the verifier enters a "stale"
+//     state and IsRevoked returns true for every serial number, causing
+//     VerifyPeerCertificate to reject all incoming connections. This is
+//     the fail-closed behaviour required by I5.
+package server
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/zap"
+)
+
+// defaultCRLRefreshInterval is used when the caller passes a non-positive
+// refresh interval to NewCRLVerifier.
+const defaultCRLRefreshInterval = 5 * time.Minute
+
+// defaultCRLMaxFailures is the number of consecutive refresh errors that
+// will cause the verifier to enter the fail-closed "stale" state.
+const defaultCRLMaxFailures = 3
+
+// crlRefreshTotal is a Prometheus counter that records the outcome of each
+// CRL refresh attempt. It is registered once, at package initialisation,
+// using promauto so tests and the server share the same metric.
+//
+// The "result" label is either "success" or "failure".
+//
+//nolint:gochecknoglobals // Prometheus collectors are inherently global.
+var crlRefreshTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "netweave_crl_refresh_total",
+		Help: "Total number of CRL refresh attempts, labelled by result.",
+	},
+	[]string{"result"},
+)
+
+// VaultCRLFetcher is the minimal interface that the verifier needs from a
+// Vault client. Using an interface keeps the verifier testable without
+// requiring a real Vault deployment.
+type VaultCRLFetcher interface {
+	// GetCRL returns the Certificate Revocation List in PEM format.
+	GetCRL(ctx context.Context) (string, error)
+}
+
+// crlSnapshot holds the parsed CRL plus the set of revoked serial numbers.
+// It is immutable once created; updates are performed by swapping the
+// atomic pointer in CRLVerifier.
+type crlSnapshot struct {
+	list    *x509.RevocationList
+	revoked map[string]struct{} // key: serial.String() (base-10)
+	fetched time.Time
+}
+
+// CRLVerifier periodically fetches a CRL from Vault and answers revocation
+// queries. It is safe for concurrent use by many goroutines.
+type CRLVerifier struct {
+	fetcher         VaultCRLFetcher
+	refreshInterval time.Duration
+	maxFailures     int
+	logger          *zap.Logger
+
+	current atomic.Pointer[crlSnapshot]
+
+	// failures is the current consecutive failure count. It is only
+	// mutated by the refresh goroutine but read atomically via the
+	// stale flag.
+	stale atomic.Bool
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// NewCRLVerifier constructs a verifier and starts a background refresh
+// goroutine. The returned verifier is wired into tls.Config.VerifyPeerCertificate
+// via WrapTLSConfig.
+//
+// The goroutine is stopped by calling Stop.
+//
+// If fetcher is nil the verifier is disabled and IsRevoked always returns
+// false; this matches the behaviour when Vault is not configured.
+func NewCRLVerifier(
+	ctx context.Context,
+	fetcher VaultCRLFetcher,
+	refreshInterval time.Duration,
+	maxFailures int,
+	logger *zap.Logger,
+) *CRLVerifier {
+	if refreshInterval <= 0 {
+		refreshInterval = defaultCRLRefreshInterval
+	}
+	if maxFailures <= 0 {
+		maxFailures = defaultCRLMaxFailures
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	v := &CRLVerifier{
+		fetcher:         fetcher,
+		refreshInterval: refreshInterval,
+		maxFailures:     maxFailures,
+		logger:          logger,
+		cancel:          cancel,
+		done:            make(chan struct{}),
+	}
+
+	if fetcher == nil {
+		// Disabled verifier: mark channel closed so Stop is a no-op.
+		close(v.done)
+		return v
+	}
+
+	// Perform an initial synchronous refresh so the first connection does
+	// not race the background goroutine. Failures here are logged but do
+	// not prevent the server from starting; the goroutine will retry.
+	if err := v.refresh(runCtx); err != nil {
+		logger.Warn("initial CRL refresh failed; will retry in background",
+			zap.Error(err),
+		)
+	}
+
+	go v.run(runCtx)
+	return v
+}
+
+// run is the background refresh loop.
+func (v *CRLVerifier) run(ctx context.Context) {
+	defer close(v.done)
+
+	ticker := time.NewTicker(v.refreshInterval)
+	defer ticker.Stop()
+
+	failures := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := v.refresh(ctx); err != nil {
+				failures++
+				v.logger.Warn("CRL refresh failed",
+					zap.Int("consecutive_failures", failures),
+					zap.Int("max_failures", v.maxFailures),
+					zap.Error(err),
+				)
+				if failures >= v.maxFailures {
+					if !v.stale.Swap(true) {
+						v.logger.Error("CRL verifier entering stale fail-closed state",
+							zap.Int("consecutive_failures", failures),
+						)
+					}
+				}
+				continue
+			}
+			if failures > 0 || v.stale.Load() {
+				v.logger.Info("CRL refresh recovered")
+			}
+			failures = 0
+			v.stale.Store(false)
+		}
+	}
+}
+
+// refresh fetches the CRL once and replaces the cached snapshot.
+func (v *CRLVerifier) refresh(ctx context.Context) error {
+	if v.fetcher == nil {
+		return errors.New("crl verifier has no fetcher")
+	}
+
+	crlPEM, err := v.fetcher.GetCRL(ctx)
+	if err != nil {
+		crlRefreshTotal.WithLabelValues("failure").Inc()
+		return fmt.Errorf("fetch CRL: %w", err)
+	}
+
+	snapshot, err := parseCRLPEM(crlPEM)
+	if err != nil {
+		crlRefreshTotal.WithLabelValues("failure").Inc()
+		return fmt.Errorf("parse CRL: %w", err)
+	}
+
+	v.current.Store(snapshot)
+	crlRefreshTotal.WithLabelValues("success").Inc()
+
+	v.logger.Debug("CRL refreshed",
+		zap.Int("revoked_count", len(snapshot.revoked)),
+		zap.Time("fetched_at", snapshot.fetched),
+	)
+	return nil
+}
+
+// parseCRLPEM decodes the PEM-encoded CRL returned by Vault and builds a
+// snapshot with a lookup map of serial numbers.
+func parseCRLPEM(crlPEM string) (*crlSnapshot, error) {
+	raw := []byte(crlPEM)
+	// Vault may return the CRL in PEM or DER. Try PEM first.
+	if block, _ := pem.Decode(raw); block != nil {
+		raw = block.Bytes
+	}
+
+	list, err := x509.ParseRevocationList(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse revocation list: %w", err)
+	}
+
+	revoked := make(map[string]struct{}, len(list.RevokedCertificateEntries))
+	for _, entry := range list.RevokedCertificateEntries {
+		if entry.SerialNumber != nil {
+			revoked[entry.SerialNumber.String()] = struct{}{}
+		}
+	}
+
+	return &crlSnapshot{
+		list:    list,
+		revoked: revoked,
+		fetched: time.Now(),
+	}, nil
+}
+
+// IsRevoked returns true if the given serial number appears in the most
+// recently fetched CRL, OR if the verifier is in a stale fail-closed
+// state. A nil serial is treated as revoked (safe default).
+func (v *CRLVerifier) IsRevoked(serial *big.Int) bool {
+	if v == nil || v.fetcher == nil {
+		return false
+	}
+	if serial == nil {
+		return true
+	}
+	if v.stale.Load() {
+		return true
+	}
+	snap := v.current.Load()
+	if snap == nil {
+		// No snapshot yet. Treat as "not revoked" until either a
+		// successful refresh populates the cache or the stale threshold
+		// is reached (handled above).
+		return false
+	}
+	_, revoked := snap.revoked[serial.String()]
+	return revoked
+}
+
+// Stale reports whether the verifier is currently in fail-closed mode.
+// Exposed primarily for tests and health diagnostics.
+func (v *CRLVerifier) Stale() bool {
+	if v == nil {
+		return false
+	}
+	return v.stale.Load()
+}
+
+// Stop cancels the background refresh goroutine and waits for it to exit.
+// Safe to call multiple times; subsequent calls are no-ops.
+func (v *CRLVerifier) Stop() {
+	if v == nil {
+		return
+	}
+	if v.cancel != nil {
+		v.cancel()
+	}
+	<-v.done
+}
+
+// VerifyPeerCertificate returns a tls.Config.VerifyPeerCertificate callback
+// that rejects connections whose peer certificate (leaf) is revoked.
+//
+// The callback parses the raw leaf certificate and consults IsRevoked.
+// When the verifier is stale, IsRevoked returns true for every serial,
+// which causes this callback to reject all connections (fail-closed).
+func (v *CRLVerifier) VerifyPeerCertificate() func([][]byte, [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		if v == nil || v.fetcher == nil {
+			return nil
+		}
+		for _, raw := range rawCerts {
+			cert, err := x509.ParseCertificate(raw)
+			if err != nil {
+				return fmt.Errorf("parse peer cert: %w", err)
+			}
+			if v.IsRevoked(cert.SerialNumber) {
+				return fmt.Errorf("peer certificate revoked (serial=%s)", cert.SerialNumber)
+			}
+		}
+		return nil
+	}
+}

--- a/internal/server/crl_verifier_test.go
+++ b/internal/server/crl_verifier_test.go
@@ -1,0 +1,230 @@
+package server
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// fakeVaultFetcher is a test double implementing VaultCRLFetcher.
+// It returns scripted responses and records the number of calls so tests
+// can assert that refresh actually occurred.
+type fakeVaultFetcher struct {
+	mu       sync.Mutex
+	pem      string
+	err      error
+	calls    int32
+	failFrom int // once calls >= failFrom, return err (if set)
+}
+
+func (f *fakeVaultFetcher) GetCRL(_ context.Context) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	atomic.AddInt32(&f.calls, 1)
+	if f.err != nil && int(atomic.LoadInt32(&f.calls)) >= f.failFrom {
+		return "", f.err
+	}
+	return f.pem, nil
+}
+
+func (f *fakeVaultFetcher) setPEM(p string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pem = p
+}
+
+func (f *fakeVaultFetcher) callCount() int {
+	return int(atomic.LoadInt32(&f.calls))
+}
+
+// generateTestCA creates a self-signed ECDSA CA that can sign CRLs.
+func generateTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "netweave-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key
+}
+
+// buildCRL produces a PEM-encoded CRL revoking the given serial numbers.
+func buildCRL(t *testing.T, ca *x509.Certificate, key *ecdsa.PrivateKey, serials ...*big.Int) string {
+	t.Helper()
+	entries := make([]x509.RevocationListEntry, 0, len(serials))
+	for _, s := range serials {
+		entries = append(entries, x509.RevocationListEntry{
+			SerialNumber:   s,
+			RevocationTime: time.Now(),
+		})
+	}
+	tmpl := &x509.RevocationList{
+		Number:                    big.NewInt(time.Now().UnixNano()),
+		ThisUpdate:                time.Now().Add(-time.Minute),
+		NextUpdate:                time.Now().Add(time.Hour),
+		RevokedCertificateEntries: entries,
+	}
+	der, err := x509.CreateRevocationList(rand.Reader, tmpl, ca, key)
+	require.NoError(t, err)
+	block := &pem.Block{Type: "X509 CRL", Bytes: der}
+	return string(pem.EncodeToMemory(block))
+}
+
+func TestCRLVerifier_RefreshPopulatesRevokedSet(t *testing.T) {
+	t.Parallel()
+
+	ca, key := generateTestCA(t)
+	revokedSerial := big.NewInt(42)
+	cleanSerial := big.NewInt(43)
+
+	fetcher := &fakeVaultFetcher{pem: buildCRL(t, ca, key, revokedSerial)}
+	v := NewCRLVerifier(context.Background(), fetcher, 0, 0, zap.NewNop())
+	t.Cleanup(v.Stop)
+
+	// Initial synchronous refresh should have populated the snapshot.
+	require.GreaterOrEqual(t, fetcher.callCount(), 1)
+	assert.True(t, v.IsRevoked(revokedSerial), "revoked serial must be flagged")
+	assert.False(t, v.IsRevoked(cleanSerial), "clean serial must not be flagged")
+}
+
+func TestCRLVerifier_RefreshUpdatesRevokedSet(t *testing.T) {
+	t.Parallel()
+
+	ca, key := generateTestCA(t)
+	first := big.NewInt(100)
+	second := big.NewInt(200)
+
+	fetcher := &fakeVaultFetcher{pem: buildCRL(t, ca, key, first)}
+	// Short refresh interval so the test does not take long.
+	v := NewCRLVerifier(context.Background(), fetcher, 10*time.Millisecond, 0, zap.NewNop())
+	t.Cleanup(v.Stop)
+
+	require.True(t, v.IsRevoked(first))
+	require.False(t, v.IsRevoked(second))
+
+	// Update the fetcher's CRL; wait for the next tick to pick it up.
+	fetcher.setPEM(buildCRL(t, ca, key, second))
+
+	require.Eventually(t, func() bool {
+		return v.IsRevoked(second) && !v.IsRevoked(first)
+	}, 2*time.Second, 10*time.Millisecond, "verifier should pick up updated CRL")
+}
+
+func TestCRLVerifier_StaleFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ca, key := generateTestCA(t)
+	fetcher := &fakeVaultFetcher{
+		pem:      buildCRL(t, ca, key),
+		err:      errors.New("vault unreachable"),
+		failFrom: 2, // first call succeeds (initial refresh), then fail
+	}
+
+	v := NewCRLVerifier(context.Background(), fetcher, 10*time.Millisecond, 3, zap.NewNop())
+	t.Cleanup(v.Stop)
+
+	// Initially healthy.
+	require.False(t, v.Stale())
+	require.False(t, v.IsRevoked(big.NewInt(999)))
+
+	// Wait until the refresh goroutine has accumulated enough failures
+	// to trip the stale flag.
+	require.Eventually(t, v.Stale, 2*time.Second, 10*time.Millisecond,
+		"verifier should enter stale state after consecutive failures")
+
+	// Once stale, every serial is considered revoked (fail-closed).
+	assert.True(t, v.IsRevoked(big.NewInt(1)))
+	assert.True(t, v.IsRevoked(big.NewInt(12345)))
+}
+
+func TestCRLVerifier_VerifyPeerCertificateRejectsRevoked(t *testing.T) {
+	t.Parallel()
+
+	ca, key := generateTestCA(t)
+	revoked := big.NewInt(7777)
+	fetcher := &fakeVaultFetcher{pem: buildCRL(t, ca, key, revoked)}
+	v := NewCRLVerifier(context.Background(), fetcher, time.Hour, 0, zap.NewNop())
+	t.Cleanup(v.Stop)
+
+	// Build a peer cert with the revoked serial.
+	peerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	peerTmpl := &x509.Certificate{
+		SerialNumber: revoked,
+		Subject:      pkix.Name{CommonName: "peer"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	peerDER, err := x509.CreateCertificate(rand.Reader, peerTmpl, ca, &peerKey.PublicKey, key)
+	require.NoError(t, err)
+
+	verify := v.VerifyPeerCertificate()
+	err = verify([][]byte{peerDER}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "revoked")
+
+	// A clean serial should pass.
+	cleanTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1234567),
+		Subject:      pkix.Name{CommonName: "clean-peer"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	cleanDER, err := x509.CreateCertificate(rand.Reader, cleanTmpl, ca, &peerKey.PublicKey, key)
+	require.NoError(t, err)
+	require.NoError(t, verify([][]byte{cleanDER}, nil))
+}
+
+func TestCRLVerifier_NilFetcherIsDisabled(t *testing.T) {
+	t.Parallel()
+
+	v := NewCRLVerifier(context.Background(), nil, 0, 0, zap.NewNop())
+	t.Cleanup(v.Stop)
+
+	assert.False(t, v.IsRevoked(big.NewInt(1)))
+	// VerifyPeerCertificate is a no-op when disabled.
+	require.NoError(t, v.VerifyPeerCertificate()([][]byte{}, nil))
+}
+
+func TestCRLVerifier_StopIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	ca, key := generateTestCA(t)
+	fetcher := &fakeVaultFetcher{pem: buildCRL(t, ca, key)}
+	v := NewCRLVerifier(context.Background(), fetcher, time.Hour, 0, zap.NewNop())
+
+	v.Stop()
+	v.Stop() // must not panic or block
+}
+
+func TestParseCRLPEM_InvalidInput(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseCRLPEM("not a crl")
+	require.Error(t, err)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -121,6 +121,11 @@ type Server struct {
 	o2AuthMw     AuthMiddleware    // mTLS-only auth middleware for O2 router
 	auditLogger  *auth.AuditLogger // Audit logging for security events
 	shutdownOnce sync.Once         // Ensures shutdown logic runs only once
+
+	// crlVerifier performs Vault-backed CRL checking on TLS peer
+	// certificates. It is optional: when nil or disabled, peer
+	// verification is unchanged from the pre-CRL behaviour.
+	crlVerifier *CRLVerifier
 }
 
 // AuthStore defines the interface for auth storage operations.
@@ -860,12 +865,36 @@ func (s *Server) buildO2TLSConfig() (*tls.Config, error) {
 		tlsCfg.ClientCAs = caCertPool
 	}
 
+	// Attach Vault-backed CRL verification when configured. This runs in
+	// addition to Go's built-in chain verification and rejects peers
+	// whose certificate serial appears in the CRL or whose verifier is
+	// in a stale fail-closed state (see issue #496 / I5).
+	if s.crlVerifier != nil && tlsCfg.ClientAuth != tls.NoClientCert {
+		tlsCfg.VerifyPeerCertificate = s.crlVerifier.VerifyPeerCertificate()
+	}
+
 	s.logger.Info("O2 mTLS configuration built",
 		zap.String("min_version", s.config.TLS.MinVersion),
 		zap.String("client_auth", s.config.TLS.ClientAuth),
+		zap.Bool("crl_enabled", s.crlVerifier != nil),
 	)
 
 	return tlsCfg, nil
+}
+
+// SetupCRLVerifier attaches a Vault-backed CRL verifier to the server so
+// that buildO2TLSConfig wires a VerifyPeerCertificate callback into the
+// resulting tls.Config. It must be called before Start.
+//
+// Passing a nil verifier disables CRL checking. The caller retains
+// ownership of the verifier's lifecycle: Shutdown will stop it.
+func (s *Server) SetupCRLVerifier(v *CRLVerifier) {
+	s.crlVerifier = v
+	if v == nil {
+		s.logger.Info("CRL verifier not configured; mTLS peer verification will not consult a CRL")
+		return
+	}
+	s.logger.Info("CRL verifier attached to server")
 }
 
 // buildTLSConfig is kept for backward compatibility with tests.
@@ -907,6 +936,12 @@ func (s *Server) shutdownWithContext(ctx context.Context) error {
 			if err := s.smoRegistry.Close(); err != nil {
 				s.logger.Warn("error closing SMO registry", zap.Error(err))
 			}
+		}
+
+		// Stop the CRL verifier refresh goroutine, if any.
+		if s.crlVerifier != nil {
+			s.logger.Info("stopping CRL verifier")
+			s.crlVerifier.Stop()
 		}
 
 		// Shutdown all HTTP servers, collecting all errors


### PR DESCRIPTION
Closes #496