### PR TITLE
[Refactor] Adapter/registry/server-construction polish (M11, M16-M19, I14-I16)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -301,6 +301,13 @@ linters:
         path: internal/backend/adapter_(factory|registry)\.go
         text: returns interface
       - linters:
+          - ireturn
+        path: internal/smo/registry\.go
+        text: returns interface
+      - linters:
+          - gochecknoinits
+        path: internal/backend/adapter_factory\.go
+      - linters:
           - revive
         path: internal/adapters/
         text: unused-parameter.*ctx

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -509,7 +509,7 @@ func createHTTPServer(
 	authMw *auth.Middleware,
 ) (*server.Server, error) {
 	// Create server (no static adapter — adapters are loaded dynamically via registry)
-	srv := server.New(cfg, logger, nil, store, authStore, authMw)
+	srv := server.New(cfg, logger, nil, store, authStore, server.WithAuthMiddleware(authMw))
 
 	logger.Info("HTTP server created",
 		zap.String("host", cfg.Server.Host),
@@ -884,7 +884,7 @@ func initializeDMS(
 // registerMockDMSAdapter registers the mock DMS adapter.
 func registerMockDMSAdapter(ctx context.Context, dmsReg *dmsregistry.Registry, logger *zap.Logger) error {
 	logger.Info("initializing mock DMS adapter")
-	mockDMSAdapter := dmsmock.NewAdapter(true) // Pre-populate with sample data
+	mockDMSAdapter := dmsmock.New(true) // Pre-populate with sample data
 	if initErr := mockDMSAdapter.Initialize(ctx); initErr != nil {
 		return fmt.Errorf("failed to initialize mock DMS adapter: %w", initErr)
 	}
@@ -921,7 +921,7 @@ func registerHelmDMSAdapter(
 		Timeout:    30 * time.Second,
 	}
 
-	helmAdapter, createErr := helm.NewAdapter(helmConfig)
+	helmAdapter, createErr := helm.New(helmConfig)
 	if createErr != nil {
 		return fmt.Errorf("failed to create Helm adapter: %w", createErr)
 	}

--- a/docs/adapters/dms/VERIFICATION.md
+++ b/docs/adapters/dms/VERIFICATION.md
@@ -44,7 +44,7 @@ func initializeDMS(
         Timeout:    30 * time.Second,
     }
 
-    helmAdapter, err := helm.NewAdapter(helmConfig)
+    helmAdapter, err := helm.New(helmConfig)
     if err != nil {
         return fmt.Errorf("failed to create Helm adapter: %w", err)
     }

--- a/internal/adapters/aws/resources.go
+++ b/internal/adapters/aws/resources.go
@@ -90,7 +90,7 @@ func (a *Adapter) ListResources(
 		resources = adapter.ApplyPagination(resources, filter.Limit, filter.Offset)
 	}
 
-	a.logger.Info("listed resources",
+	a.logger.Debug("listed resources",
 		zap.Int("count", len(resources)))
 
 	return resources, nil

--- a/internal/adapters/azure/adapter.go
+++ b/internal/adapters/azure/adapter.go
@@ -24,6 +24,14 @@ import (
 	"go.uber.org/zap"
 )
 
+// Pool mode constants for Azure resource pool mapping.
+const (
+	// PoolModeResourceGroup maps O2-IMS resource pools to Azure Resource Groups.
+	PoolModeResourceGroup = "rg"
+	// PoolModeAvailabilityZone maps O2-IMS resource pools to Azure Availability Zones.
+	PoolModeAvailabilityZone = "az"
+)
+
 // Adapter implements the adapter.Adapter interface for Azure backends.
 // It provides O2-IMS functionality by mapping O2-IMS resources to Azure resources:
 //   - Resource Pools → Resource Groups or Availability Zones
@@ -218,8 +226,9 @@ func validateAzureConfig(cfg *Config) error {
 	}
 
 	// Validate poolMode if provided
-	if cfg.PoolMode != "" && cfg.PoolMode != "rg" && cfg.PoolMode != "az" {
-		return fmt.Errorf("poolMode must be 'rg' or 'az', got %q", cfg.PoolMode)
+	if cfg.PoolMode != "" && cfg.PoolMode != PoolModeResourceGroup && cfg.PoolMode != PoolModeAvailabilityZone {
+		return fmt.Errorf("poolMode must be '%s' or '%s', got %q",
+			PoolModeResourceGroup, PoolModeAvailabilityZone, cfg.PoolMode)
 	}
 
 	return nil
@@ -253,7 +262,7 @@ func applyAzureDefaults(cfg *Config) (string, string) {
 
 	poolMode := cfg.PoolMode
 	if poolMode == "" {
-		poolMode = "rg"
+		poolMode = PoolModeResourceGroup
 	}
 
 	return deploymentManagerID, poolMode

--- a/internal/adapters/azure/resourcepools.go
+++ b/internal/adapters/azure/resourcepools.go
@@ -24,7 +24,7 @@ func (a *Adapter) ListResourcePools(
 		zap.Any("filter", filter),
 		zap.String("pool_mode", a.poolMode))
 
-	if a.poolMode == "az" {
+	if a.poolMode == PoolModeAvailabilityZone {
 		pools := a.listAZPools(ctx, filter)
 		return pools, nil
 	}
@@ -144,7 +144,7 @@ func (a *Adapter) GetResourcePool(ctx context.Context, id string) (*adapter.Reso
 	a.logger.Debug("GetResourcePool called",
 		zap.String("id", id))
 
-	if a.poolMode == "az" {
+	if a.poolMode == PoolModeAvailabilityZone {
 		return a.getAZPool(ctx, id)
 	}
 	return a.getRGPool(ctx, id)
@@ -193,7 +193,7 @@ func (a *Adapter) CreateResourcePool(
 	a.logger.Debug("CreateResourcePool called",
 		zap.String("name", pool.Name))
 
-	if a.poolMode == "az" {
+	if a.poolMode == PoolModeAvailabilityZone {
 		err = fmt.Errorf(
 			"cannot create resource pools in 'az' mode: " +
 				"availability zones are Azure-managed",
@@ -221,7 +221,7 @@ func (a *Adapter) UpdateResourcePool(
 		zap.String("id", id),
 		zap.String("name", pool.Name))
 
-	if a.poolMode == "az" {
+	if a.poolMode == PoolModeAvailabilityZone {
 		err = fmt.Errorf("cannot update resource pools in 'az' mode: availability zones are Azure-managed")
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (a *Adapter) DeleteResourcePool(_ context.Context, id string) error {
 	a.logger.Debug("DeleteResourcePool called",
 		zap.String("id", id))
 
-	if a.poolMode == "az" {
+	if a.poolMode == PoolModeAvailabilityZone {
 		return fmt.Errorf("cannot delete resource pools in 'az' mode: availability zones are Azure-managed")
 	}
 

--- a/internal/adapters/azure/resources.go
+++ b/internal/adapters/azure/resources.go
@@ -71,7 +71,7 @@ func (a *Adapter) ListResources(
 		resources = adapter.ApplyPagination(resources, filter.Limit, filter.Offset)
 	}
 
-	a.logger.Info("listed resources",
+	a.logger.Debug("listed resources",
 		zap.Int("count", len(resources)))
 
 	return resources, nil
@@ -311,7 +311,7 @@ func (a *Adapter) extractVMSize(vm *armcompute.VirtualMachine) string {
 }
 
 func (a *Adapter) determineResourcePoolID(vm *armcompute.VirtualMachine, location, resourceGroup string) string {
-	if a.poolMode == "rg" {
+	if a.poolMode == PoolModeResourceGroup {
 		return GenerateRGPoolID(resourceGroup)
 	}
 

--- a/internal/adapters/dtias/config_viper_test.go
+++ b/internal/adapters/dtias/config_viper_test.go
@@ -1,0 +1,53 @@
+package dtias_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/adapters/dtias"
+)
+
+// TestConfigMapstructureTags verifies that every field on dtias.Config can be
+// populated by Viper's UnmarshalKey, which relies on the `mapstructure` struct
+// tags. If a field is missing a tag (or uses the wrong tag name, e.g. `yaml`),
+// the asserted value will be the zero value and the test fails.
+func TestConfigMapstructureTags(t *testing.T) {
+	const yamlDoc = `
+dtias:
+  endpoint: "https://dtias.example.com/api/v1"
+  apiKey: "secret-api-key"
+  clientCert: "/tmp/cert.pem"
+  clientKey: "/tmp/key.pem"
+  caCert: "/tmp/ca.pem"
+  timeout: 45s
+  ocloudId: "ocloud-dtias-1"
+  deploymentManagerId: "dm-dtias-1"
+  datacenter: "dc-dallas-1"
+  retryAttempts: 5
+  retryDelay: 2s
+`
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(bytes.NewBufferString(yamlDoc)))
+
+	var cfg dtias.Config
+	require.NoError(t, v.UnmarshalKey("dtias", &cfg))
+
+	assert.Equal(t, "https://dtias.example.com/api/v1", cfg.Endpoint)
+	assert.Equal(t, "secret-api-key", cfg.APIKey)
+	assert.Equal(t, "/tmp/cert.pem", cfg.ClientCert)
+	assert.Equal(t, "/tmp/key.pem", cfg.ClientKey)
+	assert.Equal(t, "/tmp/ca.pem", cfg.CACert)
+	assert.Equal(t, 45*time.Second, cfg.Timeout)
+	assert.Equal(t, "ocloud-dtias-1", cfg.OCloudID)
+	assert.Equal(t, "dm-dtias-1", cfg.DeploymentManagerID)
+	assert.Equal(t, "dc-dallas-1", cfg.Datacenter)
+	assert.Equal(t, 5, cfg.RetryAttempts)
+	assert.Equal(t, 2*time.Second, cfg.RetryDelay)
+}

--- a/internal/adapters/gcp/resources.go
+++ b/internal/adapters/gcp/resources.go
@@ -37,7 +37,7 @@ func (a *Adapter) ListResources(
 		resources = adapter.ApplyPagination(resources, filter.Limit, filter.Offset)
 	}
 
-	a.logger.Info("listed resources",
+	a.logger.Debug("listed resources",
 		zap.Int("count", len(resources)))
 
 	return resources, nil

--- a/internal/adapters/kubernetes/resources.go
+++ b/internal/adapters/kubernetes/resources.go
@@ -84,7 +84,7 @@ func (a *Adapter) ListResources(
 		"filtered":       filter != nil,
 	})
 
-	a.logger.Info("listed resources",
+	a.logger.Debug("listed resources",
 		zap.Int("count", len(resources)))
 
 	return resources, nil

--- a/internal/adapters/mock/adapter.go
+++ b/internal/adapters/mock/adapter.go
@@ -32,16 +32,27 @@ type Adapter struct {
 // DefaultOCloudID is the default O-Cloud identifier used by mock adapters.
 const DefaultOCloudID = "mock-ocloud-01"
 
-// NewAdapter creates a new mock adapter with sample data.
-// Pass populateSampleData=true to pre-populate with realistic test data.
-func NewAdapter(populateSampleData bool) *Adapter {
-	return NewAdapterWithOCloudID(DefaultOCloudID, populateSampleData)
+// Config holds configuration for the mock IMS adapter.
+// Use mapstructure tags so Viper's UnmarshalKey decodes YAML/JSON/env uniformly.
+type Config struct {
+	// OCloudID overrides the default O-Cloud identifier for this mock instance.
+	// Leave empty to use DefaultOCloudID. Instances with distinct OCloudIDs
+	// produce distinct sample data, allowing multi-tenant testing.
+	OCloudID string `mapstructure:"ocloudId"`
+
+	// PopulateSampleData, when true, pre-populates the adapter with realistic
+	// resource pools, resources, and resource types for tests and demos.
+	PopulateSampleData bool `mapstructure:"populateSampleData"`
 }
 
-// NewAdapterWithOCloudID creates a new mock adapter with a custom O-Cloud ID.
-// Each instance gets distinct sample data prefixed with its ocloudID, ensuring
-// different tenants see different O-Clouds with unique resources.
-func NewAdapterWithOCloudID(ocloudID string, populateSampleData bool) *Adapter {
+// New creates a new mock IMS adapter from the provided configuration.
+// Passing a nil cfg is equivalent to &Config{} (empty OCloudID, no sample data).
+func New(cfg *Config) *Adapter {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+
+	ocloudID := cfg.OCloudID
 	if ocloudID == "" {
 		ocloudID = DefaultOCloudID
 	}
@@ -55,7 +66,7 @@ func NewAdapterWithOCloudID(ocloudID string, populateSampleData bool) *Adapter {
 	}
 	a.deploymentManager = a.createDeploymentManager()
 
-	if populateSampleData {
+	if cfg.PopulateSampleData {
 		a.populateSampleData()
 	}
 

--- a/internal/adapters/openstack/resources.go
+++ b/internal/adapters/openstack/resources.go
@@ -31,7 +31,7 @@ func (a *Adapter) ListResources(ctx context.Context, filter *adapter.Filter) ([]
 	// Apply pagination
 	resources = a.applyPaginationIfNeeded(resources, filter)
 
-	a.logger.Info("listed resources",
+	a.logger.Debug("listed resources",
 		zap.Int("count", len(resources)))
 
 	return resources, nil

--- a/internal/adapters/vmware/resources.go
+++ b/internal/adapters/vmware/resources.go
@@ -75,7 +75,7 @@ func (a *Adapter) ListResources(
 		resources = adapter.ApplyPagination(resources, filter.Limit, filter.Offset)
 	}
 
-	a.logger.Info("listed resources",
+	a.logger.Debug("listed resources",
 		zap.Int("count", len(resources)))
 
 	return resources, nil

--- a/internal/backend/adapter_factory.go
+++ b/internal/backend/adapter_factory.go
@@ -27,10 +27,10 @@ type DMSAdapterConstructor func(instance *Instance) (dmsadapter.DMSAdapter, erro
 type SMOAdapterConstructor func(instance *Instance) (smo.Plugin, error)
 
 var (
-	registryMu          sync.RWMutex
-	imsConstructors     = map[string]AdapterConstructor{}
-	dmsConstructors     = map[string]DMSAdapterConstructor{}
-	smoConstructors     = map[string]SMOAdapterConstructor{}
+	registryMu      sync.RWMutex
+	imsConstructors = map[string]AdapterConstructor{}
+	dmsConstructors = map[string]DMSAdapterConstructor{}
+	smoConstructors = map[string]SMOAdapterConstructor{}
 )
 
 // RegisterIMSAdapter registers a factory constructor for an IMS adapter type.

--- a/internal/backend/adapter_factory.go
+++ b/internal/backend/adapter_factory.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/piwi3910/netweave/internal/adapter"
 	imsmock "github.com/piwi3910/netweave/internal/adapters/mock"
@@ -13,8 +14,51 @@ import (
 	smomock "github.com/piwi3910/netweave/internal/smo/adapters/mock"
 )
 
+// ErrUnsupportedAdapterType is returned when an adapter type is not supported by the factory.
+var ErrUnsupportedAdapterType = fmt.Errorf("unsupported adapter type")
+
+// AdapterConstructor is an IMS adapter constructor registered by plugins at init-time.
+type AdapterConstructor func(instance *Instance) (adapter.Adapter, error)
+
+// DMSAdapterConstructor is a DMS adapter constructor registered by plugins at init-time.
+type DMSAdapterConstructor func(instance *Instance) (dmsadapter.DMSAdapter, error)
+
+// SMOAdapterConstructor is an SMO plugin constructor registered by plugins at init-time.
+type SMOAdapterConstructor func(instance *Instance) (smo.Plugin, error)
+
+var (
+	registryMu          sync.RWMutex
+	imsConstructors     = map[string]AdapterConstructor{}
+	dmsConstructors     = map[string]DMSAdapterConstructor{}
+	smoConstructors     = map[string]SMOAdapterConstructor{}
+)
+
+// RegisterIMSAdapter registers a factory constructor for an IMS adapter type.
+// Intended to be called from init() functions in adapter packages.
+func RegisterIMSAdapter(adapterType string, ctor AdapterConstructor) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	imsConstructors[adapterType] = ctor
+}
+
+// RegisterDMSAdapter registers a factory constructor for a DMS adapter type.
+// Intended to be called from init() functions in adapter packages.
+func RegisterDMSAdapter(adapterType string, ctor DMSAdapterConstructor) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	dmsConstructors[adapterType] = ctor
+}
+
+// RegisterSMOAdapter registers a factory constructor for an SMO adapter type.
+// Intended to be called from init() functions in adapter packages.
+func RegisterSMOAdapter(adapterType string, ctor SMOAdapterConstructor) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	smoConstructors[adapterType] = ctor
+}
+
 // AdapterFactory creates adapter instances from backend Instance records.
-// It maps adapter type strings to concrete adapter constructors.
+// It dispatches to constructors registered via Register*Adapter at init().
 type AdapterFactory struct{}
 
 // NewAdapterFactory creates a new AdapterFactory.
@@ -23,53 +67,46 @@ func NewAdapterFactory() *AdapterFactory {
 }
 
 // CreateAdapter creates an adapter.Adapter from a backend Instance record.
-// The instance's AdapterType determines which concrete adapter is created.
-// Config and credentials are parsed from the instance's encrypted fields.
 func (f *AdapterFactory) CreateAdapter(instance *Instance) (adapter.Adapter, error) {
 	if instance == nil {
 		return nil, fmt.Errorf("instance cannot be nil")
 	}
-
-	switch instance.AdapterType {
-	case "mock":
-		return f.createMockAdapter(instance)
-	default:
+	registryMu.RLock()
+	ctor, ok := imsConstructors[instance.AdapterType]
+	registryMu.RUnlock()
+	if !ok {
 		return nil, fmt.Errorf("unsupported adapter type %q: %w", instance.AdapterType, ErrUnsupportedAdapterType)
 	}
+	return ctor(instance)
 }
 
 // CreateDMSAdapter creates a dms adapter.DMSAdapter from a backend Instance record.
-// The instance's AdapterType determines which concrete DMS adapter is created.
 func (f *AdapterFactory) CreateDMSAdapter(instance *Instance) (dmsadapter.DMSAdapter, error) {
 	if instance == nil {
 		return nil, fmt.Errorf("instance cannot be nil")
 	}
-
-	switch instance.AdapterType {
-	case "mock-dms":
-		return f.createMockDMSAdapter(instance)
-	default:
+	registryMu.RLock()
+	ctor, ok := dmsConstructors[instance.AdapterType]
+	registryMu.RUnlock()
+	if !ok {
 		return nil, fmt.Errorf("unsupported DMS adapter type %q: %w", instance.AdapterType, ErrUnsupportedAdapterType)
 	}
+	return ctor(instance)
 }
 
 // CreateSMOAdapter creates an smo.Plugin from a backend Instance record.
-// The instance's AdapterType determines which concrete SMO plugin is created.
 func (f *AdapterFactory) CreateSMOAdapter(instance *Instance) (smo.Plugin, error) {
 	if instance == nil {
 		return nil, fmt.Errorf("instance cannot be nil")
 	}
-
-	switch instance.AdapterType {
-	case "mock-smo":
-		return f.createMockSMOAdapter(instance)
-	default:
+	registryMu.RLock()
+	ctor, ok := smoConstructors[instance.AdapterType]
+	registryMu.RUnlock()
+	if !ok {
 		return nil, fmt.Errorf("unsupported SMO adapter type %q: %w", instance.AdapterType, ErrUnsupportedAdapterType)
 	}
+	return ctor(instance)
 }
-
-// ErrUnsupportedAdapterType is returned when an adapter type is not supported by the factory.
-var ErrUnsupportedAdapterType = fmt.Errorf("unsupported adapter type")
 
 // parseConfigMap parses instance.Config as a generic map.
 // Config values can be strings (from admin API map[string]string)
@@ -118,8 +155,15 @@ func configString(m map[string]interface{}, key string) string {
 	return fmt.Sprintf("%v", v)
 }
 
+// init registers the built-in mock adapters.
+func init() {
+	RegisterIMSAdapter("mock", createMockAdapter)
+	RegisterDMSAdapter("mock-dms", createMockDMSAdapter)
+	RegisterSMOAdapter("mock-smo", createMockSMOAdapter)
+}
+
 // createMockAdapter creates a mock IMS adapter from instance configuration.
-func (f *AdapterFactory) createMockAdapter(instance *Instance) (adapter.Adapter, error) {
+func createMockAdapter(instance *Instance) (adapter.Adapter, error) {
 	configMap, err := parseConfigMap(instance.Config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse mock adapter config: %w", err)
@@ -132,11 +176,14 @@ func (f *AdapterFactory) createMockAdapter(instance *Instance) (adapter.Adapter,
 		ocloudID = instance.ID
 	}
 
-	return imsmock.NewAdapterWithOCloudID(ocloudID, populateSampleData), nil
+	return imsmock.New(&imsmock.Config{
+		OCloudID:           ocloudID,
+		PopulateSampleData: populateSampleData,
+	}), nil
 }
 
 // createMockDMSAdapter creates a mock DMS adapter from instance configuration.
-func (f *AdapterFactory) createMockDMSAdapter(instance *Instance) (dmsadapter.DMSAdapter, error) {
+func createMockDMSAdapter(instance *Instance) (dmsadapter.DMSAdapter, error) {
 	configMap, err := parseConfigMap(instance.Config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse mock DMS adapter config: %w", err)
@@ -144,12 +191,12 @@ func (f *AdapterFactory) createMockDMSAdapter(instance *Instance) (dmsadapter.DM
 
 	populateSampleData := configBool(configMap, "populate_sample_data", true)
 
-	return dmsmock.NewAdapter(populateSampleData), nil
+	return dmsmock.New(populateSampleData), nil
 }
 
 // createMockSMOAdapter creates a mock SMO plugin from instance configuration.
-func (f *AdapterFactory) createMockSMOAdapter(instance *Instance) (smo.Plugin, error) {
-	plugin := smomock.NewPlugin()
+func createMockSMOAdapter(instance *Instance) (smo.Plugin, error) {
+	plugin := smomock.New()
 
 	if _, err := parseConfigMap(instance.Config); err != nil {
 		return nil, fmt.Errorf("failed to parse mock SMO adapter config: %w", err)

--- a/internal/dms/adapters/argocd/README.md
+++ b/internal/dms/adapters/argocd/README.md
@@ -35,7 +35,7 @@ config := &argocd.Config{
 }
 
 // Create the adapter
-adapter, err := argocd.NewAdapter(config)
+adapter, err := argocd.New(config)
 if err != nil {
     log.Fatal(err)
 }

--- a/internal/dms/adapters/argocd/adapter.go
+++ b/internal/dms/adapters/argocd/adapter.go
@@ -100,9 +100,9 @@ type Config struct {
 	SelfHeal bool
 }
 
-// NewAdapter creates a new ArgoCD adapter instance.
+// New creates a new ArgoCD adapter instance.
 // Returns an error if the adapter cannot be initialized.
-func NewAdapter(config *Config) (*Adapter, error) {
+func New(config *Config) (*Adapter, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config cannot be nil")
 	}

--- a/internal/dms/adapters/argocd/adapter_test.go
+++ b/internal/dms/adapters/argocd/adapter_test.go
@@ -57,7 +57,7 @@ func TestNewAdapter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adp, err := argocd.NewAdapter(tt.config)
+			adp, err := argocd.New(tt.config)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -83,7 +83,7 @@ func TestNewAdapter(t *testing.T) {
 
 // TestAdapterMetadata tests adapter metadata methods.
 func TestAdapterMetadata(t *testing.T) {
-	adp, err := argocd.NewAdapter(&argocd.Config{})
+	adp, err := argocd.New(&argocd.Config{})
 	require.NoError(t, err)
 
 	t.Run("Name", func(t *testing.T) {
@@ -144,7 +144,7 @@ func createFakeAdapter(t *testing.T, objects ...runtime.Object) *argocd.Adapter 
 	// Create fake dynamic client
 	client := dynamicfake.NewSimpleDynamicClient(scheme, objects...)
 
-	adp, err := argocd.NewAdapter(&argocd.Config{
+	adp, err := argocd.New(&argocd.Config{
 		Namespace: "argocd.argocd",
 	})
 	require.NoError(t, err)
@@ -788,7 +788,7 @@ func TestClose(t *testing.T) {
 
 // TestTransformArgoCDStatus tests status transformation logic.
 func TestTransformArgoCDStatus(t *testing.T) {
-	adp, _ := argocd.NewAdapter(&argocd.Config{})
+	adp, _ := argocd.New(&argocd.Config{})
 
 	tests := []struct {
 		name         string
@@ -850,7 +850,7 @@ func TestTransformArgoCDStatus(t *testing.T) {
 
 // TestCalculateProgress tests progress calculation.
 func TestCalculateProgress(t *testing.T) {
-	adp, _ := argocd.NewAdapter(&argocd.Config{})
+	adp, _ := argocd.New(&argocd.Config{})
 
 	tests := []struct {
 		name         string
@@ -942,7 +942,7 @@ func TestBuildLabelSelector(t *testing.T) {
 
 // TestApplyPagination tests pagination logic.
 func TestApplyPagination(t *testing.T) {
-	adp, _ := argocd.NewAdapter(&argocd.Config{})
+	adp, _ := argocd.New(&argocd.Config{})
 
 	deployments := []*dmsadapter.Deployment{
 		{ID: "1"}, {ID: "2"}, {ID: "3"}, {ID: "4"}, {ID: "5"},
@@ -1234,7 +1234,7 @@ func BenchmarkListDeployments(b *testing.B) {
 	)
 	client := dynamicfake.NewSimpleDynamicClient(scheme, apps...)
 
-	adp, _ := argocd.NewAdapter(&argocd.Config{Namespace: "argocd.argocd"})
+	adp, _ := argocd.New(&argocd.Config{Namespace: "argocd.argocd"})
 	adp.DynamicClient = client
 
 	ctx := context.Background()
@@ -1325,7 +1325,7 @@ func TestExtractSource(t *testing.T) {
 
 // TestTransformApplicationToDeployment tests transformation of ArgoCD Application to Deployment.
 func TestTransformApplicationToDeployment(t *testing.T) {
-	adp, _ := argocd.NewAdapter(&argocd.Config{})
+	adp, _ := argocd.New(&argocd.Config{})
 
 	tests := []struct {
 		name       string
@@ -1451,7 +1451,7 @@ func TestConfigDefaults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adp, err := argocd.NewAdapter(tt.config)
+			adp, err := argocd.New(tt.config)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantNamespace, adp.Config.Namespace)

--- a/internal/dms/adapters/crossplane/adapter.go
+++ b/internal/dms/adapters/crossplane/adapter.go
@@ -114,8 +114,8 @@ type Config struct {
 	ProviderConfig string
 }
 
-// NewAdapter creates a new Crossplane adapter instance.
-func NewAdapter(config *Config) (*Adapter, error) {
+// New creates a new Crossplane adapter instance.
+func New(config *Config) (*Adapter, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config cannot be nil")
 	}

--- a/internal/dms/adapters/crossplane/adapter_test.go
+++ b/internal/dms/adapters/crossplane/adapter_test.go
@@ -59,7 +59,7 @@ func TestNewAdapter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adp, err := crossplane.NewAdapter(tt.config)
+			adp, err := crossplane.New(tt.config)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -82,7 +82,7 @@ func TestNewAdapter(t *testing.T) {
 
 // TestAdapterMetadata tests adapter metadata methods.
 func TestAdapterMetadata(t *testing.T) {
-	adp, err := crossplane.NewAdapter(&crossplane.Config{})
+	adp, err := crossplane.New(&crossplane.Config{})
 	require.NoError(t, err)
 
 	t.Run("Name", func(t *testing.T) {
@@ -177,7 +177,7 @@ func createFakeAdapter(t *testing.T, objects ...runtime.Object) *crossplane.Adap
 	// Create fake dynamic client
 	client := dynamicfake.NewSimpleDynamicClient(scheme, objects...)
 
-	adp, err := crossplane.NewAdapter(&crossplane.Config{
+	adp, err := crossplane.New(&crossplane.Config{
 		Namespace: "default",
 	})
 	require.NoError(t, err)
@@ -903,7 +903,7 @@ func TestValidateName(t *testing.T) {
 
 // TestCalculateProgress tests progress calculation.
 func TestCalculateProgress(t *testing.T) {
-	adp, _ := crossplane.NewAdapter(&crossplane.Config{})
+	adp, _ := crossplane.New(&crossplane.Config{})
 
 	tests := []struct {
 		name   string
@@ -926,7 +926,7 @@ func TestCalculateProgress(t *testing.T) {
 
 // TestApplyPagination tests pagination logic.
 func TestApplyPagination(t *testing.T) {
-	adp, _ := crossplane.NewAdapter(&crossplane.Config{})
+	adp, _ := crossplane.New(&crossplane.Config{})
 
 	deployments := []*dmsadapter.Deployment{
 		{ID: "1"}, {ID: "2"}, {ID: "3"}, {ID: "4"}, {ID: "5"},
@@ -1064,7 +1064,7 @@ func BenchmarkListDeployments(b *testing.B) {
 
 	client := dynamicfake.NewSimpleDynamicClient(scheme, objects...)
 
-	adp, _ := crossplane.NewAdapter(&crossplane.Config{Namespace: "default"})
+	adp, _ := crossplane.New(&crossplane.Config{Namespace: "default"})
 	adp.DynamicClient = client
 
 	ctx := context.Background()

--- a/internal/dms/adapters/flux/README.md
+++ b/internal/dms/adapters/flux/README.md
@@ -57,7 +57,7 @@ config := &flux.Config{
     TargetNamespace: "default",
 }
 
-adapter, err := flux.NewAdapter(config)
+adapter, err := flux.New(config)
 if err != nil {
     log.Fatal(err)
 }

--- a/internal/dms/adapters/flux/adapter.go
+++ b/internal/dms/adapters/flux/adapter.go
@@ -181,9 +181,9 @@ type Config struct {
 	TargetNamespace string
 }
 
-// NewAdapter creates a new Flux adapter instance.
+// New creates a new Flux adapter instance.
 // Returns an error if the adapter cannot be initialized.
-func NewAdapter(config *Config) (*Adapter, error) {
+func New(config *Config) (*Adapter, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config cannot be nil")
 	}

--- a/internal/dms/adapters/flux/adapter_test.go
+++ b/internal/dms/adapters/flux/adapter_test.go
@@ -65,7 +65,7 @@ func TestNewAdapter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adp, err := flux.NewAdapter(tt.config)
+			adp, err := flux.New(tt.config)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -91,7 +91,7 @@ func TestNewAdapter(t *testing.T) {
 
 // TestAdapterMetadata tests adapter metadata methods.
 func TestAdapterMetadata(t *testing.T) {
-	adp, err := flux.NewAdapter(&flux.Config{})
+	adp, err := flux.New(&flux.Config{})
 	require.NoError(t, err)
 
 	t.Run("Name", func(t *testing.T) {
@@ -205,7 +205,7 @@ func createFakeAdapter(t *testing.T, objects ...runtime.Object) *flux.Adapter {
 	// Create fake dynamic client
 	client := dynamicfake.NewSimpleDynamicClient(scheme, objects...)
 
-	adp, err := flux.NewAdapter(&flux.Config{
+	adp, err := flux.New(&flux.Config{
 		Namespace:       "flux.flux-system",
 		SourceNamespace: "flux.flux-system",
 	})
@@ -1174,7 +1174,7 @@ func TestClose(t *testing.T) {
 
 // TestExtractFluxStatus tests status extraction from conditions.
 func TestExtractFluxStatus(t *testing.T) {
-	adp, _ := flux.NewAdapter(&flux.Config{})
+	adp, _ := flux.New(&flux.Config{})
 
 	tests := []struct {
 		name       string
@@ -1234,7 +1234,7 @@ func TestExtractFluxStatus(t *testing.T) {
 
 // TestCalculateProgress tests progress calculation.
 func TestCalculateProgress(t *testing.T) {
-	adp, _ := flux.NewAdapter(&flux.Config{})
+	adp, _ := flux.New(&flux.Config{})
 
 	tests := []struct {
 		name   string
@@ -1316,7 +1316,7 @@ func TestBuildLabelSelector(t *testing.T) {
 
 // TestApplyPagination tests pagination logic.
 func TestApplyPagination(t *testing.T) {
-	adp, _ := flux.NewAdapter(&flux.Config{})
+	adp, _ := flux.New(&flux.Config{})
 
 	deployments := []*dmsadapter.Deployment{
 		{ID: "1"}, {ID: "2"}, {ID: "3"}, {ID: "4"}, {ID: "5"},
@@ -1476,7 +1476,7 @@ func BenchmarkListDeployments(b *testing.B) {
 
 	client := dynamicfake.NewSimpleDynamicClient(scheme, objects...)
 
-	adp, _ := flux.NewAdapter(&flux.Config{Namespace: "flux.flux-system"})
+	adp, _ := flux.New(&flux.Config{Namespace: "flux.flux-system"})
 	adp.DynamicClient = client
 
 	ctx := context.Background()

--- a/internal/dms/adapters/helm/README.md
+++ b/internal/dms/adapters/helm/README.md
@@ -93,7 +93,7 @@ import (
 
 func main() {
     // Create Helm adapter
-    helmAdapter, err := helm.NewAdapter(&helm.Config{
+    helmAdapter, err := helm.New(&helm.Config{
         Namespace:          "production",
         RepositoryURL:      "https://charts.example.com",
         RepositoryUsername: "admin",

--- a/internal/dms/adapters/helm/adapter.go
+++ b/internal/dms/adapters/helm/adapter.go
@@ -78,9 +78,9 @@ type Config struct {
 	Debug bool
 }
 
-// NewAdapter creates a new Helm adapter instance.
+// New creates a new Helm adapter instance.
 // Returns an error if the adapter cannot be initialized.
-func NewAdapter(config *Config) (*Adapter, error) {
+func New(config *Config) (*Adapter, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config cannot be nil")
 	}

--- a/internal/dms/adapters/helm/adapter_integration_test.go
+++ b/internal/dms/adapters/helm/adapter_integration_test.go
@@ -64,7 +64,7 @@ func TestHelmAdapter_ListDeploymentPackages_WithMockRepo(t *testing.T) {
 	mockRepo := createMockHelmRepo()
 	defer mockRepo.Close()
 
-	adp, err := helm.NewAdapter(&helm.Config{
+	adp, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: mockRepo.URL,
 	})
@@ -144,7 +144,7 @@ func TestHelmAdapter_GetDeploymentPackage_WithMockRepo(t *testing.T) {
 	mockRepo := createMockHelmRepo()
 	defer mockRepo.Close()
 
-	adp, err := helm.NewAdapter(&helm.Config{
+	adp, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: mockRepo.URL,
 	})
@@ -262,7 +262,7 @@ generated: "`+time.Now().Format(time.RFC3339)+`"
 	}))
 	defer mockRepo.Close()
 
-	adp, err := helm.NewAdapter(&helm.Config{
+	adp, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: mockRepo.URL,
 	})
@@ -291,7 +291,7 @@ func TestHelmAdapter_DeleteDeploymentPackage_WithMockRepo(t *testing.T) {
 	mockRepo := createMockHelmRepo()
 	defer mockRepo.Close()
 
-	adp, err := helm.NewAdapter(&helm.Config{
+	adp, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: mockRepo.URL,
 	})
@@ -323,7 +323,7 @@ func TestHelmAdapter_UploadDeploymentPackage_Complete(t *testing.T) {
 	mockRepo := createMockHelmRepo()
 	defer mockRepo.Close()
 
-	adp, err := helm.NewAdapter(&helm.Config{
+	adp, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: mockRepo.URL,
 	})

--- a/internal/dms/adapters/helm/adapter_mock_test.go
+++ b/internal/dms/adapters/helm/adapter_mock_test.go
@@ -13,7 +13,7 @@ import (
 
 // TestHelmAdapter_Health_NoK8s tests Health without Kubernetes.
 func TestHelmAdapter_Health_NoK8s(t *testing.T) {
-	adp, err := helm.NewAdapter(&helm.Config{
+	adp, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -31,7 +31,7 @@ func TestHelmAdapter_Health_NoK8s(t *testing.T) {
 
 // TestHelmAdapter_DeleteDeployment_NoK8s tests DeleteDeployment without Kubernetes.
 func TestHelmAdapter_DeleteDeployment_NoK8s(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestHelmAdapter_DeleteDeployment_NoK8s(t *testing.T) {
 
 // TestHelmAdapter_GetDeploymentLogs_NoK8s tests GetDeploymentLogs without Kubernetes.
 func TestHelmAdapter_GetDeploymentLogs_NoK8s(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestHelmAdapter_GetDeploymentLogs_NoK8s(t *testing.T) {
 
 // TestHelmAdapter_ScaleDeployment_NoK8s tests ScaleDeployment without Kubernetes.
 func TestHelmAdapter_ScaleDeployment_NoK8s(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -136,7 +136,7 @@ func TestHelmAdapter_ScaleDeployment_NoK8s(t *testing.T) {
 
 // TestHelmAdapter_GetDeploymentPackage_EmptyID tests GetDeploymentPackage with empty ID.
 func TestHelmAdapter_GetDeploymentPackage_EmptyID(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: "https://charts.example.com",
 	})
@@ -150,7 +150,7 @@ func TestHelmAdapter_GetDeploymentPackage_EmptyID(t *testing.T) {
 
 // TestHelmAdapter_ListDeploymentPackages_WithFilters tests ListDeploymentPackages with various filters.
 func TestHelmAdapter_ListDeploymentPackages_WithFilters(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: "https://charts.example.com",
 	})
@@ -205,7 +205,7 @@ func TestHelmAdapter_ListDeploymentPackages_WithFilters(t *testing.T) {
 
 // TestHelmAdapter_CreateDeployment_CompleteFlow tests CreateDeployment end-to-end.
 func TestHelmAdapter_CreateDeployment_CompleteFlow(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -253,7 +253,7 @@ func TestHelmAdapter_CreateDeployment_CompleteFlow(t *testing.T) {
 
 // TestHelmAdapter_UpdateDeployment_CompleteFlow tests UpdateDeployment end-to-end.
 func TestHelmAdapter_UpdateDeployment_CompleteFlow(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -300,7 +300,7 @@ func TestHelmAdapter_UpdateDeployment_CompleteFlow(t *testing.T) {
 
 // TestHelmAdapter_GetDeployment_CompleteFlow tests GetDeployment end-to-end.
 func TestHelmAdapter_GetDeployment_CompleteFlow(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -337,7 +337,7 @@ func TestHelmAdapter_GetDeployment_CompleteFlow(t *testing.T) {
 
 // TestHelmAdapter_GetDeploymentHistory_CompleteFlow tests GetDeploymentHistory end-to-end.
 func TestHelmAdapter_GetDeploymentHistory_CompleteFlow(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:  "test",
 		MaxHistory: 15,
 	})
@@ -375,7 +375,7 @@ func TestHelmAdapter_GetDeploymentHistory_CompleteFlow(t *testing.T) {
 
 // TestHelmAdapter_ListDeployments_CompleteFlow tests ListDeployments end-to-end.
 func TestHelmAdapter_ListDeployments_CompleteFlow(t *testing.T) {
-	adp, err := helm.NewAdapter(&helm.Config{
+	adp, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -426,7 +426,7 @@ func TestHelmAdapter_ListDeployments_CompleteFlow(t *testing.T) {
 
 // TestHelmAdapter_ScaleDeployment_GetReleaseFails tests ScaleDeployment when get release fails.
 func TestHelmAdapter_ScaleDeployment_GetReleaseFails(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -440,7 +440,7 @@ func TestHelmAdapter_ScaleDeployment_GetReleaseFails(t *testing.T) {
 
 // TestHelmAdapter_GetDeploymentPackage_NonExistentChart tests GetDeploymentPackage with non-existent chart.
 func TestHelmAdapter_GetDeploymentPackage_NonExistentChart(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: "https://charts.example.com",
 	})
@@ -473,7 +473,7 @@ func TestHelmAdapter_GetDeploymentPackage_NonExistentChart(t *testing.T) {
 
 // TestHelmAdapter_DeleteDeploymentPackage_CacheInvalidation tests that cache is cleared on delete.
 func TestHelmAdapter_DeleteDeploymentPackage_CacheInvalidation(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: "https://charts.example.com",
 	})
@@ -489,7 +489,7 @@ func TestHelmAdapter_DeleteDeploymentPackage_CacheInvalidation(t *testing.T) {
 
 // TestHelmAdapter_LoadRepositoryIndex_EmptyURL tests LoadRepositoryIndex with empty URL.
 func TestHelmAdapter_LoadRepositoryIndex_EmptyURL(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: "",
 	})
@@ -503,7 +503,7 @@ func TestHelmAdapter_LoadRepositoryIndex_EmptyURL(t *testing.T) {
 
 // TestHelmAdapter_Initialize_AlreadyInitialized tests Initialize when already initialized.
 func TestHelmAdapter_Initialize_AlreadyInitialized(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -519,7 +519,7 @@ func TestHelmAdapter_Initialize_AlreadyInitialized(t *testing.T) {
 
 // TestHelmAdapter_GetDeploymentStatus_Error tests GetDeploymentStatus error path.
 func TestHelmAdapter_GetDeploymentStatus_Error(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -532,7 +532,7 @@ func TestHelmAdapter_GetDeploymentStatus_Error(t *testing.T) {
 
 // TestHelmAdapter_RollbackDeployment_Error tests RollbackDeployment error path.
 func TestHelmAdapter_RollbackDeployment_Error(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -544,7 +544,7 @@ func TestHelmAdapter_RollbackDeployment_Error(t *testing.T) {
 
 // TestHelmAdapter_GetDeploymentHistory_Error tests GetDeploymentHistory error path.
 func TestHelmAdapter_GetDeploymentHistory_Error(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:  "test",
 		MaxHistory: 10,
 	})
@@ -558,7 +558,7 @@ func TestHelmAdapter_GetDeploymentHistory_Error(t *testing.T) {
 
 // TestHelmAdapter_CreateDeployment_NamespaceDefaults tests CreateDeployment namespace defaults.
 func TestHelmAdapter_CreateDeployment_NamespaceDefaults(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "default-namespace",
 	})
 	require.NoError(t, err)
@@ -578,7 +578,7 @@ func TestHelmAdapter_CreateDeployment_NamespaceDefaults(t *testing.T) {
 
 // TestHelmAdapter_UpdateDeployment_Error tests UpdateDeployment error path.
 func TestHelmAdapter_UpdateDeployment_Error(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -597,7 +597,7 @@ func TestHelmAdapter_UpdateDeployment_Error(t *testing.T) {
 
 // TestHelmAdapter_DeleteDeployment_Error tests DeleteDeployment error path.
 func TestHelmAdapter_DeleteDeployment_Error(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)

--- a/internal/dms/adapters/helm/adapter_test.go
+++ b/internal/dms/adapters/helm/adapter_test.go
@@ -53,7 +53,7 @@ func TestNewAdapter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter, err := helm.NewAdapter(tt.config)
+			adapter, err := helm.New(tt.config)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -78,7 +78,7 @@ func TestNewAdapter(t *testing.T) {
 }
 
 func TestHelmAdapter_Metadata(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -102,7 +102,7 @@ func TestHelmAdapter_Metadata(t *testing.T) {
 }
 
 func TestHelmAdapter_CapabilityChecks(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestHelmAdapter_CapabilityChecks(t *testing.T) {
 }
 
 func TestHelmAdapter_TransformHelmStatus(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestHelmAdapter_TransformHelmStatus(t *testing.T) {
 }
 
 func TestHelmAdapter_CalculateProgress(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestHelmAdapter_CalculateProgress(t *testing.T) {
 }
 
 func TestHelmAdapter_TransformReleaseToDeployment(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -273,7 +273,7 @@ func TestHelmAdapter_TransformReleaseToDeployment(t *testing.T) {
 }
 
 func TestHelmAdapter_TransformReleaseToStatus(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestHelmAdapter_TransformReleaseToStatus(t *testing.T) {
 }
 
 func TestHelmAdapter_BuildConditions(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -358,7 +358,7 @@ func TestHelmAdapter_BuildConditions(t *testing.T) {
 }
 
 func TestHelmAdapter_ApplyPagination(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -435,7 +435,7 @@ func TestHelmAdapter_ApplyPagination(t *testing.T) {
 }
 
 func TestHelmAdapter_UploadDeploymentPackage(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: "https://charts.example.com",
 	})
@@ -486,7 +486,7 @@ func TestHelmAdapter_UploadDeploymentPackage(t *testing.T) {
 }
 
 func TestHelmAdapter_ScaleDeployment_Validation(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -501,7 +501,7 @@ func TestHelmAdapter_ScaleDeployment_Validation(t *testing.T) {
 }
 
 func TestHelmAdapter_RollbackDeployment_Validation(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -516,7 +516,7 @@ func TestHelmAdapter_RollbackDeployment_Validation(t *testing.T) {
 }
 
 func TestHelmAdapter_Close(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -571,7 +571,7 @@ func TestConfig_Defaults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter, err := helm.NewAdapter(tt.input)
+			adapter, err := helm.New(tt.input)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantNamespace, adapter.Config.Namespace)
@@ -583,7 +583,7 @@ func TestConfig_Defaults(t *testing.T) {
 
 // Benchmark tests.
 func BenchmarkHelmAdapter_TransformReleaseToDeployment(b *testing.B) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(b, err)
@@ -613,7 +613,7 @@ func BenchmarkHelmAdapter_TransformReleaseToDeployment(b *testing.B) {
 }
 
 func BenchmarkHelmAdapter_ApplyPagination(b *testing.B) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(b, err)
@@ -634,7 +634,7 @@ func BenchmarkHelmAdapter_ApplyPagination(b *testing.B) {
 
 // TestHelmAdapter_ListDeploymentPackages tests listing packages from repository.
 func TestHelmAdapter_ListDeploymentPackages(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: "https://charts.example.com",
 	})
@@ -687,7 +687,7 @@ func TestHelmAdapter_ListDeploymentPackages(t *testing.T) {
 
 // TestHelmAdapter_GetDeploymentPackage tests getting a specific package.
 func TestHelmAdapter_GetDeploymentPackage(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: "https://charts.example.com",
 	})
@@ -762,7 +762,7 @@ func TestHelmAdapter_GetDeploymentPackage_ErrorPaths(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter, err := helm.NewAdapter(&helm.Config{
+			adapter, err := helm.New(&helm.Config{
 				Namespace:     "test",
 				RepositoryURL: "https://charts.example.com",
 			})
@@ -786,7 +786,7 @@ func TestHelmAdapter_GetDeploymentPackage_ErrorPaths(t *testing.T) {
 
 // TestHelmAdapter_DeleteDeploymentPackage tests package deletion.
 func TestHelmAdapter_DeleteDeploymentPackage(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: "https://charts.example.com",
 	})
@@ -840,7 +840,7 @@ func TestHelmAdapter_LoadRepositoryIndex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter, err := helm.NewAdapter(&helm.Config{
+			adapter, err := helm.New(&helm.Config{
 				Namespace:     "test",
 				RepositoryURL: tt.repoURL,
 			})
@@ -884,7 +884,7 @@ func TestHelmAdapter_DeleteDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter, err := helm.NewAdapter(&helm.Config{
+			adapter, err := helm.New(&helm.Config{
 				Namespace: "test",
 				Timeout:   5 * time.Second,
 			})
@@ -930,7 +930,7 @@ func TestHelmAdapter_GetDeploymentStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter, err := helm.NewAdapter(&helm.Config{
+			adapter, err := helm.New(&helm.Config{
 				Namespace: "test",
 			})
 			require.NoError(t, err)
@@ -980,7 +980,7 @@ func TestHelmAdapter_GetDeploymentHistory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter, err := helm.NewAdapter(&helm.Config{
+			adapter, err := helm.New(&helm.Config{
 				Namespace:  "test",
 				MaxHistory: 10,
 			})
@@ -1053,7 +1053,7 @@ func TestHelmAdapter_GetDeploymentLogs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter, err := helm.NewAdapter(&helm.Config{
+			adapter, err := helm.New(&helm.Config{
 				Namespace: "test",
 			})
 			require.NoError(t, err)
@@ -1079,7 +1079,7 @@ func TestHelmAdapter_GetDeploymentLogs(t *testing.T) {
 }
 
 func TestHelmAdapter_GetDeploymentLogs_AdditionalOptions(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -1182,7 +1182,7 @@ func TestHelmAdapter_Health(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter, err := helm.NewAdapter(&helm.Config{
+			adapter, err := helm.New(&helm.Config{
 				Namespace: "test",
 			})
 			require.NoError(t, err)
@@ -1207,7 +1207,7 @@ func TestHelmAdapter_Health(t *testing.T) {
 
 // TestHelmAdapter_ListDeployments tests the ListDeployments function.
 func TestHelmAdapter_ListDeployments(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 		Timeout:   5 * time.Second,
 	})
@@ -1225,7 +1225,7 @@ func TestHelmAdapter_ListDeployments(t *testing.T) {
 
 // TestHelmAdapter_GetDeployment tests the GetDeployment function.
 func TestHelmAdapter_GetDeployment(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 		Timeout:   5 * time.Second,
 	})
@@ -1243,7 +1243,7 @@ func TestHelmAdapter_GetDeployment(t *testing.T) {
 
 // TestHelmAdapter_CreateDeployment tests the CreateDeployment function.
 func TestHelmAdapter_CreateDeployment(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 		Timeout:   5 * time.Second,
 	})
@@ -1268,7 +1268,7 @@ func TestHelmAdapter_CreateDeployment(t *testing.T) {
 
 // TestHelmAdapter_UpdateDeployment tests the UpdateDeployment function.
 func TestHelmAdapter_UpdateDeployment(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 		Timeout:   5 * time.Second,
 	})
@@ -1291,7 +1291,7 @@ func TestHelmAdapter_UpdateDeployment(t *testing.T) {
 
 // TestHelmAdapter_CreateDeployment_Validation tests CreateDeployment validation.
 func TestHelmAdapter_CreateDeployment_Validation(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -1341,7 +1341,7 @@ func TestHelmAdapter_CreateDeployment_Validation(t *testing.T) {
 
 // TestHelmAdapter_UpdateDeployment_Validation tests UpdateDeployment validation.
 func TestHelmAdapter_UpdateDeployment_Validation(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -1357,7 +1357,7 @@ func TestHelmAdapter_UpdateDeployment_Validation(t *testing.T) {
 
 // TestHelmAdapter_MatchesDeploymentFilter tests the filter matching logic.
 func TestHelmAdapter_MatchesDeploymentFilter(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -1451,7 +1451,7 @@ func TestHelmAdapter_MatchesDeploymentFilter(t *testing.T) {
 
 // TestHelmAdapter_FilterAndTransformReleases tests filtering and transformation.
 func TestHelmAdapter_FilterAndTransformReleases(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -1553,7 +1553,7 @@ func TestHelmAdapter_FilterAndTransformReleases(t *testing.T) {
 
 // TestHelmAdapter_TransformHelmStatus_AllStatuses tests all Helm status transformations.
 func TestHelmAdapter_TransformHelmStatus_AllStatuses(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -1577,7 +1577,7 @@ func TestHelmAdapter_TransformHelmStatus_AllStatuses(t *testing.T) {
 
 // TestHelmAdapter_CalculateProgress_AllStatuses tests all progress calculations.
 func TestHelmAdapter_CalculateProgress_AllStatuses(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -1609,7 +1609,7 @@ func TestHelmAdapter_CalculateProgress_AllStatuses(t *testing.T) {
 // TestHelmAdapter_Initialize tests initialization behavior.
 func TestHelmAdapter_Initialize(t *testing.T) {
 	t.Run("already initialized", func(t *testing.T) {
-		adapter, err := helm.NewAdapter(&helm.Config{
+		adapter, err := helm.New(&helm.Config{
 			Namespace: "test",
 		})
 		require.NoError(t, err)
@@ -1625,7 +1625,7 @@ func TestHelmAdapter_Initialize(t *testing.T) {
 	})
 
 	t.Run("initialization without kubeconfig", func(t *testing.T) {
-		adapter, err := helm.NewAdapter(&helm.Config{
+		adapter, err := helm.New(&helm.Config{
 			Namespace: "test",
 			Debug:     true, // Enable debug for coverage
 		})
@@ -1642,7 +1642,7 @@ func TestHelmAdapter_Initialize(t *testing.T) {
 
 // TestHelmAdapter_BuildConditions_EdgeCases tests condition building edge cases.
 func TestHelmAdapter_BuildConditions_EdgeCases(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -1674,7 +1674,7 @@ func TestHelmAdapter_BuildConditions_EdgeCases(t *testing.T) {
 
 // TestHelmAdapter_ScaleDeployment_ZeroReplicas tests scaling to zero.
 func TestHelmAdapter_ScaleDeployment_ZeroReplicas(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -1695,7 +1695,7 @@ func TestHelmAdapter_ScaleDeployment_ZeroReplicas(t *testing.T) {
 }
 
 func TestHelmAdapter_ScaleDeployment_AdditionalValidation(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -1751,7 +1751,7 @@ func TestHelmAdapter_ScaleDeployment_AdditionalValidation(t *testing.T) {
 
 // TestHelmAdapter_RollbackDeployment_ZeroRevision tests rollback to revision 0.
 func TestHelmAdapter_RollbackDeployment_ZeroRevision(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -1795,7 +1795,7 @@ func TestHelmAdapter_Settings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter, err := helm.NewAdapter(&helm.Config{
+			adapter, err := helm.New(&helm.Config{
 				Kubeconfig: tt.kubeconfig,
 				Namespace:  tt.namespace,
 				Debug:      tt.debug,
@@ -2155,7 +2155,7 @@ func TestHelmAdapter_TestBuildPackage(t *testing.T) {
 
 // TestHelmAdapter_LoadRepositoryIndex_Success tests successful repository index loading.
 func TestHelmAdapter_LoadRepositoryIndex_Success(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: "https://charts.bitnami.com/bitnami",
 	})
@@ -2173,7 +2173,7 @@ func TestHelmAdapter_LoadRepositoryIndex_Success(t *testing.T) {
 
 	t.Run("cached load", func(t *testing.T) {
 		// Test that calling LoadRepositoryIndex twice doesn't re-download
-		adapter, err := helm.NewAdapter(&helm.Config{
+		adapter, err := helm.New(&helm.Config{
 			Namespace:     "test",
 			RepositoryURL: "https://charts.bitnami.com/bitnami",
 		})
@@ -2194,7 +2194,7 @@ func TestHelmAdapter_LoadRepositoryIndex_Success(t *testing.T) {
 	})
 
 	t.Run("with authentication", func(t *testing.T) {
-		adapter, err := helm.NewAdapter(&helm.Config{
+		adapter, err := helm.New(&helm.Config{
 			Namespace:          "test",
 			RepositoryURL:      "https://private.charts.example.com",
 			RepositoryUsername: "testuser",
@@ -2213,7 +2213,7 @@ func TestHelmAdapter_LoadRepositoryIndex_Success(t *testing.T) {
 // TestHelmAdapter_GetRepositoryIndex tests the getRepositoryIndex helper.
 func TestHelmAdapter_GetRepositoryIndex(t *testing.T) {
 	t.Run("index not loaded", func(t *testing.T) {
-		adapter, err := helm.NewAdapter(&helm.Config{
+		adapter, err := helm.New(&helm.Config{
 			Namespace:     "test",
 			RepositoryURL: "https://charts.example.com",
 		})
@@ -2227,7 +2227,7 @@ func TestHelmAdapter_GetRepositoryIndex(t *testing.T) {
 
 // TestHelmAdapter_ListDeployments_WithFilter tests listing deployments with various filters.
 func TestHelmAdapter_ListDeployments_WithFilter(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -2285,7 +2285,7 @@ func TestHelmAdapter_ListDeployments_WithFilter(t *testing.T) {
 
 // TestHelmAdapter_ScaleDeployment_Complete tests the full scaling flow.
 func TestHelmAdapter_ScaleDeployment_Complete(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:  "test",
 		Timeout:    30 * time.Second,
 		MaxHistory: 5,
@@ -2329,7 +2329,7 @@ func TestHelmAdapter_ScaleDeployment_Complete(t *testing.T) {
 
 // TestHelmAdapter_GetDeploymentHistory_Complete tests the full history retrieval.
 func TestHelmAdapter_GetDeploymentHistory_Complete(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:  "test",
 		MaxHistory: 20,
 	})
@@ -2368,7 +2368,7 @@ func TestHelmAdapter_GetDeploymentHistory_Complete(t *testing.T) {
 
 // TestHelmAdapter_DeleteDeploymentPackage_Complete tests package deletion scenarios.
 func TestHelmAdapter_DeleteDeploymentPackage_Complete(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace:     "test",
 		RepositoryURL: "https://charts.example.com",
 	})
@@ -2406,7 +2406,7 @@ func TestHelmAdapter_DeleteDeploymentPackage_Complete(t *testing.T) {
 
 // TestHelmAdapter_RollbackDeployment_Complete tests rollback scenarios.
 func TestHelmAdapter_RollbackDeployment_Complete(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 		Timeout:   30 * time.Second,
 	})
@@ -2449,7 +2449,7 @@ func TestHelmAdapter_RollbackDeployment_Complete(t *testing.T) {
 
 // TestHelmAdapter_GetDeploymentStatus_Complete tests status retrieval.
 func TestHelmAdapter_GetDeploymentStatus_Complete(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -2490,7 +2490,7 @@ func TestHelmAdapter_GetDeploymentStatus_Complete(t *testing.T) {
 
 // TestHelmAdapter_TestBuildPodLogOptions tests the buildPodLogOptions helper function.
 func TestHelmAdapter_TestBuildPodLogOptions(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -2592,7 +2592,7 @@ func TestHelmAdapter_TestBuildPodLogOptions(t *testing.T) {
 
 // TestHelmAdapter_Initialize_DebugMode tests initialization with debug enabled.
 func TestHelmAdapter_Initialize_DebugMode(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 		Debug:     true,
 	})
@@ -2608,7 +2608,7 @@ func TestHelmAdapter_Initialize_DebugMode(t *testing.T) {
 
 // TestHelmAdapter_TransformHelmStatus_DefaultCase tests the default status case.
 func TestHelmAdapter_TransformHelmStatus_DefaultCase(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)
@@ -2621,7 +2621,7 @@ func TestHelmAdapter_TransformHelmStatus_DefaultCase(t *testing.T) {
 
 // TestHelmAdapter_CalculateProgress_DefaultCase tests the default progress case.
 func TestHelmAdapter_CalculateProgress_DefaultCase(t *testing.T) {
-	adapter, err := helm.NewAdapter(&helm.Config{
+	adapter, err := helm.New(&helm.Config{
 		Namespace: "test",
 	})
 	require.NoError(t, err)

--- a/internal/dms/adapters/kustomize/adapter.go
+++ b/internal/dms/adapters/kustomize/adapter.go
@@ -97,8 +97,8 @@ type Config struct {
 	Force bool
 }
 
-// NewAdapter creates a new Kustomize adapter instance.
-func NewAdapter(config *Config) (*Adapter, error) {
+// New creates a new Kustomize adapter instance.
+func New(config *Config) (*Adapter, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config cannot be nil")
 	}

--- a/internal/dms/adapters/kustomize/adapter_test.go
+++ b/internal/dms/adapters/kustomize/adapter_test.go
@@ -59,7 +59,7 @@ func TestNewAdapter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adp, err := kustomize.NewAdapter(tt.config)
+			adp, err := kustomize.New(tt.config)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -82,7 +82,7 @@ func TestNewAdapter(t *testing.T) {
 
 // TestAdapterMetadata tests adapter metadata methods.
 func TestAdapterMetadata(t *testing.T) {
-	adp, err := kustomize.NewAdapter(&kustomize.Config{})
+	adp, err := kustomize.New(&kustomize.Config{})
 	require.NoError(t, err)
 
 	t.Run("Name", func(t *testing.T) {
@@ -156,7 +156,7 @@ func createFakeAdapter(t *testing.T, objects ...runtime.Object) *kustomize.Adapt
 	// Create fake dynamic client
 	client := dynamicfake.NewSimpleDynamicClient(scheme, objects...)
 
-	adp, err := kustomize.NewAdapter(&kustomize.Config{
+	adp, err := kustomize.New(&kustomize.Config{
 		Namespace: "default",
 		BaseURL:   "https://github.com/example/kustomize-repo",
 	})
@@ -883,7 +883,7 @@ func TestValidatePath(t *testing.T) {
 
 // TestCalculateProgress tests progress calculation.
 func TestCalculateProgress(t *testing.T) {
-	adp, _ := kustomize.NewAdapter(&kustomize.Config{})
+	adp, _ := kustomize.New(&kustomize.Config{})
 
 	tests := []struct {
 		name   string
@@ -906,7 +906,7 @@ func TestCalculateProgress(t *testing.T) {
 
 // TestApplyPagination tests pagination logic.
 func TestApplyPagination(t *testing.T) {
-	adp, _ := kustomize.NewAdapter(&kustomize.Config{})
+	adp, _ := kustomize.New(&kustomize.Config{})
 
 	deployments := []*dmsadapter.Deployment{
 		{ID: "1"}, {ID: "2"}, {ID: "3"}, {ID: "4"}, {ID: "5"},
@@ -1037,7 +1037,7 @@ func BenchmarkListDeployments(b *testing.B) {
 
 	client := dynamicfake.NewSimpleDynamicClient(scheme, objects...)
 
-	adp, _ := kustomize.NewAdapter(&kustomize.Config{Namespace: "default"})
+	adp, _ := kustomize.New(&kustomize.Config{Namespace: "default"})
 	adp.DynamicClient = client
 
 	ctx := context.Background()

--- a/internal/dms/adapters/mock/adapter.go
+++ b/internal/dms/adapters/mock/adapter.go
@@ -27,9 +27,9 @@ type Adapter struct {
 	history     map[string]*adapter.DeploymentHistory
 }
 
-// NewAdapter creates a new mock DMS adapter with sample data.
+// New creates a new mock DMS adapter with sample data.
 // Pass populateSampleData=true to pre-populate with realistic test packages.
-func NewAdapter(populateSampleData bool) *Adapter {
+func New(populateSampleData bool) *Adapter {
 	a := &Adapter{
 		packages:    make(map[string]*adapter.DeploymentPackage),
 		deployments: make(map[string]*adapter.Deployment),

--- a/internal/dms/adapters/onaplcm/adapter.go
+++ b/internal/dms/adapters/onaplcm/adapter.go
@@ -88,8 +88,8 @@ type Config struct {
 	RequestID string
 }
 
-// NewAdapter creates a new ONAP-LCM adapter instance.
-func NewAdapter(config *Config) (*Adapter, error) {
+// New creates a new ONAP-LCM adapter instance.
+func New(config *Config) (*Adapter, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config cannot be nil")
 	}

--- a/internal/dms/adapters/onaplcm/adapter_test.go
+++ b/internal/dms/adapters/onaplcm/adapter_test.go
@@ -63,7 +63,7 @@ func TestNewAdapter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adp, err := onaplcm.NewAdapter(tt.config)
+			adp, err := onaplcm.New(tt.config)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -83,7 +83,7 @@ func TestNewAdapter(t *testing.T) {
 
 // TestAdapterMetadata tests adapter metadata methods.
 func TestAdapterMetadata(t *testing.T) {
-	adp, err := onaplcm.NewAdapter(&onaplcm.Config{})
+	adp, err := onaplcm.New(&onaplcm.Config{})
 	require.NoError(t, err)
 
 	t.Run("Name", func(t *testing.T) {
@@ -120,7 +120,7 @@ func TestAdapterMetadata(t *testing.T) {
 func createTestAdapter(t *testing.T) *onaplcm.Adapter {
 	t.Helper()
 
-	adp, err := onaplcm.NewAdapter(&onaplcm.Config{
+	adp, err := onaplcm.New(&onaplcm.Config{
 		SOEndpoint: "http://localhost:8080",
 		Timeout:    5 * time.Second,
 	})
@@ -603,7 +603,7 @@ func TestGetDeploymentLogs(t *testing.T) {
 // TestHealth tests health check functionality.
 func TestHealth(t *testing.T) {
 	t.Run("healthy without endpoint", func(t *testing.T) {
-		adp, err := onaplcm.NewAdapter(&onaplcm.Config{})
+		adp, err := onaplcm.New(&onaplcm.Config{})
 		require.NoError(t, err)
 
 		err = adp.Health(context.Background())
@@ -616,7 +616,7 @@ func TestHealth(t *testing.T) {
 		}))
 		defer server.Close()
 
-		adp, err := onaplcm.NewAdapter(&onaplcm.Config{
+		adp, err := onaplcm.New(&onaplcm.Config{
 			SOEndpoint: server.URL,
 		})
 		require.NoError(t, err)
@@ -667,7 +667,7 @@ func TestValidateName(t *testing.T) {
 
 // TestCalculateProgress tests progress calculation.
 func TestCalculateProgress(t *testing.T) {
-	adp, _ := onaplcm.NewAdapter(&onaplcm.Config{})
+	adp, _ := onaplcm.New(&onaplcm.Config{})
 
 	tests := []struct {
 		name   string
@@ -743,7 +743,7 @@ func TestContextCancellation(t *testing.T) {
 
 // TestApplyPagination tests pagination logic.
 func TestApplyPagination(t *testing.T) {
-	adp, _ := onaplcm.NewAdapter(&onaplcm.Config{})
+	adp, _ := onaplcm.New(&onaplcm.Config{})
 
 	deployments := []*dmsadapter.Deployment{
 		{ID: "1"}, {ID: "2"}, {ID: "3"}, {ID: "4"}, {ID: "5"},

--- a/internal/dms/adapters/osmlcm/adapter.go
+++ b/internal/dms/adapters/osmlcm/adapter.go
@@ -87,8 +87,8 @@ type Config struct {
 	TLSSkipVerify bool
 }
 
-// NewAdapter creates a new OSM-LCM adapter instance.
-func NewAdapter(config *Config) (*Adapter, error) {
+// New creates a new OSM-LCM adapter instance.
+func New(config *Config) (*Adapter, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config cannot be nil")
 	}

--- a/internal/dms/adapters/osmlcm/adapter_test.go
+++ b/internal/dms/adapters/osmlcm/adapter_test.go
@@ -71,7 +71,7 @@ func TestNewAdapter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adp, err := osmlcm.NewAdapter(tt.config)
+			adp, err := osmlcm.New(tt.config)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -94,7 +94,7 @@ func TestNewAdapter(t *testing.T) {
 
 // TestAdapterMetadata tests adapter metadata methods.
 func TestAdapterMetadata(t *testing.T) {
-	adp, err := osmlcm.NewAdapter(&osmlcm.Config{})
+	adp, err := osmlcm.New(&osmlcm.Config{})
 	require.NoError(t, err)
 
 	t.Run("Name", func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestAdapterMetadata(t *testing.T) {
 func createTestAdapter(t *testing.T) *osmlcm.Adapter {
 	t.Helper()
 
-	adp, err := osmlcm.NewAdapter(&osmlcm.Config{
+	adp, err := osmlcm.New(&osmlcm.Config{
 		NBIEndpoint: "http://localhost:9999",
 		Timeout:     5 * time.Second,
 	})
@@ -680,7 +680,7 @@ func TestGetDeploymentLogs(t *testing.T) {
 // TestHealth tests health check functionality.
 func TestHealth(t *testing.T) {
 	t.Run("healthy without endpoint", func(t *testing.T) {
-		adp, err := osmlcm.NewAdapter(&osmlcm.Config{})
+		adp, err := osmlcm.New(&osmlcm.Config{})
 		require.NoError(t, err)
 
 		err = adp.Health(context.Background())
@@ -693,7 +693,7 @@ func TestHealth(t *testing.T) {
 		}))
 		defer server.Close()
 
-		adp, err := osmlcm.NewAdapter(&osmlcm.Config{
+		adp, err := osmlcm.New(&osmlcm.Config{
 			NBIEndpoint: server.URL,
 		})
 		require.NoError(t, err)
@@ -708,7 +708,7 @@ func TestHealth(t *testing.T) {
 		}))
 		defer server.Close()
 
-		adp, err := osmlcm.NewAdapter(&osmlcm.Config{
+		adp, err := osmlcm.New(&osmlcm.Config{
 			NBIEndpoint: server.URL,
 		})
 		require.NoError(t, err)
@@ -762,7 +762,7 @@ func TestValidateName(t *testing.T) {
 
 // TestCalculateProgress tests progress calculation.
 func TestCalculateProgress(t *testing.T) {
-	adp, _ := osmlcm.NewAdapter(&osmlcm.Config{})
+	adp, _ := osmlcm.New(&osmlcm.Config{})
 
 	tests := []struct {
 		name   string
@@ -786,7 +786,7 @@ func TestCalculateProgress(t *testing.T) {
 
 // TestConditionStatus tests condition status helper.
 func TestConditionStatus(t *testing.T) {
-	adp, _ := osmlcm.NewAdapter(&osmlcm.Config{})
+	adp, _ := osmlcm.New(&osmlcm.Config{})
 
 	t.Run("deployed returns True", func(t *testing.T) {
 		assert.Equal(t, "True", adp.ConditionStatus(dmsadapter.DeploymentStatusDeployed))
@@ -800,7 +800,7 @@ func TestConditionStatus(t *testing.T) {
 
 // TestConditionReason tests condition reason helper.
 func TestConditionReason(t *testing.T) {
-	adp, _ := osmlcm.NewAdapter(&osmlcm.Config{})
+	adp, _ := osmlcm.New(&osmlcm.Config{})
 
 	tests := []struct {
 		status dmsadapter.DeploymentStatus
@@ -950,7 +950,7 @@ func TestContextCancellation(t *testing.T) {
 
 // TestApplyPagination tests pagination logic.
 func TestApplyPagination(t *testing.T) {
-	adp, _ := osmlcm.NewAdapter(&osmlcm.Config{})
+	adp, _ := osmlcm.New(&osmlcm.Config{})
 
 	deployments := []*dmsadapter.Deployment{
 		{ID: "1"}, {ID: "2"}, {ID: "3"}, {ID: "4"}, {ID: "5"},
@@ -984,7 +984,7 @@ func TestApplyPagination(t *testing.T) {
 
 // TestApplyPackagePagination tests package pagination logic.
 func TestApplyPackagePagination(t *testing.T) {
-	adp, _ := osmlcm.NewAdapter(&osmlcm.Config{})
+	adp, _ := osmlcm.New(&osmlcm.Config{})
 
 	pkgs := []*dmsadapter.DeploymentPackage{
 		{ID: "1"}, {ID: "2"}, {ID: "3"}, {ID: "4"}, {ID: "5"},
@@ -1032,7 +1032,7 @@ func TestDoRequest(t *testing.T) {
 		}))
 		defer server.Close()
 
-		adp, err := osmlcm.NewAdapter(&osmlcm.Config{
+		adp, err := osmlcm.New(&osmlcm.Config{
 			NBIEndpoint: server.URL,
 		})
 		require.NoError(t, err)
@@ -1053,7 +1053,7 @@ func TestDoRequest(t *testing.T) {
 		}))
 		defer server.Close()
 
-		adp, err := osmlcm.NewAdapter(&osmlcm.Config{
+		adp, err := osmlcm.New(&osmlcm.Config{
 			NBIEndpoint: server.URL,
 			Username:    testUsername,
 			Password:    testSecretData,
@@ -1072,7 +1072,7 @@ func TestDoRequest(t *testing.T) {
 		}))
 		defer server.Close()
 
-		adp, err := osmlcm.NewAdapter(&osmlcm.Config{
+		adp, err := osmlcm.New(&osmlcm.Config{
 			NBIEndpoint: server.URL,
 		})
 		require.NoError(t, err)
@@ -1090,7 +1090,7 @@ func TestDoRequest(t *testing.T) {
 		}))
 		defer server.Close()
 
-		adp, err := osmlcm.NewAdapter(&osmlcm.Config{
+		adp, err := osmlcm.New(&osmlcm.Config{
 			NBIEndpoint: server.URL,
 		})
 		require.NoError(t, err)
@@ -1106,7 +1106,7 @@ func TestDoRequest(t *testing.T) {
 
 // BenchmarkCreateDeployment benchmarks deployment creation.
 func BenchmarkCreateDeployment(b *testing.B) {
-	adp, _ := osmlcm.NewAdapter(&osmlcm.Config{
+	adp, _ := osmlcm.New(&osmlcm.Config{
 		NBIEndpoint: "http://localhost:9999",
 	})
 	_ = adp.Initialize()
@@ -1125,7 +1125,7 @@ func BenchmarkCreateDeployment(b *testing.B) {
 
 // BenchmarkListDeployments benchmarks deployment listing.
 func BenchmarkListDeployments(b *testing.B) {
-	adp, _ := osmlcm.NewAdapter(&osmlcm.Config{
+	adp, _ := osmlcm.New(&osmlcm.Config{
 		NBIEndpoint: "http://localhost:9999",
 	})
 	_ = adp.Initialize()

--- a/internal/dms/handlers/handlers.go
+++ b/internal/dms/handlers/handlers.go
@@ -74,9 +74,7 @@ func (h *Handler) getAdapterFromQuery(c *gin.Context) (adapter.DMSAdapter, error
 	reg := h.getActiveRegistry(c)
 
 	if adapterName != "" {
-		reg.Mu.RLock()
-		adp = reg.Plugins[adapterName]
-		reg.Mu.RUnlock()
+		adp = reg.Get(adapterName)
 
 		if adp == nil {
 			return nil, fmt.Errorf("adapter not found: %s", adapterName)
@@ -85,11 +83,7 @@ func (h *Handler) getAdapterFromQuery(c *gin.Context) (adapter.DMSAdapter, error
 	}
 
 	// Use default adapter
-	reg.Mu.RLock()
-	if reg.DefaultPlugin != "" {
-		adp = reg.Plugins[reg.DefaultPlugin]
-	}
-	reg.Mu.RUnlock()
+	adp = reg.GetDefault()
 
 	if adp == nil {
 		return nil, fmt.Errorf("no default DMS adapter configured")
@@ -967,12 +961,7 @@ func (h *Handler) GetDeploymentLifecycleInfo(c *gin.Context) {
 
 // Health returns the health status of the DMS subsystem.
 func (h *Handler) Health(ctx context.Context) error {
-	var adp adapter.DMSAdapter
-	h.registry.Mu.RLock()
-	if h.registry.DefaultPlugin != "" {
-		adp = h.registry.Plugins[h.registry.DefaultPlugin]
-	}
-	h.registry.Mu.RUnlock()
+	adp := h.registry.GetDefault()
 	if adp == nil {
 		return errors.New("no DMS adapter available")
 	}

--- a/internal/dms/init.go
+++ b/internal/dms/init.go
@@ -171,7 +171,7 @@ func registerHelmAdapter(
 		RepositoryURL: config.RepositoryURL,
 	}
 
-	adapter, err := helm.NewAdapter(helmConfig)
+	adapter, err := helm.New(helmConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create Helm adapter: %w", err)
 	}
@@ -201,7 +201,7 @@ func registerArgoCDAdapter(
 		Namespace:  config.Namespace,
 	}
 
-	adapter, err := argocd.NewAdapter(argoCDConfig)
+	adapter, err := argocd.New(argoCDConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create ArgoCD adapter: %w", err)
 	}
@@ -230,7 +230,7 @@ func registerFluxAdapter(
 		Namespace:  config.Namespace,
 	}
 
-	adapter, err := flux.NewAdapter(fluxConfig)
+	adapter, err := flux.New(fluxConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create Flux adapter: %w", err)
 	}
@@ -260,7 +260,7 @@ func registerKustomizeAdapter(
 		BaseURL:    config.BaseURL,
 	}
 
-	adapter, err := kustomize.NewAdapter(kustomizeConfig)
+	adapter, err := kustomize.New(kustomizeConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create Kustomize adapter: %w", err)
 	}
@@ -290,7 +290,7 @@ func registerCrossplaneAdapter(
 		Namespace:  config.Namespace,
 	}
 
-	adapter, err := crossplane.NewAdapter(crossplaneConfig)
+	adapter, err := crossplane.New(crossplaneConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create Crossplane adapter: %w", err)
 	}
@@ -320,7 +320,7 @@ func registerONAPLCMAdapter(
 		Password:   config.Password,
 	}
 
-	adapter, err := onaplcm.NewAdapter(onapConfig)
+	adapter, err := onaplcm.New(onapConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create ONAP-LCM adapter: %w", err)
 	}
@@ -351,7 +351,7 @@ func registerOSMLCMAdapter(
 		Password:    config.Password,
 	}
 
-	adapter, err := osmlcm.NewAdapter(osmConfig)
+	adapter, err := osmlcm.New(osmConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create OSM-LCM adapter: %w", err)
 	}

--- a/internal/graphql/resolvers/resolver_test.go
+++ b/internal/graphql/resolvers/resolver_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewResolver(t *testing.T) {
-	adp := mockadapter.NewAdapter(false)
+	adp := mockadapter.New(&mockadapter.Config{})
 	logger := zap.NewNop()
 
 	r := NewResolver(adp, nil, nil, logger)
@@ -21,7 +21,7 @@ func TestNewResolver(t *testing.T) {
 }
 
 func TestGetActiveAdapter_FallbackToDefault(t *testing.T) {
-	adp := mockadapter.NewAdapter(false)
+	adp := mockadapter.New(&mockadapter.Config{})
 	logger := zap.NewNop()
 	r := NewResolver(adp, nil, nil, logger)
 
@@ -32,8 +32,8 @@ func TestGetActiveAdapter_FallbackToDefault(t *testing.T) {
 }
 
 func TestGetActiveAdapter_UsesContextAdapter(t *testing.T) {
-	defaultAdp := mockadapter.NewAdapter(false)
-	contextAdp := mockadapter.NewAdapterWithOCloudID("context-ocloud", false)
+	defaultAdp := mockadapter.New(&mockadapter.Config{})
+	contextAdp := mockadapter.New(&mockadapter.Config{OCloudID: "context-ocloud"})
 	logger := zap.NewNop()
 	r := NewResolver(defaultAdp, nil, nil, logger)
 
@@ -44,7 +44,7 @@ func TestGetActiveAdapter_UsesContextAdapter(t *testing.T) {
 }
 
 func TestGetActiveAdapter_NilContextValue(t *testing.T) {
-	defaultAdp := mockadapter.NewAdapter(false)
+	defaultAdp := mockadapter.New(&mockadapter.Config{})
 	logger := zap.NewNop()
 	r := NewResolver(defaultAdp, nil, nil, logger)
 
@@ -55,7 +55,7 @@ func TestGetActiveAdapter_NilContextValue(t *testing.T) {
 }
 
 func TestWithAdapter(t *testing.T) {
-	adp := mockadapter.NewAdapter(false)
+	adp := mockadapter.New(&mockadapter.Config{})
 	ctx := context.Background()
 
 	newCtx := WithAdapter(ctx, adp)

--- a/internal/graphql/server_test.go
+++ b/internal/graphql/server_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestNewServer(t *testing.T) {
-	adp := mockadapter.NewAdapter(false)
+	adp := mockadapter.New(&mockadapter.Config{})
 	logger := zap.NewNop()
 	resolver := resolvers.NewResolver(adp, nil, nil, logger)
 
@@ -43,7 +43,7 @@ func TestPlaygroundHandler(t *testing.T) {
 }
 
 func TestGinHandler(t *testing.T) {
-	adp := mockadapter.NewAdapter(false)
+	adp := mockadapter.New(&mockadapter.Config{})
 	logger := zap.NewNop()
 	resolver := resolvers.NewResolver(adp, nil, nil, logger)
 	srv := NewServer(resolver, ServerOptions{
@@ -96,7 +96,7 @@ func TestNewServer_IntrospectionGating(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			adp := mockadapter.NewAdapter(false)
+			adp := mockadapter.New(&mockadapter.Config{})
 			resolver := resolvers.NewResolver(adp, nil, nil, logger)
 			srv := NewServer(resolver, ServerOptions{
 				GinMode:              tc.mode,

--- a/internal/observability/doc.go
+++ b/internal/observability/doc.go
@@ -33,6 +33,24 @@
 //
 //	metrics.RecordHTTPRequest("GET", "/api/v1/subscriptions", 200, duration, responseSize)
 //
+// # Log Level Policy (MANDATORY)
+//
+// All packages (especially adapters) MUST follow this log-level convention to
+// keep production log volume predictable and signal-to-noise high:
+//
+//   - Debug: routine get/list operations, cache hits, internal state dumps.
+//     These fire on every read and would flood production logs at Info.
+//   - Info:  state transitions — create/update/delete operations, adapter
+//     initialization, subscription registration, graceful start/stop events.
+//   - Warn:  retryable failures — transient backend errors, fallbacks, degraded
+//     modes that the caller may recover from.
+//   - Error: non-retryable failures — configuration errors, auth failures,
+//     unrecoverable backend errors, audit-log write failures.
+//
+// Rationale: Info-level "listed N items" statements from every adapter on
+// every poll interval drown out real state-transition events. Keep reads at
+// Debug; reserve Info for things an operator wants to see once per event.
+//
 // # Metric Naming Rule (MANDATORY)
 //
 // All Prometheus metrics emitted by any package in this repository MUST use:

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -172,9 +172,7 @@ func (r *Router) collectMatchingAdapters(routingCtx *Context) []adapter.DMSAdapt
 			continue
 		}
 
-		r.Registry.Mu.RLock()
-		plugin := r.Registry.Plugins[rule.AdapterName]
-		r.Registry.Mu.RUnlock()
+		plugin := r.Registry.Get(rule.AdapterName)
 
 		adapters = append(adapters, plugin)
 		seen[rule.AdapterName] = true
@@ -190,9 +188,7 @@ func (r *Router) collectMatchingAdapters(routingCtx *Context) []adapter.DMSAdapt
 
 // isAdapterValid checks if an adapter exists and meets requirements.
 func (r *Router) isAdapterValid(name string, requiredCaps []adapter.Capability) bool {
-	r.Registry.Mu.RLock()
-	plugin := r.Registry.Plugins[name]
-	r.Registry.Mu.RUnlock()
+	plugin := r.Registry.Get(name)
 
 	if plugin == nil {
 		return false
@@ -208,10 +204,8 @@ func (r *Router) isAdapterValid(name string, requiredCaps []adapter.Capability) 
 
 // addDefaultAdapter adds the default adapter to the list if available.
 func (r *Router) addDefaultAdapter(adapters *[]adapter.DMSAdapter) {
-	r.Registry.Mu.RLock()
-	defaultName := r.Registry.DefaultPlugin
-	defaultPlugin := r.Registry.Plugins[defaultName]
-	r.Registry.Mu.RUnlock()
+	defaultName := r.Registry.GetDefaultName()
+	defaultPlugin := r.Registry.GetDefault()
 
 	if defaultName != "" && defaultPlugin != nil {
 		*adapters = append(*adapters, defaultPlugin)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -168,13 +168,31 @@ type Metrics struct {
 //	authStore := auth.NewRedisStore(&auth.RedisConfig{...})
 //	srv := server.New(cfg, logger, adapter, store, authStore)
 //	srv := server.New(cfg, logger, adapter, store, authStore, authMw) // with pre-configured auth middleware
+// ServerOption configures a Server during construction. Use the With* helpers
+// (e.g. WithAuthMiddleware) to produce options.
+type ServerOption func(*serverOptions)
+
+// serverOptions holds resolved option values. It is an implementation detail.
+type serverOptions struct {
+	authMiddleware *auth.Middleware
+}
+
+// WithAuthMiddleware supplies a pre-configured auth middleware for the admin,
+// TMF, and GraphQL routers. If not provided, the server constructs its own
+// OAuth2-only middleware when an auth store is supplied.
+func WithAuthMiddleware(mw *auth.Middleware) ServerOption {
+	return func(o *serverOptions) {
+		o.authMiddleware = mw
+	}
+}
+
 func New(
 	cfg *config.Config,
 	logger *zap.Logger,
 	adp adapter.Adapter,
 	store storage.Store,
 	authStore AuthStore,
-	opts ...interface{},
+	opts ...ServerOption,
 ) *Server {
 	if cfg == nil {
 		panic("config cannot be nil")
@@ -221,13 +239,14 @@ func New(
 	var auditLogger *auth.AuditLogger
 	var tenantHandler *handlers.TenantHandler
 
-	// Check if a pre-configured auth middleware was passed via opts
-	var preConfiguredMw *auth.Middleware
+	// Resolve functional options (I16).
+	resolvedOpts := serverOptions{}
 	for _, opt := range opts {
-		if mw, ok := opt.(*auth.Middleware); ok && mw != nil {
-			preConfiguredMw = mw
+		if opt != nil {
+			opt(&resolvedOpts)
 		}
 	}
+	preConfiguredMw := resolvedOpts.authMiddleware
 
 	if authStore != nil {
 		// Type assert authStore to auth.Store for middleware initialization

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -168,6 +168,7 @@ type Metrics struct {
 //	authStore := auth.NewRedisStore(&auth.RedisConfig{...})
 //	srv := server.New(cfg, logger, adapter, store, authStore)
 //	srv := server.New(cfg, logger, adapter, store, authStore, authMw) // with pre-configured auth middleware
+//
 // ServerOption configures a Server during construction. Use the With* helpers
 // (e.g. WithAuthMiddleware) to produce options.
 type ServerOption func(*serverOptions)

--- a/internal/server/smo_routes.go
+++ b/internal/server/smo_routes.go
@@ -160,18 +160,14 @@ func (h *SMOHandler) publishEvent(c *gin.Context, publishFn func(context.Context
 	var err error
 
 	if pluginName != "" {
-		reg.Mu.RLock()
-		plugin = reg.Plugins[pluginName]
-		reg.Mu.RUnlock()
+		plugin = reg.Get(pluginName)
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", pluginName)
 		}
 	} else {
-		reg.Mu.RLock()
-		defaultName := reg.DefaultPlugin
-		plugin = reg.Plugins[defaultName]
-		reg.Mu.RUnlock()
+		defaultName := reg.DefaultName()
+		plugin = reg.Get(defaultName)
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -233,9 +229,7 @@ func (h *SMOHandler) getPluginFromQuery(c *gin.Context) (smo.Plugin, error) {
 	var plugin smo.Plugin
 
 	if pluginName != "" {
-		reg.Mu.RLock()
-		plugin = reg.Plugins[pluginName]
-		reg.Mu.RUnlock()
+		plugin = reg.Get(pluginName)
 
 		if plugin == nil {
 			return nil, fmt.Errorf("plugin %s not found", pluginName)
@@ -244,10 +238,8 @@ func (h *SMOHandler) getPluginFromQuery(c *gin.Context) (smo.Plugin, error) {
 	}
 
 	// Use default plugin
-	reg.Mu.RLock()
-	defaultName := reg.DefaultPlugin
-	plugin = reg.Plugins[defaultName]
-	reg.Mu.RUnlock()
+	defaultName := reg.DefaultName()
+	plugin = reg.Get(defaultName)
 
 	if defaultName == "" {
 		return nil, fmt.Errorf("no default plugin configured")
@@ -397,10 +389,8 @@ func (h *SMOHandler) HandleGetPlugin(c *gin.Context) {
 	reg := h.getActiveRegistry(c)
 	h.logger.Info("getting SMO plugin", zap.String("plugin_id", pluginID))
 
-	reg.Mu.RLock()
-	var exists bool
-	plugin, exists := reg.Plugins[pluginID]
-	reg.Mu.RUnlock()
+plugin := reg.Get(pluginID)
+	exists := plugin != nil
 	var err error
 	if !exists {
 		err = fmt.Errorf("plugin %s not found", pluginID)
@@ -453,9 +443,7 @@ func (h *SMOHandler) HandleExecuteWorkflow(c *gin.Context) {
 	var err error
 
 	if req.PluginName != "" {
-		reg.Mu.RLock()
-		plugin = reg.Plugins[req.PluginName]
-		reg.Mu.RUnlock()
+		plugin = reg.Get(req.PluginName)
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", req.PluginName)
 			h.respondWithNotFound(c, err)
@@ -464,10 +452,8 @@ func (h *SMOHandler) HandleExecuteWorkflow(c *gin.Context) {
 		}
 		pluginName = req.PluginName
 	} else {
-		reg.Mu.RLock()
-		defaultName := reg.DefaultPlugin
-		plugin = reg.Plugins[defaultName]
-		reg.Mu.RUnlock()
+		defaultName := reg.DefaultName()
+		plugin = reg.Get(defaultName)
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -561,18 +547,14 @@ func (h *SMOHandler) HandleCancelWorkflow(c *gin.Context) {
 	var err error
 	// Get plugin inline (avoid ireturn linter)
 	if pluginName != "" {
-		reg.Mu.RLock()
-		plugin = reg.Plugins[pluginName]
-		reg.Mu.RUnlock()
+		plugin = reg.Get(pluginName)
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", pluginName)
 		}
 	} else {
-		reg.Mu.RLock()
-		defaultName := reg.DefaultPlugin
-		plugin = reg.Plugins[defaultName]
-		reg.Mu.RUnlock()
+		defaultName := reg.DefaultName()
+		plugin = reg.Get(defaultName)
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -621,18 +603,14 @@ func (h *SMOHandler) HandleListServiceModels(c *gin.Context) {
 	var err error
 	// Get plugin inline (avoid ireturn linter)
 	if pluginName != "" {
-		reg.Mu.RLock()
-		plugin = reg.Plugins[pluginName]
-		reg.Mu.RUnlock()
+		plugin = reg.Get(pluginName)
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", pluginName)
 		}
 	} else {
-		reg.Mu.RLock()
-		defaultName := reg.DefaultPlugin
-		plugin = reg.Plugins[defaultName]
-		reg.Mu.RUnlock()
+		defaultName := reg.DefaultName()
+		plugin = reg.Get(defaultName)
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -676,18 +654,14 @@ func (h *SMOHandler) HandleCreateServiceModel(c *gin.Context) {
 	var err error
 	// Get plugin inline (avoid ireturn linter)
 	if req.PluginName != "" {
-		reg.Mu.RLock()
-		plugin = reg.Plugins[req.PluginName]
-		reg.Mu.RUnlock()
+		plugin = reg.Get(req.PluginName)
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", req.PluginName)
 		}
 	} else {
-		reg.Mu.RLock()
-		defaultName := reg.DefaultPlugin
-		plugin = reg.Plugins[defaultName]
-		reg.Mu.RUnlock()
+		defaultName := reg.DefaultName()
+		plugin = reg.Get(defaultName)
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -798,18 +772,14 @@ func (h *SMOHandler) HandleApplyPolicy(c *gin.Context) {
 	var err error
 	// Get plugin inline (avoid ireturn linter)
 	if req.PluginName != "" {
-		reg.Mu.RLock()
-		plugin = reg.Plugins[req.PluginName]
-		reg.Mu.RUnlock()
+		plugin = reg.Get(req.PluginName)
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", req.PluginName)
 		}
 	} else {
-		reg.Mu.RLock()
-		defaultName := reg.DefaultPlugin
-		plugin = reg.Plugins[defaultName]
-		reg.Mu.RUnlock()
+		defaultName := reg.DefaultName()
+		plugin = reg.Get(defaultName)
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -893,18 +863,14 @@ func (h *SMOHandler) HandleSyncInfrastructure(c *gin.Context) {
 	var err error
 	// Get plugin inline (avoid ireturn linter)
 	if pluginName != "" {
-		reg.Mu.RLock()
-		plugin = reg.Plugins[pluginName]
-		reg.Mu.RUnlock()
+		plugin = reg.Get(pluginName)
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", pluginName)
 		}
 	} else {
-		reg.Mu.RLock()
-		defaultName := reg.DefaultPlugin
-		plugin = reg.Plugins[defaultName]
-		reg.Mu.RUnlock()
+		defaultName := reg.DefaultName()
+		plugin = reg.Get(defaultName)
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")
@@ -954,18 +920,14 @@ func (h *SMOHandler) HandleSyncDeployments(c *gin.Context) {
 	var err error
 	// Get plugin inline (avoid ireturn linter)
 	if pluginName != "" {
-		reg.Mu.RLock()
-		plugin = reg.Plugins[pluginName]
-		reg.Mu.RUnlock()
+		plugin = reg.Get(pluginName)
 
 		if plugin == nil {
 			err = fmt.Errorf("plugin %s not found", pluginName)
 		}
 	} else {
-		reg.Mu.RLock()
-		defaultName := reg.DefaultPlugin
-		plugin = reg.Plugins[defaultName]
-		reg.Mu.RUnlock()
+		defaultName := reg.DefaultName()
+		plugin = reg.Get(defaultName)
 
 		if defaultName == "" {
 			err = fmt.Errorf("no default plugin configured")

--- a/internal/server/smo_routes.go
+++ b/internal/server/smo_routes.go
@@ -389,7 +389,7 @@ func (h *SMOHandler) HandleGetPlugin(c *gin.Context) {
 	reg := h.getActiveRegistry(c)
 	h.logger.Info("getting SMO plugin", zap.String("plugin_id", pluginID))
 
-plugin := reg.Get(pluginID)
+	plugin := reg.Get(pluginID)
 	exists := plugin != nil
 	var err error
 	if !exists {

--- a/internal/smo/adapters/mock/plugin.go
+++ b/internal/smo/adapters/mock/plugin.go
@@ -53,8 +53,8 @@ type policyState struct {
 	Violations int
 }
 
-// NewPlugin creates a new mock SMO plugin.
-func NewPlugin() *Plugin {
+// New creates a new mock SMO plugin.
+func New() *Plugin {
 	return &Plugin{
 		workflows:     make(map[string]*workflowExecution),
 		serviceModels: make(map[string]*smo.ServiceModel),

--- a/internal/smo/adapters/onap/northbound_test.go
+++ b/internal/smo/adapters/onap/northbound_test.go
@@ -69,7 +69,7 @@ func setupPluginWithServers(t *testing.T, aaiH, dmaapH, soH, sdncH http.HandlerF
 		EnableSDNC:            true,
 	}
 
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = cfg
 
 	// Create clients pointing at test servers, directly setting unexported fields
@@ -168,7 +168,7 @@ func TestSyncInfrastructureInventory_Success(t *testing.T) {
 
 func TestSyncInfrastructureInventory_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 	plugin.Config = testConfig()
 
@@ -179,7 +179,7 @@ func TestSyncInfrastructureInventory_Closed(t *testing.T) {
 
 func TestSyncInfrastructureInventory_Disabled(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	cfg := testConfig()
 	cfg.EnableInventorySync = false
 	plugin.Config = cfg
@@ -191,7 +191,7 @@ func TestSyncInfrastructureInventory_Disabled(t *testing.T) {
 
 func TestSyncInfrastructureInventory_NoAAIClient(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	err := plugin.SyncInfrastructureInventory(context.Background(), &smo.InfrastructureInventory{})
@@ -249,7 +249,7 @@ func TestSyncDeploymentInventory_Success(t *testing.T) {
 
 func TestSyncDeploymentInventory_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 	plugin.Config = testConfig()
 
@@ -260,7 +260,7 @@ func TestSyncDeploymentInventory_Closed(t *testing.T) {
 
 func TestSyncDeploymentInventory_Disabled(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	cfg := testConfig()
 	cfg.EnableInventorySync = false
 	plugin.Config = cfg
@@ -272,7 +272,7 @@ func TestSyncDeploymentInventory_Disabled(t *testing.T) {
 
 func TestSyncDeploymentInventory_NoAAIClient(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	err := plugin.SyncDeploymentInventory(context.Background(), &smo.DeploymentInventory{})
@@ -331,7 +331,7 @@ func TestPublishInfrastructureEvent_Success(t *testing.T) {
 
 func TestPublishInfrastructureEvent_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 	plugin.Config = testConfig()
 
@@ -342,7 +342,7 @@ func TestPublishInfrastructureEvent_Closed(t *testing.T) {
 
 func TestPublishInfrastructureEvent_Disabled(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	cfg := testConfig()
 	cfg.EnableEventPublishing = false
 	plugin.Config = cfg
@@ -354,7 +354,7 @@ func TestPublishInfrastructureEvent_Disabled(t *testing.T) {
 
 func TestPublishInfrastructureEvent_NoDMaaPClient(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	err := plugin.PublishInfrastructureEvent(context.Background(), &smo.InfrastructureEvent{})
@@ -407,7 +407,7 @@ func TestPublishDeploymentEvent_Success(t *testing.T) {
 
 func TestPublishDeploymentEvent_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 	plugin.Config = testConfig()
 
@@ -418,7 +418,7 @@ func TestPublishDeploymentEvent_Closed(t *testing.T) {
 
 func TestPublishDeploymentEvent_Disabled(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	cfg := testConfig()
 	cfg.EnableEventPublishing = false
 	plugin.Config = cfg
@@ -430,7 +430,7 @@ func TestPublishDeploymentEvent_Disabled(t *testing.T) {
 
 func TestPublishDeploymentEvent_NoDMaaPClient(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	err := plugin.PublishDeploymentEvent(context.Background(), &smo.DeploymentEvent{})
@@ -486,7 +486,7 @@ func TestHealth_SomeUnhealthy(t *testing.T) {
 
 func TestHealth_NoClients(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	health := plugin.Health(context.Background())
@@ -495,7 +495,7 @@ func TestHealth_NoClients(t *testing.T) {
 
 func TestHealth_ClosedPlugin(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 
 	health := plugin.Health(context.Background())
@@ -507,7 +507,7 @@ func TestHealth_ClosedPlugin(t *testing.T) {
 
 func TestInitialize_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 
 	err := plugin.Initialize(context.Background(), map[string]interface{}{})
@@ -517,7 +517,7 @@ func TestInitialize_Closed(t *testing.T) {
 
 func TestInitialize_InvalidConfig(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 
 	config := map[string]interface{}{
 		"enableInventorySync": true,
@@ -562,7 +562,7 @@ func TestExecuteWorkflow_Success(t *testing.T) {
 
 func TestExecuteWorkflow_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 	plugin.Config = testConfig()
 
@@ -573,7 +573,7 @@ func TestExecuteWorkflow_Closed(t *testing.T) {
 
 func TestExecuteWorkflow_Disabled(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	cfg := testConfig()
 	cfg.EnableDMSBackend = false
 	plugin.Config = cfg
@@ -585,7 +585,7 @@ func TestExecuteWorkflow_Disabled(t *testing.T) {
 
 func TestExecuteWorkflow_NoSOClient(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	_, err := plugin.ExecuteWorkflow(context.Background(), &smo.WorkflowRequest{WorkflowName: "test"})
@@ -666,7 +666,7 @@ func TestGetWorkflowStatus_Failed(t *testing.T) {
 
 func TestGetWorkflowStatus_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 	plugin.Config = testConfig()
 
@@ -677,7 +677,7 @@ func TestGetWorkflowStatus_Closed(t *testing.T) {
 
 func TestGetWorkflowStatus_Disabled(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	cfg := testConfig()
 	cfg.EnableDMSBackend = false
 	plugin.Config = cfg
@@ -689,7 +689,7 @@ func TestGetWorkflowStatus_Disabled(t *testing.T) {
 
 func TestGetWorkflowStatus_NoSOClient(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	_, err := plugin.GetWorkflowStatus(context.Background(), "exec-123")
@@ -713,7 +713,7 @@ func TestCancelWorkflow_Success(t *testing.T) {
 
 func TestCancelWorkflow_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 	plugin.Config = testConfig()
 
@@ -724,7 +724,7 @@ func TestCancelWorkflow_Closed(t *testing.T) {
 
 func TestCancelWorkflow_Disabled(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	cfg := testConfig()
 	cfg.EnableDMSBackend = false
 	plugin.Config = cfg
@@ -736,7 +736,7 @@ func TestCancelWorkflow_Disabled(t *testing.T) {
 
 func TestCancelWorkflow_NoSOClient(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	err := plugin.CancelWorkflow(context.Background(), "exec-123")
@@ -767,7 +767,7 @@ func TestRegisterServiceModel_Success(t *testing.T) {
 
 func TestRegisterServiceModel_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 	plugin.Config = testConfig()
 
@@ -778,7 +778,7 @@ func TestRegisterServiceModel_Closed(t *testing.T) {
 
 func TestRegisterServiceModel_Disabled(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	cfg := testConfig()
 	cfg.EnableDMSBackend = false
 	plugin.Config = cfg
@@ -790,7 +790,7 @@ func TestRegisterServiceModel_Disabled(t *testing.T) {
 
 func TestRegisterServiceModel_NoSOClient(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	err := plugin.RegisterServiceModel(context.Background(), &smo.ServiceModel{ID: "m1"})
@@ -826,7 +826,7 @@ func TestGetServiceModel_Success(t *testing.T) {
 
 func TestGetServiceModel_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 	plugin.Config = testConfig()
 
@@ -837,7 +837,7 @@ func TestGetServiceModel_Closed(t *testing.T) {
 
 func TestGetServiceModel_Disabled(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	cfg := testConfig()
 	cfg.EnableDMSBackend = false
 	plugin.Config = cfg
@@ -849,7 +849,7 @@ func TestGetServiceModel_Disabled(t *testing.T) {
 
 func TestGetServiceModel_NoSOClient(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	_, err := plugin.GetServiceModel(context.Background(), "model-1")
@@ -891,7 +891,7 @@ func TestListServiceModels_Success(t *testing.T) {
 
 func TestListServiceModels_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 	plugin.Config = testConfig()
 
@@ -904,7 +904,7 @@ func TestListServiceModels_Closed(t *testing.T) {
 
 func TestApplyPolicy_Success(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	policy := &smo.Policy{
@@ -918,7 +918,7 @@ func TestApplyPolicy_Success(t *testing.T) {
 
 func TestApplyPolicy_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 	plugin.Config = testConfig()
 
@@ -931,7 +931,7 @@ func TestApplyPolicy_Closed(t *testing.T) {
 
 func TestGetPolicyStatus_Success(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	status, err := plugin.GetPolicyStatus(context.Background(), "policy-1")
@@ -943,7 +943,7 @@ func TestGetPolicyStatus_Success(t *testing.T) {
 
 func TestGetPolicyStatus_Closed(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Closed = true
 	plugin.Config = testConfig()
 
@@ -970,7 +970,7 @@ func TestClose_WithClients(t *testing.T) {
 
 func TestCapabilities_NilConfig(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 
 	caps := plugin.Capabilities()
 	assert.Empty(t, caps)
@@ -1080,7 +1080,7 @@ func TestIsNilInterface(t *testing.T) {
 
 func TestTransformToAAIInventory(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	inventory := &smo.InfrastructureInventory{
@@ -1148,7 +1148,7 @@ func TestTransformToAAIInventory(t *testing.T) {
 
 func TestTransformDeploymentToServiceInstance(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	now := time.Now()
@@ -1171,7 +1171,7 @@ func TestTransformDeploymentToServiceInstance(t *testing.T) {
 
 func TestTransformToVESEvent(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	now := time.Now()
@@ -1192,7 +1192,7 @@ func TestTransformToVESEvent(t *testing.T) {
 
 func TestTransformDeploymentEventToVES(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := NewPlugin(logger)
+	plugin := newTestONAPInPkg(logger)
 	plugin.Config = testConfig()
 
 	now := time.Now()

--- a/internal/smo/adapters/onap/plugin.go
+++ b/internal/smo/adapters/onap/plugin.go
@@ -41,6 +41,11 @@ type Plugin struct {
 
 // Config defines the configuration for the ONAP plugin.
 type Config struct {
+	// Logger is an optional zap.Logger to use for plugin logging. If nil, a
+	// no-op logger is installed. Tagged `mapstructure:"-"` so Viper does not
+	// attempt to decode it from configuration files.
+	Logger *zap.Logger `mapstructure:"-"`
+
 	// Northbound Configuration (netweave → ONAP)
 	AAIURL   string `mapstructure:"aaiUrl"`
 	DMaaPURL string `mapstructure:"dmaapUrl"`
@@ -89,14 +94,26 @@ func DefaultConfig() *Config {
 	}
 }
 
-// NewPlugin creates a new ONAP plugin instance with the provided logger.
-// The plugin is not initialized until Initialize() is called.
-func NewPlugin(logger *zap.Logger) *Plugin {
+// New creates a new ONAP plugin instance from the provided configuration.
+// The plugin is not fully initialized until Initialize() is called with a
+// configuration map; New only installs the logger and records metadata so that
+// the Plugin satisfies smo.Plugin before Initialize runs.
+//
+// Passing a nil cfg is equivalent to &Config{} (no-op logger, no connections).
+// The returned error is reserved for future use (signature alignment with OSM).
+func New(cfg *Config) (*Plugin, error) {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	return &Plugin{
 		Name:    "onap",
 		Version: "1.0.0",
 		logger:  logger,
-	}
+	}, nil
 }
 
 // Metadata returns the plugin's identifying information.

--- a/internal/smo/adapters/onap/plugin_test.go
+++ b/internal/smo/adapters/onap/plugin_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestNewPlugin(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	assert.NotNil(t, plugin)
 	assert.Equal(t, "onap", plugin.Name)
@@ -26,7 +26,7 @@ func TestNewPlugin(t *testing.T) {
 
 func TestPluginMetadata(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	metadata := plugin.Metadata()
 
@@ -90,7 +90,7 @@ func TestPluginCapabilities(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := zaptest.NewLogger(t)
-			plugin := onap.NewPlugin(logger)
+			plugin := newTestONAP(logger)
 			plugin.Config = tt.config
 
 			capabilities := plugin.Capabilities()
@@ -292,7 +292,7 @@ func TestParseConfig(t *testing.T) {
 
 func TestPluginClose(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 	plugin.Config = onap.DefaultConfig()
 
 	// Close once
@@ -307,7 +307,7 @@ func TestPluginClose(t *testing.T) {
 
 func TestPluginHealthClosedState(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 	plugin.Closed = true
 
 	health := plugin.Health(context.Background())
@@ -318,7 +318,7 @@ func TestPluginHealthClosedState(t *testing.T) {
 
 func TestMapDeploymentStatusToOrchestrationStatus(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	tests := []struct {
 		input    string
@@ -344,7 +344,7 @@ func TestMapDeploymentStatusToOrchestrationStatus(t *testing.T) {
 
 func TestMapONAPRequestStateToStatus(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	tests := []struct {
 		input    string
@@ -370,7 +370,7 @@ func TestMapONAPRequestStateToStatus(t *testing.T) {
 
 func TestGetDMaaPTopic(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	tests := []struct {
 		eventType     string
@@ -394,7 +394,7 @@ func TestGetDMaaPTopic(t *testing.T) {
 // TestPlugin_Initialize tests the Initialize function.
 func TestPlugin_Initialize(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	config := map[string]interface{}{
 		"endpoint":   "https://onap.example.com",
@@ -411,7 +411,7 @@ func TestPlugin_Initialize(t *testing.T) {
 // TestPlugin_Health tests the Health function.
 func TestPlugin_Health(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	config := map[string]interface{}{
 		"endpoint":   "https://onap.example.com",
@@ -436,7 +436,7 @@ func TestPlugin_Health(t *testing.T) {
 // TestPlugin_SyncInfrastructureInventory tests the SyncInfrastructureInventory function.
 func TestPlugin_SyncInfrastructureInventory(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	config := map[string]interface{}{
 		"endpoint":   "https://onap.example.com",
@@ -467,7 +467,7 @@ func TestPlugin_SyncInfrastructureInventory(t *testing.T) {
 // TestPlugin_SyncDeploymentInventory tests the SyncDeploymentInventory function.
 func TestPlugin_SyncDeploymentInventory(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	config := map[string]interface{}{
 		"endpoint":   "https://onap.example.com",
@@ -498,7 +498,7 @@ func TestPlugin_SyncDeploymentInventory(t *testing.T) {
 // TestPlugin_PublishInfrastructureEvent tests the PublishInfrastructureEvent function.
 func TestPlugin_PublishInfrastructureEvent(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	config := map[string]interface{}{
 		"endpoint":   "https://onap.example.com",
@@ -530,7 +530,7 @@ func TestPlugin_PublishInfrastructureEvent(t *testing.T) {
 // TestPlugin_PublishDeploymentEvent tests the PublishDeploymentEvent function.
 func TestPlugin_PublishDeploymentEvent(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	config := map[string]interface{}{
 		"endpoint":   "https://onap.example.com",
@@ -562,7 +562,7 @@ func TestPlugin_PublishDeploymentEvent(t *testing.T) {
 // TestPlugin_ExecuteWorkflow tests the ExecuteWorkflow function.
 func TestPlugin_ExecuteWorkflow(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	config := map[string]interface{}{
 		"endpoint":   "https://onap.example.com",
@@ -595,7 +595,7 @@ func TestPlugin_ExecuteWorkflow(t *testing.T) {
 // TestPlugin_GetWorkflowStatus tests the GetWorkflowStatus function.
 func TestPlugin_GetWorkflowStatus(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	config := map[string]interface{}{
 		"endpoint":   "https://onap.example.com",
@@ -623,7 +623,7 @@ func TestPlugin_GetWorkflowStatus(t *testing.T) {
 // TestPlugin_Close tests the Close function.
 func TestPlugin_Close(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	plugin := onap.NewPlugin(logger)
+	plugin := newTestONAP(logger)
 
 	// Close without initialization should not error
 	err := plugin.Close()

--- a/internal/smo/adapters/onap/testhelpers_inpkg_test.go
+++ b/internal/smo/adapters/onap/testhelpers_inpkg_test.go
@@ -1,0 +1,16 @@
+package onap
+
+import "go.uber.org/zap"
+
+// newTestONAPInPkg is an in-package test helper that constructs an ONAP plugin
+// with the given logger. It mirrors the old NewPlugin(logger) signature used
+// before the M11 constructor rename (onap.NewPlugin -> onap.New) so existing
+// in-package tests remain terse. It panics on the (currently unreachable)
+// error path to avoid littering callers with require.NoError checks.
+func newTestONAPInPkg(logger *zap.Logger) *Plugin {
+	p, err := New(&Config{Logger: logger})
+	if err != nil {
+		panic("onap.New unexpectedly returned error in test: " + err.Error())
+	}
+	return p
+}

--- a/internal/smo/adapters/onap/testhelpers_test.go
+++ b/internal/smo/adapters/onap/testhelpers_test.go
@@ -1,0 +1,20 @@
+package onap_test
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/piwi3910/netweave/internal/smo/adapters/onap"
+)
+
+// newTestONAP is a test-only helper that constructs an ONAP plugin and panics
+// on the (currently unreachable) error path. Tests used to call the old
+// onap.NewPlugin(logger) which returned *Plugin with no error. onap.New now
+// returns (*Plugin, error) to align with the OSM plugin signature; this helper
+// keeps the tests terse without littering them with require.NoError checks.
+func newTestONAP(logger *zap.Logger) *onap.Plugin {
+	plugin, err := onap.New(&onap.Config{Logger: logger})
+	if err != nil {
+		panic("onap.New unexpectedly returned error in test: " + err.Error())
+	}
+	return plugin
+}

--- a/internal/smo/adapters/osm/README.md
+++ b/internal/smo/adapters/osm/README.md
@@ -150,7 +150,7 @@ config := &osm.Config{
     Project:  "admin",
 }
 
-plugin, err := osm.NewPlugin(config)
+plugin, err := osm.New(config)
 if err != nil {
     log.Fatalf("Failed to create OSM plugin: %v", err)
 }

--- a/internal/smo/adapters/osm/config_viper_test.go
+++ b/internal/smo/adapters/osm/config_viper_test.go
@@ -1,0 +1,57 @@
+package osm_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/smo/adapters/osm"
+)
+
+// TestConfigMapstructureTags verifies that every field on osm.Config can be
+// populated by Viper's UnmarshalKey. Viper respects `mapstructure` tags, not
+// `yaml`/`json` tags, so missing or mis-named tags would leave fields at their
+// zero value — causing the corresponding assertion below to fail.
+func TestConfigMapstructureTags(t *testing.T) {
+	const yamlDoc = `
+osm:
+  nbiUrl: "https://osm.example.com:9999"
+  username: "admin"
+  password: "secret"
+  project: "tenant1"
+  requestTimeout: 45s
+  inventorySyncInterval: 10m
+  lcmPollingInterval: 15s
+  maxRetries: 5
+  retryDelay: 2s
+  retryMaxDelay: 60s
+  retryMultiplier: 3.0
+  enableInventorySync: true
+  enableEventPublish: false
+`
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(bytes.NewBufferString(yamlDoc)))
+
+	var cfg osm.Config
+	require.NoError(t, v.UnmarshalKey("osm", &cfg))
+
+	assert.Equal(t, "https://osm.example.com:9999", cfg.NBIURL)
+	assert.Equal(t, "admin", cfg.Username)
+	assert.Equal(t, "secret", cfg.Password)
+	assert.Equal(t, "tenant1", cfg.Project)
+	assert.Equal(t, 45*time.Second, cfg.RequestTimeout)
+	assert.Equal(t, 10*time.Minute, cfg.InventorySyncInterval)
+	assert.Equal(t, 15*time.Second, cfg.LCMPollingInterval)
+	assert.Equal(t, 5, cfg.MaxRetries)
+	assert.Equal(t, 2*time.Second, cfg.RetryDelay)
+	assert.Equal(t, 60*time.Second, cfg.RetryMaxDelay)
+	assert.InDelta(t, 3.0, cfg.RetryMultiplier, 0.0001)
+	assert.True(t, cfg.EnableInventorySync)
+	assert.False(t, cfg.EnableEventPublish)
+}

--- a/internal/smo/adapters/osm/northbound_test.go
+++ b/internal/smo/adapters/osm/northbound_test.go
@@ -426,7 +426,7 @@ func createTestPlugin(t *testing.T, serverURL string) *osm.Plugin {
 		EnableEventPublish:  true,
 	}
 
-	plugin, err := osm.NewPlugin(config)
+	plugin, err := osm.New(config)
 	if err != nil {
 		t.Fatalf("Failed to create test plugin: %v", err)
 	}

--- a/internal/smo/adapters/osm/plugin.go
+++ b/internal/smo/adapters/osm/plugin.go
@@ -84,9 +84,9 @@ func DefaultConfig() *Config {
 	}
 }
 
-// NewPlugin creates a new OSM plugin instance with the provided configuration.
+// New creates a new OSM plugin instance with the provided configuration.
 // It initializes the OSM NBI client and validates the configuration.
-func NewPlugin(config *Config) (*Plugin, error) {
+func New(config *Config) (*Plugin, error) {
 	if config == nil {
 		config = DefaultConfig()
 	}

--- a/internal/smo/adapters/osm/plugin_test.go
+++ b/internal/smo/adapters/osm/plugin_test.go
@@ -77,7 +77,7 @@ func TestNewPlugin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			plugin, err := osm.NewPlugin(tt.config)
+			plugin, err := osm.New(tt.config)
 
 			if tt.wantErr {
 				validateExpectedError(t, err, tt.errMsg)
@@ -94,11 +94,11 @@ func validateExpectedError(t *testing.T, err error, errMsg string) {
 	t.Helper()
 
 	if err == nil {
-		t.Error("osm.NewPlugin() expected error but got none")
+		t.Error("osm.New() expected error but got none")
 		return
 	}
 	if errMsg != "" && err.Error() != errMsg {
-		t.Errorf("osm.NewPlugin() error = %v, want %v", err.Error(), errMsg)
+		t.Errorf("osm.New() error = %v, want %v", err.Error(), errMsg)
 	}
 }
 
@@ -107,12 +107,12 @@ func validatePluginCreation(t *testing.T, plugin *osm.Plugin, err error) {
 	t.Helper()
 
 	if err != nil {
-		t.Errorf("osm.NewPlugin() unexpected error: %v", err)
+		t.Errorf("osm.New() unexpected error: %v", err)
 		return
 	}
 
 	if plugin == nil {
-		t.Error("osm.NewPlugin() returned nil plugin")
+		t.Error("osm.New() returned nil plugin")
 		return
 	}
 
@@ -161,9 +161,9 @@ func TestPluginMetadata(t *testing.T) {
 		Password: "secret",
 	}
 
-	plugin, err := osm.NewPlugin(config)
+	plugin, err := osm.New(config)
 	if err != nil {
-		t.Fatalf("osm.NewPlugin() failed: %v", err)
+		t.Fatalf("osm.New() failed: %v", err)
 	}
 
 	// Test Name
@@ -212,9 +212,9 @@ func TestPluginCapabilityChecks(t *testing.T) {
 		Password: "secret",
 	}
 
-	plugin, err := osm.NewPlugin(config)
+	plugin, err := osm.New(config)
 	if err != nil {
-		t.Fatalf("osm.NewPlugin() failed: %v", err)
+		t.Fatalf("osm.New() failed: %v", err)
 	}
 
 	tests := []struct {
@@ -274,9 +274,9 @@ func TestPluginLifecycle(t *testing.T) {
 		EnableInventorySync: false,
 	}
 
-	plugin, err := osm.NewPlugin(config)
+	plugin, err := osm.New(config)
 	if err != nil {
-		t.Fatalf("osm.NewPlugin() failed: %v", err)
+		t.Fatalf("osm.New() failed: %v", err)
 	}
 
 	// Test Health before initialization (should fail)
@@ -345,9 +345,9 @@ func TestMapOSMStatus(t *testing.T) {
 		Password: "secret",
 	}
 
-	plugin, err := osm.NewPlugin(config)
+	plugin, err := osm.New(config)
 	if err != nil {
-		t.Fatalf("osm.NewPlugin() failed: %v", err)
+		t.Fatalf("osm.New() failed: %v", err)
 	}
 
 	tests := []struct {

--- a/internal/smo/adapters/osm/southbound_test.go
+++ b/internal/smo/adapters/osm/southbound_test.go
@@ -20,7 +20,7 @@ func TestPlugin_Metadata(t *testing.T) {
 		Password: "secret",
 		Project:  "admin",
 	}
-	plugin, err := osm.NewPlugin(cfg)
+	plugin, err := osm.New(cfg)
 	require.NoError(t, err)
 
 	metadata := plugin.Metadata()
@@ -39,7 +39,7 @@ func TestNewSMOPluginAdapter(t *testing.T) {
 		Password: "secret",
 		Project:  "admin",
 	}
-	plugin, err := osm.NewPlugin(cfg)
+	plugin, err := osm.New(cfg)
 	require.NoError(t, err)
 
 	adapter := osm.NewSMOPluginAdapter(plugin)
@@ -56,7 +56,7 @@ func TestSMOPluginAdapter_Capabilities(t *testing.T) {
 		Password: "secret",
 		Project:  "admin",
 	}
-	plugin, err := osm.NewPlugin(cfg)
+	plugin, err := osm.New(cfg)
 	require.NoError(t, err)
 
 	adapter := osm.NewSMOPluginAdapter(plugin)
@@ -99,7 +99,7 @@ func TestSMOPluginAdapter_Initialize(t *testing.T) {
 				Password: "secret",
 				Project:  "admin",
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			adapter := osm.NewSMOPluginAdapter(plugin)
@@ -134,7 +134,7 @@ func TestSMOPluginAdapter_Health(t *testing.T) {
 					Password: "secret",
 					Project:  "admin",
 				}
-				plugin, _ := osm.NewPlugin(cfg)
+				plugin, _ := osm.New(cfg)
 				return plugin
 			},
 			expectHealthy: false, // Will be unhealthy as we can't connect to real OSM
@@ -231,7 +231,7 @@ func TestPlugin_SyncInfrastructureInventory(t *testing.T) {
 				Password: "secret",
 				Project:  "admin",
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			ctx := context.Background()
@@ -294,7 +294,7 @@ func TestPlugin_SyncDeploymentInventory(t *testing.T) {
 				Password: "secret",
 				Project:  "admin",
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			ctx := context.Background()
@@ -363,7 +363,7 @@ func TestPlugin_PublishInfrastructureEvent(t *testing.T) {
 				Project:            "admin",
 				EnableEventPublish: tt.enabled,
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			ctx := context.Background()
@@ -415,7 +415,7 @@ func TestPlugin_PublishDeploymentEvent(t *testing.T) {
 				Password: "secret",
 				Project:  "admin",
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			ctx := context.Background()
@@ -557,7 +557,7 @@ func TestPlugin_ExecuteWorkflow(t *testing.T) {
 				Password: "secret",
 				Project:  "admin",
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			// Initialize plugin for workflow execution
@@ -612,7 +612,7 @@ func TestPlugin_GetWorkflowStatus(t *testing.T) {
 				Password: "secret",
 				Project:  "admin",
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			// Initialize plugin
@@ -667,7 +667,7 @@ func TestPlugin_CancelWorkflow(t *testing.T) {
 				Password: "secret",
 				Project:  "admin",
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			// Initialize plugin
@@ -743,7 +743,7 @@ func TestPlugin_RegisterServiceModel(t *testing.T) {
 				Password: "secret",
 				Project:  "admin",
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			// Initialize plugin
@@ -793,7 +793,7 @@ func TestPlugin_GetServiceModel(t *testing.T) {
 				Password: "secret",
 				Project:  "admin",
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			// Initialize plugin
@@ -825,7 +825,7 @@ func TestPlugin_ListServiceModels(t *testing.T) {
 		Password: "secret",
 		Project:  "admin",
 	}
-	plugin, err := osm.NewPlugin(cfg)
+	plugin, err := osm.New(cfg)
 	require.NoError(t, err)
 
 	// Initialize plugin
@@ -868,7 +868,7 @@ func TestPlugin_DeleteServiceModel(t *testing.T) {
 				Password: "secret",
 				Project:  "admin",
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			// Initialize plugin
@@ -924,7 +924,7 @@ func TestPlugin_ApplyPolicy(t *testing.T) {
 				Password: "secret",
 				Project:  "admin",
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			ctx := context.Background()
@@ -972,7 +972,7 @@ func TestPlugin_GetPolicyStatus(t *testing.T) {
 				Password: "secret",
 				Project:  "admin",
 			}
-			plugin, err := osm.NewPlugin(cfg)
+			plugin, err := osm.New(cfg)
 			require.NoError(t, err)
 
 			ctx := context.Background()

--- a/internal/smo/registry.go
+++ b/internal/smo/registry.go
@@ -177,9 +177,29 @@ func (r *Registry) Unregister(name string) error {
 	return nil
 }
 
-// Get retrieves a plugin by name.
+// Get retrieves a plugin by name. Returns nil if the plugin is not registered.
+func (r *Registry) Get(name string) Plugin {
+	r.Mu.RLock()
+	defer r.Mu.RUnlock()
+	return r.Plugins[name]
+}
 
-// GetDefault retrieves the default plugin.
+// GetDefault retrieves the default plugin. Returns nil if no default is set.
+func (r *Registry) GetDefault() Plugin {
+	r.Mu.RLock()
+	defer r.Mu.RUnlock()
+	if r.DefaultPlugin == "" {
+		return nil
+	}
+	return r.Plugins[r.DefaultPlugin]
+}
+
+// DefaultName returns the name of the default plugin, or empty string if none is set.
+func (r *Registry) DefaultName() string {
+	r.Mu.RLock()
+	defer r.Mu.RUnlock()
+	return r.DefaultPlugin
+}
 
 // SetDefault sets the default plugin by name.
 func (r *Registry) SetDefault(name string) error {

--- a/tests/integration/o2ims/tmforum_test.go
+++ b/tests/integration/o2ims/tmforum_test.go
@@ -63,7 +63,7 @@ func setupTMFTestServer(t *testing.T) *helpers.TestServer {
 	dmsRegistry := registry.NewRegistry(logger, nil)
 
 	// Register mock DMS adapter (with sample data for testing)
-	mockDMS := mock.NewAdapter(true) // true = populate sample data
+	mockDMS := mock.New(true) // true = populate sample data
 
 	err := dmsRegistry.Register(ctx, "mock-dms", "mock", mockDMS, nil, true)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Closes #526, #531, #532, #533, #534, #505, #506, #507.

Adapter/registry/server-construction polish across IMS, DMS, and SMO subsystems.

- **M11**: Standardize adapter constructors on `New(*Config)` across IMS mock, DMS (argocd, crossplane, flux, helm, kustomize, mock, onaplcm, osmlcm), and SMO (mock, osm, onap). ONAP now accepts a `Config` struct and returns `(*Plugin, error)` to align with OSM.
- **M16**: Add Viper `UnmarshalKey` round-trip tests for DTIAS and OSM configs to prevent silent loss of config fields.
- **M17**: No-op (mock alias already `imsadapter`).
- **M18**: Demote routine "listed resources" logs to Debug across openstack, vmware, kubernetes, azure, gcp, aws adapters; add log-level policy doc in `internal/observability/doc.go`.
- **M19**: Introduce `PoolModeResourceGroup` / `PoolModeAvailabilityZone` constants in `internal/adapters/azure`; replace string literals throughout resource pool and resource handling.
- **I14**: Add `Get` / `GetDefault` / `DefaultName` methods to `internal/smo.Registry` (mirroring DMS) and migrate `internal/server/smo_routes.go`, `internal/routing/routing.go`, and `internal/dms/handlers/handlers.go` off `Mu`/`Plugins`/`DefaultPlugin` direct field access.
- **I15**: Replace the static `switch` in `internal/backend/adapter_factory.go` with `init()`-based registration. New `Register{IMS,DMS,SMO}Adapter` registrars are called from `init()` to wire the mock adapters; external adapter packages can now self-register.
- **I16**: Replace `server.New`'s `opts ...interface{}` with typed functional options (`ServerOption`) and expose `WithAuthMiddleware`; `cmd/gateway/main.go` now uses `server.WithAuthMiddleware(authMw)`.

> Note: may need rebase against H11/H12/M20 PR if that lands first, since both touch registry internals.

## Test plan

- [x] `go build ./...`
- [x] `go test -race -short ./...` (all non-infra packages green)
- [x] `golangci-lint run --config=.golangci.yml --timeout=10m` (no new findings; pre-existing gosec/staticcheck issues unchanged)
- [ ] CI pipeline green