### PR TITLE
[Refactor] H12+M20: Shared in-memory and storage-backed subscription store

### DIFF
--- a/internal/adapter/substore.go
+++ b/internal/adapter/substore.go
@@ -156,6 +156,20 @@ func (s *InMemorySubscriptionStore) Reset() {
 	s.subs = make(map[string]*Subscription)
 }
 
+// Snapshot returns a slice copy of all subscriptions. Unlike List, it does not
+// take a context and is intended for callers that expose legacy non-ctx
+// signatures (e.g., adapter-local helpers) where threading a context would be
+// a breaking change.
+func (s *InMemorySubscriptionStore) Snapshot() []*Subscription {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]*Subscription, 0, len(s.subs))
+	for _, sub := range s.subs {
+		result = append(result, sub)
+	}
+	return result
+}
+
 // RawMap returns the underlying map.
 //
 // This exists solely to preserve legacy test hooks (ExportSubscriptions) that
@@ -274,7 +288,10 @@ func (s *StorageBackedSubscriptionStore) Delete(ctx context.Context, id string) 
 }
 
 // List returns all subscriptions matching filter.
-func (s *StorageBackedSubscriptionStore) List(ctx context.Context, filter *SubscriptionFilter) ([]*Subscription, error) {
+func (s *StorageBackedSubscriptionStore) List(
+	ctx context.Context,
+	filter *SubscriptionFilter,
+) ([]*Subscription, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("context canceled: %w", err)
 	}

--- a/internal/adapter/substore.go
+++ b/internal/adapter/substore.go
@@ -1,0 +1,282 @@
+// Package adapter provides shared abstractions for cloud backend adapters.
+//
+// This file contains two subscription store implementations that eliminate
+// duplication across adapters (AWS, Azure, GCP, OpenStack, VMware, DTIAS):
+//
+//   - InMemorySubscriptionStore: a thread-safe, in-memory subscription store
+//     used by adapters whose underlying cloud provider lacks native event
+//     notifications (polling-based subscriptions).
+//
+//   - StorageBackedSubscriptionStore: a sibling store that delegates to the
+//     storage.Store interface so subscriptions survive adapter restarts.
+//     Adapters opt-in via configuration; the default remains in-memory.
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// InMemorySubscriptionStore is a thread-safe in-memory subscription store.
+// It is the default backing for adapters that lack native event subscriptions
+// and implement polling-based notifications.
+//
+// All methods respect context cancellation: if the caller's context is
+// already canceled, the method returns immediately with ctx.Err() wrapped.
+//
+// The zero value is not usable; construct instances with
+// NewInMemorySubscriptionStore.
+type InMemorySubscriptionStore struct {
+	mu   sync.RWMutex
+	subs map[string]*Subscription
+}
+
+// NewInMemorySubscriptionStore returns a ready-to-use in-memory store.
+func NewInMemorySubscriptionStore() *InMemorySubscriptionStore {
+	return &InMemorySubscriptionStore{
+		subs: make(map[string]*Subscription),
+	}
+}
+
+// Create inserts a new subscription.
+// Returns ErrSubscriptionExists if the subscription ID is already present.
+// Returns an error if sub is nil or sub.SubscriptionID is empty.
+func (s *InMemorySubscriptionStore) Create(ctx context.Context, sub *Subscription) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("context canceled: %w", err)
+	}
+	if sub == nil {
+		return fmt.Errorf("subscription is nil")
+	}
+	if sub.SubscriptionID == "" {
+		return fmt.Errorf("subscription ID is required")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.subs[sub.SubscriptionID]; exists {
+		return fmt.Errorf("%w: %s", ErrSubscriptionExists, sub.SubscriptionID)
+	}
+
+	s.subs[sub.SubscriptionID] = sub
+	return nil
+}
+
+// Get retrieves a subscription by ID.
+// Returns ErrSubscriptionNotFound if no subscription with the given ID exists.
+func (s *InMemorySubscriptionStore) Get(ctx context.Context, id string) (*Subscription, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("context canceled: %w", err)
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sub, exists := s.subs[id]
+	if !exists {
+		return nil, fmt.Errorf("%w: %s", ErrSubscriptionNotFound, id)
+	}
+	return sub, nil
+}
+
+// Update replaces an existing subscription.
+// Returns ErrSubscriptionNotFound if no subscription with the given ID exists.
+// The caller is responsible for preserving the SubscriptionID in sub.
+func (s *InMemorySubscriptionStore) Update(ctx context.Context, id string, sub *Subscription) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("context canceled: %w", err)
+	}
+	if sub == nil {
+		return fmt.Errorf("subscription is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.subs[id]; !exists {
+		return fmt.Errorf("%w: %s", ErrSubscriptionNotFound, id)
+	}
+	s.subs[id] = sub
+	return nil
+}
+
+// Delete removes a subscription by ID.
+// Returns ErrSubscriptionNotFound if no subscription with the given ID exists.
+func (s *InMemorySubscriptionStore) Delete(ctx context.Context, id string) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("context canceled: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.subs[id]; !exists {
+		return fmt.Errorf("%w: %s", ErrSubscriptionNotFound, id)
+	}
+	delete(s.subs, id)
+	return nil
+}
+
+// List returns all subscriptions matching filter. A nil filter returns every
+// subscription. A non-nil filter applies the same semantics as
+// SubscriptionFilter comparisons (non-empty fields must match the
+// corresponding subscription field).
+func (s *InMemorySubscriptionStore) List(ctx context.Context, filter *SubscriptionFilter) ([]*Subscription, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("context canceled: %w", err)
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]*Subscription, 0, len(s.subs))
+	for _, sub := range s.subs {
+		if subscriptionMatchesFilter(sub, filter) {
+			result = append(result, sub)
+		}
+	}
+	return result, nil
+}
+
+// Len returns the current number of subscriptions.
+// Safe for concurrent use.
+func (s *InMemorySubscriptionStore) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.subs)
+}
+
+// Reset removes all subscriptions. Intended for use by Close() on adapters
+// that share this store.
+func (s *InMemorySubscriptionStore) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.subs = make(map[string]*Subscription)
+}
+
+// RawMap returns the underlying map.
+//
+// This exists solely to preserve legacy test hooks (ExportSubscriptions) that
+// want to seed or inspect subscriptions directly. Callers must not access it
+// concurrently with adapter operations.
+func (s *InMemorySubscriptionStore) RawMap() map[string]*Subscription {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.subs
+}
+
+// subscriptionMatchesFilter reports whether sub's filter matches the supplied
+// filter criteria. Non-empty fields in filter must match sub.Filter.
+func subscriptionMatchesFilter(sub *Subscription, filter *SubscriptionFilter) bool {
+	if filter == nil {
+		return true
+	}
+	sf := sub.Filter
+	if filter.ResourcePoolID != "" {
+		if sf == nil || sf.ResourcePoolID != filter.ResourcePoolID {
+			return false
+		}
+	}
+	if filter.ResourceTypeID != "" {
+		if sf == nil || sf.ResourceTypeID != filter.ResourceTypeID {
+			return false
+		}
+	}
+	if filter.ResourceID != "" {
+		if sf == nil || sf.ResourceID != filter.ResourceID {
+			return false
+		}
+	}
+	return true
+}
+
+// StorageStore describes the subset of storage.Store operations required by
+// StorageBackedSubscriptionStore. It is declared here (instead of importing
+// internal/storage directly) to avoid an import cycle: the storage package is
+// free to depend on this adapter package via its concrete types if needed, and
+// callers wire in any implementation that satisfies this surface.
+type StorageStore interface {
+	// Create persists a subscription. Implementations return a sentinel
+	// "already exists" error when the ID is a duplicate.
+	Create(ctx context.Context, id, consumerSubscriptionID, callback string, filter *SubscriptionFilter) error
+
+	// Get retrieves a subscription by ID. Implementations return a sentinel
+	// "not found" error when absent.
+	Get(ctx context.Context, id string) (*Subscription, error)
+
+	// Update overwrites an existing subscription.
+	Update(ctx context.Context, id, consumerSubscriptionID, callback string, filter *SubscriptionFilter) error
+
+	// Delete removes a subscription by ID.
+	Delete(ctx context.Context, id string) error
+
+	// List returns all subscriptions, optionally filtered.
+	List(ctx context.Context, filter *SubscriptionFilter) ([]*Subscription, error)
+}
+
+// StorageBackedSubscriptionStore delegates subscription CRUD to a durable
+// storage backend (e.g., Redis, Postgres). It provides the same method set as
+// InMemorySubscriptionStore so adapters can select between in-memory and
+// persistent storage via configuration.
+//
+// Adapters must explicitly opt-in; the default remains the in-memory store.
+type StorageBackedSubscriptionStore struct {
+	backend StorageStore
+}
+
+// NewStorageBackedSubscriptionStore returns a store that delegates to
+// backend. backend must not be nil.
+func NewStorageBackedSubscriptionStore(backend StorageStore) *StorageBackedSubscriptionStore {
+	return &StorageBackedSubscriptionStore{backend: backend}
+}
+
+// Create persists sub via the backend.
+func (s *StorageBackedSubscriptionStore) Create(ctx context.Context, sub *Subscription) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("context canceled: %w", err)
+	}
+	if sub == nil {
+		return fmt.Errorf("subscription is nil")
+	}
+	if sub.SubscriptionID == "" {
+		return fmt.Errorf("subscription ID is required")
+	}
+	return s.backend.Create(ctx, sub.SubscriptionID, sub.ConsumerSubscriptionID, sub.Callback, sub.Filter)
+}
+
+// Get retrieves a subscription by ID from the backend.
+func (s *StorageBackedSubscriptionStore) Get(ctx context.Context, id string) (*Subscription, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("context canceled: %w", err)
+	}
+	return s.backend.Get(ctx, id)
+}
+
+// Update replaces the subscription identified by id.
+func (s *StorageBackedSubscriptionStore) Update(ctx context.Context, id string, sub *Subscription) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("context canceled: %w", err)
+	}
+	if sub == nil {
+		return fmt.Errorf("subscription is nil")
+	}
+	return s.backend.Update(ctx, id, sub.ConsumerSubscriptionID, sub.Callback, sub.Filter)
+}
+
+// Delete removes the subscription identified by id.
+func (s *StorageBackedSubscriptionStore) Delete(ctx context.Context, id string) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("context canceled: %w", err)
+	}
+	return s.backend.Delete(ctx, id)
+}
+
+// List returns all subscriptions matching filter.
+func (s *StorageBackedSubscriptionStore) List(ctx context.Context, filter *SubscriptionFilter) ([]*Subscription, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("context canceled: %w", err)
+	}
+	return s.backend.List(ctx, filter)
+}

--- a/internal/adapter/substore_test.go
+++ b/internal/adapter/substore_test.go
@@ -1,0 +1,412 @@
+package adapter_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/adapter"
+)
+
+func newSub(id, cb string, filter *adapter.SubscriptionFilter) *adapter.Subscription {
+	return &adapter.Subscription{
+		SubscriptionID: id,
+		Callback:       cb,
+		Filter:         filter,
+	}
+}
+
+func TestInMemorySubscriptionStore_Create(t *testing.T) {
+	tests := []struct {
+		name    string
+		sub     *adapter.Subscription
+		setup   func(s *adapter.InMemorySubscriptionStore)
+		wantErr error
+	}{
+		{
+			name: "valid subscription",
+			sub:  newSub("sub-1", "https://example.com/hook", nil),
+		},
+		{
+			name:    "nil subscription",
+			sub:     nil,
+			wantErr: errors.New("subscription is nil"),
+		},
+		{
+			name:    "empty ID",
+			sub:     newSub("", "https://example.com/hook", nil),
+			wantErr: errors.New("subscription ID is required"),
+		},
+		{
+			name: "duplicate subscription",
+			sub:  newSub("sub-1", "https://example.com/hook", nil),
+			setup: func(s *adapter.InMemorySubscriptionStore) {
+				_ = s.Create(context.Background(), newSub("sub-1", "https://existing.example.com/hook", nil))
+			},
+			wantErr: adapter.ErrSubscriptionExists,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := adapter.NewInMemorySubscriptionStore()
+			if tt.setup != nil {
+				tt.setup(store)
+			}
+
+			err := store.Create(context.Background(), tt.sub)
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				got, err := store.Get(context.Background(), tt.sub.SubscriptionID)
+				require.NoError(t, err)
+				assert.Equal(t, tt.sub.Callback, got.Callback)
+				return
+			}
+			require.Error(t, err)
+			if errors.Is(tt.wantErr, adapter.ErrSubscriptionExists) {
+				assert.ErrorIs(t, err, adapter.ErrSubscriptionExists)
+			} else {
+				assert.Contains(t, err.Error(), tt.wantErr.Error())
+			}
+		})
+	}
+}
+
+func TestInMemorySubscriptionStore_Get(t *testing.T) {
+	store := adapter.NewInMemorySubscriptionStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, newSub("sub-1", "https://example.com/hook", nil)))
+
+	got, err := store.Get(ctx, "sub-1")
+	require.NoError(t, err)
+	assert.Equal(t, "sub-1", got.SubscriptionID)
+
+	_, err = store.Get(ctx, "missing")
+	assert.ErrorIs(t, err, adapter.ErrSubscriptionNotFound)
+}
+
+func TestInMemorySubscriptionStore_Update(t *testing.T) {
+	store := adapter.NewInMemorySubscriptionStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, newSub("sub-1", "https://old.example.com/hook", nil)))
+
+	// Missing subscription
+	err := store.Update(ctx, "missing", newSub("missing", "https://new.example.com/hook", nil))
+	assert.ErrorIs(t, err, adapter.ErrSubscriptionNotFound)
+
+	// Nil subscription
+	err = store.Update(ctx, "sub-1", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subscription is nil")
+
+	// Successful update
+	updated := newSub("sub-1", "https://new.example.com/hook", nil)
+	require.NoError(t, store.Update(ctx, "sub-1", updated))
+
+	got, err := store.Get(ctx, "sub-1")
+	require.NoError(t, err)
+	assert.Equal(t, "https://new.example.com/hook", got.Callback)
+}
+
+func TestInMemorySubscriptionStore_Delete(t *testing.T) {
+	store := adapter.NewInMemorySubscriptionStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, newSub("sub-1", "https://example.com/hook", nil)))
+
+	assert.ErrorIs(t, store.Delete(ctx, "missing"), adapter.ErrSubscriptionNotFound)
+	require.NoError(t, store.Delete(ctx, "sub-1"))
+
+	_, err := store.Get(ctx, "sub-1")
+	assert.ErrorIs(t, err, adapter.ErrSubscriptionNotFound)
+}
+
+func TestInMemorySubscriptionStore_List(t *testing.T) {
+	store := adapter.NewInMemorySubscriptionStore()
+	ctx := context.Background()
+
+	f1 := &adapter.SubscriptionFilter{ResourcePoolID: "pool-a", ResourceTypeID: "type-a"}
+	f2 := &adapter.SubscriptionFilter{ResourcePoolID: "pool-b", ResourceTypeID: "type-b", ResourceID: "res-b"}
+
+	require.NoError(t, store.Create(ctx, newSub("sub-1", "https://a.example.com", f1)))
+	require.NoError(t, store.Create(ctx, newSub("sub-2", "https://b.example.com", f2)))
+	require.NoError(t, store.Create(ctx, newSub("sub-3", "https://c.example.com", nil)))
+
+	tests := []struct {
+		name    string
+		filter  *adapter.SubscriptionFilter
+		wantLen int
+	}{
+		{name: "nil filter returns all", filter: nil, wantLen: 3},
+		{name: "pool filter", filter: &adapter.SubscriptionFilter{ResourcePoolID: "pool-a"}, wantLen: 1},
+		{name: "type filter", filter: &adapter.SubscriptionFilter{ResourceTypeID: "type-b"}, wantLen: 1},
+		{name: "resource filter", filter: &adapter.SubscriptionFilter{ResourceID: "res-b"}, wantLen: 1},
+		{name: "no matches", filter: &adapter.SubscriptionFilter{ResourcePoolID: "nonexistent"}, wantLen: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := store.List(ctx, tt.filter)
+			require.NoError(t, err)
+			assert.Len(t, got, tt.wantLen)
+		})
+	}
+}
+
+func TestInMemorySubscriptionStore_ContextCancellation(t *testing.T) {
+	store := adapter.NewInMemorySubscriptionStore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.Error(t, store.Create(ctx, newSub("sub-1", "https://example.com", nil)))
+	_, err := store.Get(ctx, "sub-1")
+	assert.Error(t, err)
+	assert.Error(t, store.Update(ctx, "sub-1", newSub("sub-1", "https://example.com", nil)))
+	assert.Error(t, store.Delete(ctx, "sub-1"))
+	_, err = store.List(ctx, nil)
+	assert.Error(t, err)
+}
+
+func TestInMemorySubscriptionStore_LenReset(t *testing.T) {
+	store := adapter.NewInMemorySubscriptionStore()
+	ctx := context.Background()
+	assert.Equal(t, 0, store.Len())
+
+	require.NoError(t, store.Create(ctx, newSub("sub-1", "https://a.example.com", nil)))
+	require.NoError(t, store.Create(ctx, newSub("sub-2", "https://b.example.com", nil)))
+	assert.Equal(t, 2, store.Len())
+
+	store.Reset()
+	assert.Equal(t, 0, store.Len())
+}
+
+func TestInMemorySubscriptionStore_RawMap(t *testing.T) {
+	store := adapter.NewInMemorySubscriptionStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, newSub("sub-1", "https://a.example.com", nil)))
+
+	m := store.RawMap()
+	require.NotNil(t, m)
+	assert.Contains(t, m, "sub-1")
+
+	// Seeding via the raw map is observable via Get.
+	m["sub-2"] = newSub("sub-2", "https://b.example.com", nil)
+	got, err := store.Get(ctx, "sub-2")
+	require.NoError(t, err)
+	assert.Equal(t, "https://b.example.com", got.Callback)
+}
+
+func TestInMemorySubscriptionStore_ConcurrentAccess(t *testing.T) {
+	store := adapter.NewInMemorySubscriptionStore()
+	ctx := context.Background()
+
+	const goroutines = 50
+	const perGoroutine = 20
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				id := fmt.Sprintf("sub-%d-%d", i, j)
+				if err := store.Create(ctx, newSub(id, "https://example.com", nil)); err != nil {
+					t.Errorf("create: %v", err)
+					return
+				}
+				if _, err := store.Get(ctx, id); err != nil {
+					t.Errorf("get: %v", err)
+					return
+				}
+				if err := store.Update(ctx, id, newSub(id, "https://updated.example.com", nil)); err != nil {
+					t.Errorf("update: %v", err)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, goroutines*perGoroutine, store.Len())
+
+	// Concurrent list + delete
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < goroutines; i++ {
+			_, err := store.List(ctx, nil)
+			if err != nil {
+				t.Errorf("list: %v", err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < goroutines; i++ {
+			for j := 0; j < perGoroutine; j++ {
+				_ = store.Delete(ctx, fmt.Sprintf("sub-%d-%d", i, j))
+			}
+		}
+	}()
+	wg.Wait()
+
+	assert.Equal(t, 0, store.Len())
+}
+
+// --- StorageBackedSubscriptionStore tests (with fake backend) ---
+
+type fakeBackend struct {
+	mu   sync.Mutex
+	subs map[string]*adapter.Subscription
+	// counters for verifying delegation
+	createCalls int
+	getCalls    int
+	updateCalls int
+	deleteCalls int
+	listCalls   int
+}
+
+func newFakeBackend() *fakeBackend {
+	return &fakeBackend{subs: make(map[string]*adapter.Subscription)}
+}
+
+func (f *fakeBackend) Create(_ context.Context, id, consumerID, callback string, filter *adapter.SubscriptionFilter) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.createCalls++
+	if _, ok := f.subs[id]; ok {
+		return fmt.Errorf("%w: %s", adapter.ErrSubscriptionExists, id)
+	}
+	f.subs[id] = &adapter.Subscription{
+		SubscriptionID:         id,
+		ConsumerSubscriptionID: consumerID,
+		Callback:               callback,
+		Filter:                 filter,
+	}
+	return nil
+}
+
+func (f *fakeBackend) Get(_ context.Context, id string) (*adapter.Subscription, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getCalls++
+	sub, ok := f.subs[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	}
+	return sub, nil
+}
+
+func (f *fakeBackend) Update(_ context.Context, id, consumerID, callback string, filter *adapter.SubscriptionFilter) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.updateCalls++
+	if _, ok := f.subs[id]; !ok {
+		return fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	}
+	f.subs[id] = &adapter.Subscription{
+		SubscriptionID:         id,
+		ConsumerSubscriptionID: consumerID,
+		Callback:               callback,
+		Filter:                 filter,
+	}
+	return nil
+}
+
+func (f *fakeBackend) Delete(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleteCalls++
+	if _, ok := f.subs[id]; !ok {
+		return fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	}
+	delete(f.subs, id)
+	return nil
+}
+
+func (f *fakeBackend) List(_ context.Context, _ *adapter.SubscriptionFilter) ([]*adapter.Subscription, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listCalls++
+	result := make([]*adapter.Subscription, 0, len(f.subs))
+	for _, sub := range f.subs {
+		result = append(result, sub)
+	}
+	return result, nil
+}
+
+func TestStorageBackedSubscriptionStore_DelegatesCRUD(t *testing.T) {
+	backend := newFakeBackend()
+	store := adapter.NewStorageBackedSubscriptionStore(backend)
+
+	ctx := context.Background()
+	sub := newSub("sub-1", "https://example.com", nil)
+
+	require.NoError(t, store.Create(ctx, sub))
+	assert.Equal(t, 1, backend.createCalls)
+
+	got, err := store.Get(ctx, "sub-1")
+	require.NoError(t, err)
+	assert.Equal(t, "sub-1", got.SubscriptionID)
+	assert.Equal(t, 1, backend.getCalls)
+
+	require.NoError(t, store.Update(ctx, "sub-1", newSub("sub-1", "https://updated.example.com", nil)))
+	assert.Equal(t, 1, backend.updateCalls)
+
+	list, err := store.List(ctx, nil)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+	assert.Equal(t, 1, backend.listCalls)
+
+	require.NoError(t, store.Delete(ctx, "sub-1"))
+	assert.Equal(t, 1, backend.deleteCalls)
+
+	_, err = store.Get(ctx, "sub-1")
+	assert.ErrorIs(t, err, adapter.ErrSubscriptionNotFound)
+}
+
+func TestStorageBackedSubscriptionStore_Validation(t *testing.T) {
+	backend := newFakeBackend()
+	store := adapter.NewStorageBackedSubscriptionStore(backend)
+	ctx := context.Background()
+
+	assert.Error(t, store.Create(ctx, nil))
+	assert.Error(t, store.Create(ctx, newSub("", "https://example.com", nil)))
+	assert.Error(t, store.Update(ctx, "sub-1", nil))
+	// No backend calls should have been made for invalid input.
+	assert.Equal(t, 0, backend.createCalls)
+	assert.Equal(t, 0, backend.updateCalls)
+}
+
+func TestStorageBackedSubscriptionStore_ContextCancellation(t *testing.T) {
+	backend := newFakeBackend()
+	store := adapter.NewStorageBackedSubscriptionStore(backend)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.Error(t, store.Create(ctx, newSub("sub-1", "https://example.com", nil)))
+	_, err := store.Get(ctx, "sub-1")
+	assert.Error(t, err)
+	assert.Error(t, store.Update(ctx, "sub-1", newSub("sub-1", "https://example.com", nil)))
+	assert.Error(t, store.Delete(ctx, "sub-1"))
+	_, err = store.List(ctx, nil)
+	assert.Error(t, err)
+
+	// Backend must not be invoked when context is already canceled.
+	assert.Equal(t, 0, backend.createCalls)
+	assert.Equal(t, 0, backend.getCalls)
+	assert.Equal(t, 0, backend.updateCalls)
+	assert.Equal(t, 0, backend.deleteCalls)
+	assert.Equal(t, 0, backend.listCalls)
+}

--- a/internal/adapter/substore_test.go
+++ b/internal/adapter/substore_test.go
@@ -280,7 +280,11 @@ func newFakeBackend() *fakeBackend {
 	return &fakeBackend{subs: make(map[string]*adapter.Subscription)}
 }
 
-func (f *fakeBackend) Create(_ context.Context, id, consumerID, callback string, filter *adapter.SubscriptionFilter) error {
+func (f *fakeBackend) Create(
+	_ context.Context,
+	id, consumerID, callback string,
+	filter *adapter.SubscriptionFilter,
+) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.createCalls++
@@ -307,7 +311,11 @@ func (f *fakeBackend) Get(_ context.Context, id string) (*adapter.Subscription, 
 	return sub, nil
 }
 
-func (f *fakeBackend) Update(_ context.Context, id, consumerID, callback string, filter *adapter.SubscriptionFilter) error {
+func (f *fakeBackend) Update(
+	_ context.Context,
+	id, consumerID, callback string,
+	filter *adapter.SubscriptionFilter,
+) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.updateCalls++

--- a/internal/adapters/aws/adapter.go
+++ b/internal/adapters/aws/adapter.go
@@ -12,7 +12,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -55,13 +54,11 @@ type Adapter struct {
 	// region is the AWS region this adapter manages.
 	region string
 
-	// subscriptions holds active subscriptions (polling-based fallback).
-	// Note: Subscriptions are stored in-memory and will be lost on adapter restart.
-	// For production use, consider implementing persistent storage via Redis.
-	subscriptions map[string]*adapter.Subscription
-
-	// subscriptionsMu protects the subscriptions map.
-	subscriptionsMu sync.RWMutex
+	// subs holds active subscriptions (polling-based fallback).
+	// Note: The default store is in-memory and will be lost on adapter restart.
+	// For durable storage, construct a StorageBackedSubscriptionStore and inject
+	// it here; subscriptions.go delegates CRUD through the stored methods.
+	subs *adapter.InMemorySubscriptionStore
 
 	// poolMode determines how resource pools are mapped.
 	// "az" maps to Availability Zones, "asg" maps to Auto Scaling Groups.
@@ -153,7 +150,7 @@ func New(cfg *Config) (*Adapter, error) {
 		oCloudID:            cfg.OCloudID,
 		deploymentManagerID: deploymentManagerID,
 		region:              cfg.Region,
-		subscriptions:       make(map[string]*adapter.Subscription),
+		subs:                adapter.NewInMemorySubscriptionStore(),
 		poolMode:            poolMode,
 	}, nil
 }
@@ -356,9 +353,7 @@ func (a *Adapter) Close() error {
 	a.logger.Info("closing AWS adapter")
 
 	// Clear subscriptions
-	a.subscriptionsMu.Lock()
-	a.subscriptions = make(map[string]*adapter.Subscription)
-	a.subscriptionsMu.Unlock()
+	a.subs.Reset()
 
 	// Sync logger before shutdown
 	// Sync errors on stderr/stdout are expected and can be ignored

--- a/internal/adapters/aws/export_test.go
+++ b/internal/adapters/aws/export_test.go
@@ -21,7 +21,7 @@ func NewTestAdapter(
 		deploymentManagerID: deploymentManagerID,
 		region:              region,
 		poolMode:            poolMode,
-		subscriptions:       make(map[string]*adapter.Subscription),
+		subs:                adapter.NewInMemorySubscriptionStore(),
 	}
 }
 
@@ -33,12 +33,13 @@ func NewTestAdapterWithSubs(
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	if subscriptions == nil {
-		subscriptions = make(map[string]*adapter.Subscription)
+	store := adapter.NewInMemorySubscriptionStore()
+	for k, v := range subscriptions {
+		store.RawMap()[k] = v
 	}
 	return &Adapter{
-		logger:        logger,
-		subscriptions: subscriptions,
+		logger: logger,
+		subs:   store,
 	}
 }
 
@@ -57,9 +58,9 @@ func (a *Adapter) ExportPoolMode() string { return a.poolMode }
 // ExportSetPoolMode sets the poolMode field for tests.
 func (a *Adapter) ExportSetPoolMode(mode string) { a.poolMode = mode }
 
-// ExportSubscriptions exposes the subscriptions map for tests.
+// ExportSubscriptions exposes the underlying subscriptions map for tests.
 // The returned map is the same map the adapter uses, so it can be read and written
 // in tests, but callers must not access it concurrently with adapter operations.
 func (a *Adapter) ExportSubscriptions() map[string]*adapter.Subscription {
-	return a.subscriptions
+	return a.subs.RawMap()
 }

--- a/internal/adapters/aws/extra_test.go
+++ b/internal/adapters/aws/extra_test.go
@@ -368,7 +368,7 @@ func createTestAdapter(t *testing.T, mockURL string) *Adapter {
 		oCloudID:            "test-ocloud",
 		deploymentManagerID: "ocloud-aws-us-east-1",
 		region:              "us-east-1",
-		subscriptions:       make(map[string]*adapter.Subscription),
+		subs:                adapter.NewInMemorySubscriptionStore(),
 		poolMode:            "az",
 	}
 }

--- a/internal/adapters/aws/subscriptions.go
+++ b/internal/adapters/aws/subscriptions.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -139,14 +138,5 @@ func (a *Adapter) DeleteSubscription(ctx context.Context, id string) error {
 // ListSubscriptions returns all active subscriptions.
 // This is a helper method not part of the Adapter interface.
 func (a *Adapter) ListSubscriptions() []*adapter.Subscription {
-	subs, err := a.subs.List(context.Background(), nil)
-	if err != nil {
-		// Background context never cancels; a non-nil error here would indicate
-		// a programming error. Fall back to an empty slice for safety.
-		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			a.logger.Warn("listing subscriptions returned unexpected error", zap.Error(err))
-		}
-		return nil
-	}
-	return subs
+	return a.subs.Snapshot()
 }

--- a/internal/adapters/aws/subscriptions.go
+++ b/internal/adapters/aws/subscriptions.go
@@ -2,42 +2,44 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
+
 	"github.com/piwi3910/netweave/internal/adapter"
 	"github.com/piwi3910/netweave/internal/security/urlredact"
-	"go.uber.org/zap"
 )
+
+// adapterName is used for metrics labels.
+const adapterName = "aws"
 
 // CreateSubscription creates a new event subscription.
 // AWS adapter uses polling-based subscriptions since CloudWatch Events
 // integration would require additional AWS infrastructure setup.
 func (a *Adapter) CreateSubscription(
-	_ context.Context,
+	ctx context.Context,
 	sub *adapter.Subscription,
 ) (*adapter.Subscription, error) {
 	var err error
 	start := time.Now()
-	defer func() { adapter.ObserveOperation("aws", "CreateSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "CreateSubscription", start, err) }()
 
 	a.logger.Debug("CreateSubscription called",
 		zap.String("callback", urlredact.Redact(sub.Callback)))
 
-	// Validate callback URL
 	if sub.Callback == "" {
 		err = fmt.Errorf("callback URL is required")
 		return nil, err
 	}
 
-	// Generate subscription ID if not provided
 	subscriptionID := sub.SubscriptionID
 	if subscriptionID == "" {
 		subscriptionID = fmt.Sprintf("aws-sub-%s", uuid.New().String())
 	}
 
-	// Create the subscription
 	newSub := &adapter.Subscription{
 		SubscriptionID:         subscriptionID,
 		Callback:               sub.Callback,
@@ -45,14 +47,11 @@ func (a *Adapter) CreateSubscription(
 		Filter:                 sub.Filter,
 	}
 
-	// Store in memory
-	a.subscriptionsMu.Lock()
-	a.subscriptions[subscriptionID] = newSub
-	subscriptionCount := len(a.subscriptions)
-	a.subscriptionsMu.Unlock()
+	if err = a.subs.Create(ctx, newSub); err != nil {
+		return nil, err
+	}
 
-	// Update subscription count metric
-	adapter.UpdateSubscriptionCount("aws", subscriptionCount)
+	adapter.UpdateSubscriptionCount(adapterName, a.subs.Len())
 
 	a.logger.Info("created subscription",
 		zap.String("subscriptionId", subscriptionID),
@@ -62,116 +61,92 @@ func (a *Adapter) CreateSubscription(
 }
 
 // GetSubscription retrieves a specific subscription by ID.
-func (a *Adapter) GetSubscription(_ context.Context, id string) (*adapter.Subscription, error) {
-	var (
-		sub *adapter.Subscription
-		err error
-	)
+func (a *Adapter) GetSubscription(ctx context.Context, id string) (*adapter.Subscription, error) {
+	var err error
 	start := time.Now()
-	defer func() { adapter.ObserveOperation("aws", "GetSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "GetSubscription", start, err) }()
 
-	a.logger.Debug("GetSubscription called",
-		zap.String("id", id))
+	a.logger.Debug("GetSubscription called", zap.String("id", id))
 
-	a.subscriptionsMu.RLock()
-	sub, exists := a.subscriptions[id]
-	a.subscriptionsMu.RUnlock()
-
-	if !exists {
-		return nil, fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	sub, err := a.subs.Get(ctx, id)
+	if err != nil {
+		return nil, err
 	}
-
 	return sub, nil
 }
 
 // UpdateSubscription updates an existing subscription.
 func (a *Adapter) UpdateSubscription(
-	_ context.Context,
+	ctx context.Context,
 	id string,
 	sub *adapter.Subscription,
 ) (*adapter.Subscription, error) {
-	var (
-		result *adapter.Subscription
-		err    error
-	)
+	var err error
 	start := time.Now()
-	defer func() { adapter.ObserveOperation("aws", "UpdateSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "UpdateSubscription", start, err) }()
 
 	a.logger.Debug("UpdateSubscription called",
 		zap.String("id", id),
 		zap.String("callback", urlredact.Redact(sub.Callback)))
 
-	// Validate callback URL
 	if sub.Callback == "" {
-		return nil, fmt.Errorf("callback URL is required")
+		err = fmt.Errorf("callback URL is required")
+		return nil, err
 	}
 
-	a.subscriptionsMu.Lock()
-	defer a.subscriptionsMu.Unlock()
-
-	// Check if subscription exists
-	existing, exists := a.subscriptions[id]
-	if !exists {
-		return nil, fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	existing, err := a.subs.Get(ctx, id)
+	if err != nil {
+		return nil, err
 	}
 
-	// Create updated subscription preserving the ID
-	result = &adapter.Subscription{
+	updated := &adapter.Subscription{
 		SubscriptionID:         id,
 		Callback:               sub.Callback,
 		ConsumerSubscriptionID: sub.ConsumerSubscriptionID,
 		Filter:                 sub.Filter,
 	}
 
-	// Store updated subscription
-	a.subscriptions[id] = result
+	if err = a.subs.Update(ctx, id, updated); err != nil {
+		return nil, err
+	}
 
 	a.logger.Info("updated subscription",
 		zap.String("subscription_id", id),
 		zap.String("old_callback", existing.Callback),
 		zap.String("new_callback", sub.Callback))
 
-	return result, nil
+	return updated, nil
 }
 
 // DeleteSubscription deletes a subscription by ID.
-func (a *Adapter) DeleteSubscription(_ context.Context, id string) error {
+func (a *Adapter) DeleteSubscription(ctx context.Context, id string) error {
 	var err error
 	start := time.Now()
-	defer func() { adapter.ObserveOperation("aws", "DeleteSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "DeleteSubscription", start, err) }()
 
-	a.logger.Debug("DeleteSubscription called",
-		zap.String("id", id))
+	a.logger.Debug("DeleteSubscription called", zap.String("id", id))
 
-	a.subscriptionsMu.Lock()
-	if _, exists := a.subscriptions[id]; !exists {
-		a.subscriptionsMu.Unlock()
-		return fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	if err = a.subs.Delete(ctx, id); err != nil {
+		return err
 	}
 
-	delete(a.subscriptions, id)
-	subscriptionCount := len(a.subscriptions)
-	a.subscriptionsMu.Unlock()
+	adapter.UpdateSubscriptionCount(adapterName, a.subs.Len())
 
-	// Update subscription count metric
-	adapter.UpdateSubscriptionCount("aws", subscriptionCount)
-
-	a.logger.Info("deleted subscription",
-		zap.String("subscription_id", id))
-
+	a.logger.Info("deleted subscription", zap.String("subscription_id", id))
 	return nil
 }
 
 // ListSubscriptions returns all active subscriptions.
 // This is a helper method not part of the Adapter interface.
 func (a *Adapter) ListSubscriptions() []*adapter.Subscription {
-	a.subscriptionsMu.RLock()
-	defer a.subscriptionsMu.RUnlock()
-
-	subs := make([]*adapter.Subscription, 0, len(a.subscriptions))
-	for _, sub := range a.subscriptions {
-		subs = append(subs, sub)
+	subs, err := a.subs.List(context.Background(), nil)
+	if err != nil {
+		// Background context never cancels; a non-nil error here would indicate
+		// a programming error. Fall back to an empty slice for safety.
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			a.logger.Warn("listing subscriptions returned unexpected error", zap.Error(err))
+		}
+		return nil
 	}
-
 	return subs
 }

--- a/internal/adapters/azure/adapter.go
+++ b/internal/adapters/azure/adapter.go
@@ -12,7 +12,6 @@ package azure
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -59,13 +58,10 @@ type Adapter struct {
 	// location is the Azure region/location.
 	location string
 
-	// subscriptions holds active O2-IMS subscriptions (polling-based fallback).
-	// Note: Subscriptions are stored in-memory and will be lost on adapter restart.
-	// For production use, consider implementing persistent storage via Redis.
-	subscriptions map[string]*adapter.Subscription
-
-	// subscriptionsMu protects the subscriptions map.
-	subscriptionsMu sync.RWMutex
+	// subs holds active O2-IMS subscriptions (polling-based fallback).
+	// Note: The default store is in-memory and will be lost on adapter restart.
+	// For durable storage, wire in a StorageBackedSubscriptionStore.
+	subs *adapter.InMemorySubscriptionStore
 
 	// poolMode determines how resource pools are mapped.
 	// "rg" maps to Resource Groups, "az" maps to Availability Zones.
@@ -185,7 +181,7 @@ func New(cfg *Config) (*Adapter, error) {
 		deploymentManagerID: deploymentManagerID,
 		subscriptionID:      cfg.SubscriptionID,
 		location:            cfg.Location,
-		subscriptions:       make(map[string]*adapter.Subscription),
+		subs:                adapter.NewInMemorySubscriptionStore(),
 		poolMode:            poolMode,
 	}
 
@@ -400,9 +396,7 @@ func (a *Adapter) Close() error {
 	a.logger.Info("closing Azure adapter")
 
 	// Clear subscriptions
-	a.subscriptionsMu.Lock()
-	a.subscriptions = make(map[string]*adapter.Subscription)
-	a.subscriptionsMu.Unlock()
+	a.subs.Reset()
 
 	// Sync logger before shutdown
 	// Sync errors on stderr/stdout are expected and can be ignored

--- a/internal/adapters/azure/export_test.go
+++ b/internal/adapters/azure/export_test.go
@@ -8,13 +8,13 @@ import (
 // NewTestAdapter creates an Adapter for testing with a no-op logger.
 func NewTestAdapter() *Adapter {
 	return &Adapter{
-		logger:        zap.NewNop(),
-		subscriptions: make(map[string]*adapter.Subscription),
+		logger: zap.NewNop(),
+		subs:   adapter.NewInMemorySubscriptionStore(),
 	}
 }
 
-// ExportSubscriptions exposes the subscriptions map for tests.
+// ExportSubscriptions exposes the underlying subscriptions map for tests.
 // Callers must not access it concurrently with adapter operations.
 func (a *Adapter) ExportSubscriptions() map[string]*adapter.Subscription {
-	return a.subscriptions
+	return a.subs.RawMap()
 }

--- a/internal/adapters/azure/extra_test.go
+++ b/internal/adapters/azure/extra_test.go
@@ -22,7 +22,7 @@ func newTestAdapter(poolMode string) *Adapter {
 		deploymentManagerID: "ocloud-azure-eastus",
 		subscriptionID:      "sub-123",
 		location:            "eastus",
-		subscriptions:       make(map[string]*adapter.Subscription),
+		subs:                adapter.NewInMemorySubscriptionStore(),
 		poolMode:            poolMode,
 	}
 }
@@ -662,7 +662,7 @@ func TestUpdateSubscription_Internal(t *testing.T) {
 		SubscriptionID: "sub-1",
 		Callback:       "https://example.com/old",
 	}
-	adp.subscriptions["sub-1"] = initial
+	adp.subs.RawMap()["sub-1"] = initial
 
 	t.Run("success", func(t *testing.T) {
 		updated, err := adp.UpdateSubscription(context.Background(), "sub-1", &adapter.Subscription{

--- a/internal/adapters/azure/subscriptions.go
+++ b/internal/adapters/azure/subscriptions.go
@@ -2,42 +2,44 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
+
 	"github.com/piwi3910/netweave/internal/adapter"
 	"github.com/piwi3910/netweave/internal/security/urlredact"
-	"go.uber.org/zap"
 )
+
+// adapterName is used for metrics labels.
+const adapterName = "azure"
 
 // CreateSubscription creates a new event subscription.
 // Azure adapter uses polling-based subscriptions since Event Grid
 // integration would require additional Azure infrastructure setup.
 func (a *Adapter) CreateSubscription(
-	_ context.Context,
+	ctx context.Context,
 	sub *adapter.Subscription,
 ) (*adapter.Subscription, error) {
 	var err error
 	start := time.Now()
-	defer func() { adapter.ObserveOperation("azure", "CreateSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "CreateSubscription", start, err) }()
 
 	a.logger.Debug("CreateSubscription called",
 		zap.String("callback", urlredact.Redact(sub.Callback)))
 
-	// Validate callback URL
 	if sub.Callback == "" {
 		err = fmt.Errorf("callback URL is required")
 		return nil, err
 	}
 
-	// Generate subscription ID if not provided
 	subscriptionID := sub.SubscriptionID
 	if subscriptionID == "" {
 		subscriptionID = fmt.Sprintf("azure-sub-%s", uuid.New().String())
 	}
 
-	// Create the subscription
 	newSub := &adapter.Subscription{
 		SubscriptionID:         subscriptionID,
 		Callback:               sub.Callback,
@@ -45,14 +47,11 @@ func (a *Adapter) CreateSubscription(
 		Filter:                 sub.Filter,
 	}
 
-	// Store in memory
-	a.subscriptionsMu.Lock()
-	a.subscriptions[subscriptionID] = newSub
-	count := len(a.subscriptions)
-	a.subscriptionsMu.Unlock()
+	if err = a.subs.Create(ctx, newSub); err != nil {
+		return nil, err
+	}
 
-	// Update subscription count metric
-	adapter.UpdateSubscriptionCount("azure", count)
+	adapter.UpdateSubscriptionCount(adapterName, a.subs.Len())
 
 	a.logger.Info("created subscription",
 		zap.String("subscriptionId", subscriptionID),
@@ -62,115 +61,90 @@ func (a *Adapter) CreateSubscription(
 }
 
 // GetSubscription retrieves a specific subscription by ID.
-func (a *Adapter) GetSubscription(_ context.Context, id string) (*adapter.Subscription, error) {
-	var (
-		sub *adapter.Subscription
-		err error
-	)
+func (a *Adapter) GetSubscription(ctx context.Context, id string) (*adapter.Subscription, error) {
+	var err error
 	start := time.Now()
-	defer func() { adapter.ObserveOperation("azure", "GetSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "GetSubscription", start, err) }()
 
-	a.logger.Debug("GetSubscription called",
-		zap.String("id", id))
+	a.logger.Debug("GetSubscription called", zap.String("id", id))
 
-	a.subscriptionsMu.RLock()
-	sub, exists := a.subscriptions[id]
-	a.subscriptionsMu.RUnlock()
-
-	if !exists {
-		return nil, fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	sub, err := a.subs.Get(ctx, id)
+	if err != nil {
+		return nil, err
 	}
-
 	return sub, nil
 }
 
 // UpdateSubscription updates an existing subscription.
 func (a *Adapter) UpdateSubscription(
-	_ context.Context,
+	ctx context.Context,
 	id string,
 	sub *adapter.Subscription,
 ) (*adapter.Subscription, error) {
 	var err error
 	start := time.Now()
-	defer func() { adapter.ObserveOperation("azure", "UpdateSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "UpdateSubscription", start, err) }()
 
 	a.logger.Debug("UpdateSubscription called",
 		zap.String("id", id),
 		zap.String("callback", urlredact.Redact(sub.Callback)))
 
-	// Validate callback URL
 	if sub.Callback == "" {
 		err = fmt.Errorf("callback URL is required")
 		return nil, err
 	}
 
-	a.subscriptionsMu.Lock()
-	defer a.subscriptionsMu.Unlock()
-
-	// Check if subscription exists
-	existing, exists := a.subscriptions[id]
-	if !exists {
-		err = fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	existing, err := a.subs.Get(ctx, id)
+	if err != nil {
 		return nil, err
 	}
 
-	// Create updated subscription preserving the ID
-	updatedSub := &adapter.Subscription{
+	updated := &adapter.Subscription{
 		SubscriptionID:         id,
 		Callback:               sub.Callback,
 		ConsumerSubscriptionID: sub.ConsumerSubscriptionID,
 		Filter:                 sub.Filter,
 	}
 
-	// Store updated subscription
-	a.subscriptions[id] = updatedSub
+	if err = a.subs.Update(ctx, id, updated); err != nil {
+		return nil, err
+	}
 
 	a.logger.Info("updated subscription",
 		zap.String("subscription_id", id),
 		zap.String("old_callback", existing.Callback),
 		zap.String("new_callback", sub.Callback))
 
-	return updatedSub, nil
+	return updated, nil
 }
 
 // DeleteSubscription deletes a subscription by ID.
-func (a *Adapter) DeleteSubscription(_ context.Context, id string) error {
+func (a *Adapter) DeleteSubscription(ctx context.Context, id string) error {
 	var err error
 	start := time.Now()
-	defer func() { adapter.ObserveOperation("azure", "DeleteSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "DeleteSubscription", start, err) }()
 
-	a.logger.Debug("DeleteSubscription called",
-		zap.String("id", id))
+	a.logger.Debug("DeleteSubscription called", zap.String("id", id))
 
-	a.subscriptionsMu.Lock()
-	if _, exists := a.subscriptions[id]; !exists {
-		a.subscriptionsMu.Unlock()
-		return fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	if err = a.subs.Delete(ctx, id); err != nil {
+		return err
 	}
 
-	delete(a.subscriptions, id)
-	count := len(a.subscriptions)
-	a.subscriptionsMu.Unlock()
+	adapter.UpdateSubscriptionCount(adapterName, a.subs.Len())
 
-	// Update subscription count metric
-	adapter.UpdateSubscriptionCount("azure", count)
-
-	a.logger.Info("deleted subscription",
-		zap.String("subscription_id", id))
-
+	a.logger.Info("deleted subscription", zap.String("subscription_id", id))
 	return nil
 }
 
 // ListSubscriptions returns all active subscriptions.
 // This is a helper method not part of the Adapter interface.
 func (a *Adapter) ListSubscriptions() []*adapter.Subscription {
-	a.subscriptionsMu.RLock()
-	defer a.subscriptionsMu.RUnlock()
-
-	subs := make([]*adapter.Subscription, 0, len(a.subscriptions))
-	for _, sub := range a.subscriptions {
-		subs = append(subs, sub)
+	subs, err := a.subs.List(context.Background(), nil)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			a.logger.Warn("listing subscriptions returned unexpected error", zap.Error(err))
+		}
+		return nil
 	}
-
 	return subs
 }

--- a/internal/adapters/azure/subscriptions.go
+++ b/internal/adapters/azure/subscriptions.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -139,12 +138,5 @@ func (a *Adapter) DeleteSubscription(ctx context.Context, id string) error {
 // ListSubscriptions returns all active subscriptions.
 // This is a helper method not part of the Adapter interface.
 func (a *Adapter) ListSubscriptions() []*adapter.Subscription {
-	subs, err := a.subs.List(context.Background(), nil)
-	if err != nil {
-		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			a.logger.Warn("listing subscriptions returned unexpected error", zap.Error(err))
-		}
-		return nil
-	}
-	return subs
+	return a.subs.Snapshot()
 }

--- a/internal/adapters/dtias/adapter.go
+++ b/internal/adapters/dtias/adapter.go
@@ -12,7 +12,6 @@ package dtias
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -42,13 +41,13 @@ type Adapter struct {
 	// deploymentManagerID is the identifier for this deployment manager
 	DeploymentManagerID string
 
-	// subscriptions holds active subscriptions for polling-based change detection.
+	// Subs holds active subscriptions for polling-based change detection.
 	// Since DTIAS has no native event system, subscriptions are stored locally
 	// and the gateway layer implements polling to detect changes.
-	Subscriptions map[string]*adapter.Subscription
-
-	// subscriptionsMu protects the subscriptions map.
-	SubscriptionsMu sync.RWMutex
+	//
+	// The default store is in-memory. For durable storage, wire in a
+	// StorageBackedSubscriptionStore.
+	Subs *adapter.InMemorySubscriptionStore
 }
 
 // Config holds configuration for creating a DTIASAdapter.
@@ -135,7 +134,7 @@ func New(cfg *Config) (*Adapter, error) {
 		Config:              cfg,
 		OCloudID:            cfg.OCloudID,
 		DeploymentManagerID: cfg.DeploymentManagerID,
-		Subscriptions:       make(map[string]*adapter.Subscription),
+		Subs:                adapter.NewInMemorySubscriptionStore(),
 	}
 
 	logger.Info("DTIAS adapter initialized",
@@ -258,9 +257,7 @@ func (a *Adapter) Close() error {
 	a.logger.Info("closing DTIAS adapter")
 
 	// Clear subscriptions
-	a.SubscriptionsMu.Lock()
-	a.Subscriptions = make(map[string]*adapter.Subscription)
-	a.SubscriptionsMu.Unlock()
+	a.Subs.Reset()
 
 	// Close client connections
 	if err := a.client.Close(); err != nil {

--- a/internal/adapters/dtias/adapter_test.go
+++ b/internal/adapters/dtias/adapter_test.go
@@ -436,5 +436,5 @@ func TestCloseWithSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify subscriptions are cleared
-	assert.Empty(t, adp.Subscriptions)
+	assert.Equal(t, 0, adp.Subs.Len())
 }

--- a/internal/adapters/dtias/extra_test.go
+++ b/internal/adapters/dtias/extra_test.go
@@ -32,7 +32,7 @@ func setupDTIASTestServer(t *testing.T, handlers map[string]http.HandlerFunc) (*
 	}
 	adp.OCloudID = "ocloud-test"
 	adp.DeploymentManagerID = "dm-test"
-	adp.Subscriptions = make(map[string]*adapter.Subscription)
+	adp.Subs = adapter.NewInMemorySubscriptionStore()
 
 	return server, adp
 }

--- a/internal/adapters/dtias/subscriptions.go
+++ b/internal/adapters/dtias/subscriptions.go
@@ -2,6 +2,7 @@ package dtias
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -20,24 +21,21 @@ import (
 //  3. Match changes against subscription filters
 //  4. Send webhook notifications to matching subscription callbacks
 func (a *Adapter) CreateSubscription(
-	_ context.Context,
+	ctx context.Context,
 	sub *adapter.Subscription,
 ) (*adapter.Subscription, error) {
 	a.logger.Debug("CreateSubscription called",
 		zap.String("callback", urlredact.Redact(sub.Callback)))
 
-	// Validate required fields
 	if sub.Callback == "" {
 		return nil, fmt.Errorf("callback URL is required")
 	}
 
-	// Generate subscription ID if not provided
 	subscriptionID := sub.SubscriptionID
 	if subscriptionID == "" {
 		subscriptionID = uuid.New().String()
 	}
 
-	// Create the subscription
 	newSub := &adapter.Subscription{
 		SubscriptionID:         subscriptionID,
 		Callback:               sub.Callback,
@@ -45,14 +43,9 @@ func (a *Adapter) CreateSubscription(
 		Filter:                 sub.Filter,
 	}
 
-	// Store the subscription atomically with existence check
-	a.SubscriptionsMu.Lock()
-	if _, exists := a.Subscriptions[subscriptionID]; exists {
-		a.SubscriptionsMu.Unlock()
-		return nil, fmt.Errorf("%w: %s", adapter.ErrSubscriptionExists, subscriptionID)
+	if err := a.Subs.Create(ctx, newSub); err != nil {
+		return nil, err
 	}
-	a.Subscriptions[subscriptionID] = newSub
-	a.SubscriptionsMu.Unlock()
 
 	a.logger.Info("subscription created (polling-based)",
 		zap.String("subscriptionId", subscriptionID),
@@ -62,46 +55,29 @@ func (a *Adapter) CreateSubscription(
 }
 
 // GetSubscription retrieves a specific subscription by ID.
-func (a *Adapter) GetSubscription(_ context.Context, id string) (*adapter.Subscription, error) {
-	a.logger.Debug("GetSubscription called",
-		zap.String("id", id))
-
-	a.SubscriptionsMu.RLock()
-	sub, ok := a.Subscriptions[id]
-	a.SubscriptionsMu.RUnlock()
-
-	if !ok {
-		return nil, fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
-	}
-
-	return sub, nil
+func (a *Adapter) GetSubscription(ctx context.Context, id string) (*adapter.Subscription, error) {
+	a.logger.Debug("GetSubscription called", zap.String("id", id))
+	return a.Subs.Get(ctx, id)
 }
 
 // UpdateSubscription updates an existing subscription.
 // Returns the updated subscription or an error if not found.
 func (a *Adapter) UpdateSubscription(
-	_ context.Context,
+	ctx context.Context,
 	id string,
 	sub *adapter.Subscription,
 ) (*adapter.Subscription, error) {
-	a.logger.Debug("UpdateSubscription called",
-		zap.String("id", id))
+	a.logger.Debug("UpdateSubscription called", zap.String("id", id))
 
-	// Validate required fields
 	if sub.Callback == "" {
 		return nil, fmt.Errorf("callback URL is required")
 	}
 
-	// Update the subscription atomically with existence check
-	a.SubscriptionsMu.Lock()
-	defer a.SubscriptionsMu.Unlock()
-
-	existing, ok := a.Subscriptions[id]
-	if !ok {
-		return nil, fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	existing, err := a.Subs.Get(ctx, id)
+	if err != nil {
+		return nil, err
 	}
 
-	// Create updated subscription preserving the ID
 	updated := &adapter.Subscription{
 		SubscriptionID:         id,
 		Callback:               sub.Callback,
@@ -109,7 +85,9 @@ func (a *Adapter) UpdateSubscription(
 		Filter:                 sub.Filter,
 	}
 
-	a.Subscriptions[id] = updated
+	if err := a.Subs.Update(ctx, id, updated); err != nil {
+		return nil, err
+	}
 
 	a.logger.Info("subscription updated",
 		zap.String("subscription_id", id),
@@ -120,36 +98,27 @@ func (a *Adapter) UpdateSubscription(
 }
 
 // DeleteSubscription deletes a subscription by ID.
-func (a *Adapter) DeleteSubscription(_ context.Context, id string) error {
-	a.logger.Debug("DeleteSubscription called",
-		zap.String("id", id))
+func (a *Adapter) DeleteSubscription(ctx context.Context, id string) error {
+	a.logger.Debug("DeleteSubscription called", zap.String("id", id))
 
-	a.SubscriptionsMu.Lock()
-	defer a.SubscriptionsMu.Unlock()
-
-	if _, ok := a.Subscriptions[id]; !ok {
-		return fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	if err := a.Subs.Delete(ctx, id); err != nil {
+		return err
 	}
 
-	delete(a.Subscriptions, id)
-
-	a.logger.Info("subscription deleted",
-		zap.String("subscription_id", id))
-
+	a.logger.Info("subscription deleted", zap.String("subscription_id", id))
 	return nil
 }
 
 // ListSubscriptions returns all active subscriptions.
 // This is useful for the polling mechanism to know which subscriptions need notifications.
 func (a *Adapter) ListSubscriptions() []*adapter.Subscription {
-	a.SubscriptionsMu.RLock()
-	defer a.SubscriptionsMu.RUnlock()
-
-	subs := make([]*adapter.Subscription, 0, len(a.Subscriptions))
-	for _, sub := range a.Subscriptions {
-		subs = append(subs, sub)
+	subs, err := a.Subs.List(context.Background(), nil)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			a.logger.Warn("listing subscriptions returned unexpected error", zap.Error(err))
+		}
+		return nil
 	}
-
 	return subs
 }
 

--- a/internal/adapters/dtias/subscriptions.go
+++ b/internal/adapters/dtias/subscriptions.go
@@ -2,7 +2,6 @@ package dtias
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -112,14 +111,7 @@ func (a *Adapter) DeleteSubscription(ctx context.Context, id string) error {
 // ListSubscriptions returns all active subscriptions.
 // This is useful for the polling mechanism to know which subscriptions need notifications.
 func (a *Adapter) ListSubscriptions() []*adapter.Subscription {
-	subs, err := a.Subs.List(context.Background(), nil)
-	if err != nil {
-		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			a.logger.Warn("listing subscriptions returned unexpected error", zap.Error(err))
-		}
-		return nil
-	}
-	return subs
+	return a.Subs.Snapshot()
 }
 
 // PollingRecommendation provides guidance for implementing subscription-like functionality

--- a/internal/adapters/dtias/testing.go
+++ b/internal/adapters/dtias/testing.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"go.uber.org/zap"
+
+	"github.com/piwi3910/netweave/internal/adapter"
 )
 
 // NewTestAdapter creates an Adapter for testing with a custom HTTP client.
@@ -17,5 +19,6 @@ func NewTestAdapter(baseURL string, httpClient *http.Client, logger *zap.Logger)
 	return &Adapter{
 		client: client,
 		logger: logger,
+		Subs:   adapter.NewInMemorySubscriptionStore(),
 	}
 }

--- a/internal/adapters/gcp/adapter.go
+++ b/internal/adapters/gcp/adapter.go
@@ -12,7 +12,6 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
@@ -64,13 +63,10 @@ type Adapter struct {
 	// region is the GCP region (e.g., "us-central1").
 	region string
 
-	// subscriptions holds active O2-IMS subscriptions (polling-based fallback).
-	// Note: Subscriptions are stored in-memory and will be lost on adapter restart.
-	// For production use, consider implementing persistent storage via Redis.
-	subscriptions map[string]*adapter.Subscription
-
-	// subscriptionsMu protects the subscriptions map.
-	subscriptionsMu sync.RWMutex
+	// subs holds active O2-IMS subscriptions (polling-based fallback).
+	// Note: The default store is in-memory and will be lost on adapter restart.
+	// For durable storage, wire in a StorageBackedSubscriptionStore.
+	subs *adapter.InMemorySubscriptionStore
 
 	// poolMode determines how resource pools are mapped.
 	// "zone" maps to Zones, "ig" maps to Instance Groups.
@@ -159,7 +155,7 @@ func New(cfg *Config) (*Adapter, error) {
 		deploymentManagerID:  deploymentManagerID,
 		projectID:            cfg.ProjectID,
 		region:               cfg.Region,
-		subscriptions:        make(map[string]*adapter.Subscription),
+		subs:                 adapter.NewInMemorySubscriptionStore(),
 		poolMode:             poolMode,
 	}, nil
 }
@@ -384,9 +380,7 @@ func (a *Adapter) Close() error {
 	a.logger.Info("closing GCP adapter")
 
 	// Clear subscriptions
-	a.subscriptionsMu.Lock()
-	a.subscriptions = make(map[string]*adapter.Subscription)
-	a.subscriptionsMu.Unlock()
+	a.subs.Reset()
 
 	// Close all clients
 	var errs []error

--- a/internal/adapters/gcp/export_test.go
+++ b/internal/adapters/gcp/export_test.go
@@ -121,7 +121,7 @@ func ExportNewFakeGCPAdapter(ctx context.Context, endpoint string) (*Adapter, er
 		deploymentManagerID:  "test-dm-gcp",
 		projectID:            "test-project",
 		region:               "us-central1",
-		subscriptions:        make(map[string]*adapter.Subscription),
+		subs:                 adapter.NewInMemorySubscriptionStore(),
 		poolMode:             poolModeZone,
 	}, nil
 }
@@ -129,15 +129,15 @@ func ExportNewFakeGCPAdapter(ctx context.Context, endpoint string) (*Adapter, er
 // NewTestAdapter creates a GCP Adapter for testing with a no-op logger.
 func NewTestAdapter() *Adapter {
 	return &Adapter{
-		logger:        zap.NewNop(),
-		subscriptions: make(map[string]*adapter.Subscription),
+		logger: zap.NewNop(),
+		subs:   adapter.NewInMemorySubscriptionStore(),
 	}
 }
 
-// ExportSubscriptions exposes the subscriptions map for tests.
+// ExportSubscriptions exposes the underlying subscriptions map for tests.
 // Callers must not access it concurrently with adapter operations.
 func (a *Adapter) ExportSubscriptions() map[string]*adapter.Subscription {
-	return a.subscriptions
+	return a.subs.RawMap()
 }
 
 // ExportCloseAdapter closes all clients on the adapter.

--- a/internal/adapters/gcp/subscriptions.go
+++ b/internal/adapters/gcp/subscriptions.go
@@ -2,7 +2,6 @@ package gcp
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -136,12 +135,5 @@ func (a *Adapter) DeleteSubscription(ctx context.Context, id string) error {
 // ListSubscriptions returns all active subscriptions.
 // This is a helper method not part of the Adapter interface.
 func (a *Adapter) ListSubscriptions() []*adapter.Subscription {
-	subs, err := a.subs.List(context.Background(), nil)
-	if err != nil {
-		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			a.logger.Warn("listing subscriptions returned unexpected error", zap.Error(err))
-		}
-		return nil
-	}
-	return subs
+	return a.subs.Snapshot()
 }

--- a/internal/adapters/gcp/subscriptions.go
+++ b/internal/adapters/gcp/subscriptions.go
@@ -2,38 +2,41 @@ package gcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
+
 	"github.com/piwi3910/netweave/internal/adapter"
 	"github.com/piwi3910/netweave/internal/security/urlredact"
-	"go.uber.org/zap"
 )
+
+// adapterName is used for metrics labels.
+const adapterName = "gcp"
 
 // CreateSubscription creates a new event subscription.
 // GCP adapter uses polling-based subscriptions since Pub/Sub
 // integration would require additional GCP infrastructure setup.
-func (a *Adapter) CreateSubscription(_ context.Context, sub *adapter.Subscription) (*adapter.Subscription, error) {
+func (a *Adapter) CreateSubscription(ctx context.Context, sub *adapter.Subscription) (*adapter.Subscription, error) {
 	start := time.Now()
 	var err error
-	defer func() { adapter.ObserveOperation("gcp", "CreateSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "CreateSubscription", start, err) }()
 
 	a.logger.Debug("CreateSubscription called",
 		zap.String("callback", urlredact.Redact(sub.Callback)))
 
-	// Validate callback URL
 	if sub.Callback == "" {
-		return nil, fmt.Errorf("callback URL is required")
+		err = fmt.Errorf("callback URL is required")
+		return nil, err
 	}
 
-	// Generate subscription ID if not provided
 	subscriptionID := sub.SubscriptionID
 	if subscriptionID == "" {
 		subscriptionID = fmt.Sprintf("gcp-sub-%s", uuid.New().String())
 	}
 
-	// Create the subscription
 	newSub := &adapter.Subscription{
 		SubscriptionID:         subscriptionID,
 		Callback:               sub.Callback,
@@ -41,14 +44,11 @@ func (a *Adapter) CreateSubscription(_ context.Context, sub *adapter.Subscriptio
 		Filter:                 sub.Filter,
 	}
 
-	// Store in memory
-	a.subscriptionsMu.Lock()
-	a.subscriptions[subscriptionID] = newSub
-	count := len(a.subscriptions)
-	a.subscriptionsMu.Unlock()
+	if err = a.subs.Create(ctx, newSub); err != nil {
+		return nil, err
+	}
 
-	// Update subscription count metric
-	adapter.UpdateSubscriptionCount("gcp", count)
+	adapter.UpdateSubscriptionCount(adapterName, a.subs.Len())
 
 	a.logger.Info("created subscription",
 		zap.String("subscriptionId", subscriptionID),
@@ -58,110 +58,90 @@ func (a *Adapter) CreateSubscription(_ context.Context, sub *adapter.Subscriptio
 }
 
 // GetSubscription retrieves a specific subscription by ID.
-func (a *Adapter) GetSubscription(_ context.Context, id string) (*adapter.Subscription, error) {
+func (a *Adapter) GetSubscription(ctx context.Context, id string) (*adapter.Subscription, error) {
 	start := time.Now()
 	var err error
-	defer func() { adapter.ObserveOperation("gcp", "GetSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "GetSubscription", start, err) }()
 
-	a.logger.Debug("GetSubscription called",
-		zap.String("id", id))
+	a.logger.Debug("GetSubscription called", zap.String("id", id))
 
-	a.subscriptionsMu.RLock()
-	sub, exists := a.subscriptions[id]
-	a.subscriptionsMu.RUnlock()
-
-	if !exists {
-		return nil, fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	sub, err := a.subs.Get(ctx, id)
+	if err != nil {
+		return nil, err
 	}
-
 	return sub, nil
 }
 
 // UpdateSubscription updates an existing subscription.
 func (a *Adapter) UpdateSubscription(
-	_ context.Context,
+	ctx context.Context,
 	id string,
 	sub *adapter.Subscription,
 ) (*adapter.Subscription, error) {
 	start := time.Now()
 	var err error
-	defer func() { adapter.ObserveOperation("gcp", "UpdateSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "UpdateSubscription", start, err) }()
 
 	a.logger.Debug("UpdateSubscription called",
 		zap.String("id", id),
 		zap.String("callback", urlredact.Redact(sub.Callback)))
 
-	// Validate callback URL
 	if sub.Callback == "" {
-		return nil, fmt.Errorf("callback URL is required")
+		err = fmt.Errorf("callback URL is required")
+		return nil, err
 	}
 
-	a.subscriptionsMu.Lock()
-	defer a.subscriptionsMu.Unlock()
-
-	// Check if subscription exists
-	existing, exists := a.subscriptions[id]
-	if !exists {
-		return nil, fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	existing, err := a.subs.Get(ctx, id)
+	if err != nil {
+		return nil, err
 	}
 
-	// Create updated subscription preserving the ID
-	updatedSub := &adapter.Subscription{
+	updated := &adapter.Subscription{
 		SubscriptionID:         id,
 		Callback:               sub.Callback,
 		ConsumerSubscriptionID: sub.ConsumerSubscriptionID,
 		Filter:                 sub.Filter,
 	}
 
-	// Store updated subscription
-	a.subscriptions[id] = updatedSub
+	if err = a.subs.Update(ctx, id, updated); err != nil {
+		return nil, err
+	}
 
 	a.logger.Info("updated subscription",
 		zap.String("subscription_id", id),
 		zap.String("old_callback", existing.Callback),
 		zap.String("new_callback", sub.Callback))
 
-	return updatedSub, nil
+	return updated, nil
 }
 
 // DeleteSubscription deletes a subscription by ID.
-func (a *Adapter) DeleteSubscription(_ context.Context, id string) error {
+func (a *Adapter) DeleteSubscription(ctx context.Context, id string) error {
 	start := time.Now()
 	var err error
-	defer func() { adapter.ObserveOperation("gcp", "DeleteSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "DeleteSubscription", start, err) }()
 
-	a.logger.Debug("DeleteSubscription called",
-		zap.String("id", id))
+	a.logger.Debug("DeleteSubscription called", zap.String("id", id))
 
-	a.subscriptionsMu.Lock()
-	if _, exists := a.subscriptions[id]; !exists {
-		a.subscriptionsMu.Unlock()
-		return fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	if err = a.subs.Delete(ctx, id); err != nil {
+		return err
 	}
 
-	delete(a.subscriptions, id)
-	count := len(a.subscriptions)
-	a.subscriptionsMu.Unlock()
+	adapter.UpdateSubscriptionCount(adapterName, a.subs.Len())
 
-	// Update subscription count metric
-	adapter.UpdateSubscriptionCount("gcp", count)
-
-	a.logger.Info("deleted subscription",
-		zap.String("subscription_id", id))
-
+	a.logger.Info("deleted subscription", zap.String("subscription_id", id))
 	return nil
 }
 
 // ListSubscriptions returns all active subscriptions.
 // This is a helper method not part of the Adapter interface.
 func (a *Adapter) ListSubscriptions() []*adapter.Subscription {
-	a.subscriptionsMu.RLock()
-	defer a.subscriptionsMu.RUnlock()
-
-	subs := make([]*adapter.Subscription, 0, len(a.subscriptions))
-	for _, sub := range a.subscriptions {
-		subs = append(subs, sub)
+	subs, err := a.subs.List(context.Background(), nil)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			a.logger.Warn("listing subscriptions returned unexpected error", zap.Error(err))
+		}
+		return nil
 	}
-
 	return subs
 }

--- a/internal/adapters/openstack/adapter.go
+++ b/internal/adapters/openstack/adapter.go
@@ -54,8 +54,10 @@ type Adapter struct {
 	// projectName is the OpenStack project (tenant) name.
 	projectName string
 
-	// subscriptions holds active subscriptions (polling-based).
-	subscriptions map[string]*adapter.Subscription
+	// subs holds active subscriptions (polling-based).
+	// The default store is in-memory. For durable storage, wire in a
+	// StorageBackedSubscriptionStore.
+	subs *adapter.InMemorySubscriptionStore
 
 	// pollingStates tracks the polling state for each active subscription.
 	pollingStates map[string]*SubscriptionState
@@ -143,7 +145,7 @@ func New(cfg *Config) (*Adapter, error) {
 		deploymentManagerID: deploymentManagerID,
 		region:              cfg.Region,
 		projectName:         cfg.ProjectName,
-		subscriptions:       make(map[string]*adapter.Subscription),
+		subs:                adapter.NewInMemorySubscriptionStore(),
 	}
 
 	logger.Info("OpenStack adapter initialized successfully",

--- a/internal/adapters/openstack/export_test.go
+++ b/internal/adapters/openstack/export_test.go
@@ -45,7 +45,7 @@ func ExportNewFakeAdapter(computeMux, identityMux, placementMux *http.ServeMux) 
 		deploymentManagerID: "test-dm-openstack",
 		region:              "TestRegion",
 		projectName:         "test-project",
-		subscriptions:       make(map[string]*adapter.Subscription),
+		subs:                adapter.NewInMemorySubscriptionStore(),
 		pollingStates:       make(map[string]*SubscriptionState),
 	}
 }
@@ -68,7 +68,7 @@ func ExportNewFakeAdapterWithCompute(handler http.Handler) (*Adapter, *httptest.
 		deploymentManagerID: "test-dm-openstack",
 		region:              "TestRegion",
 		projectName:         "test-project",
-		subscriptions:       make(map[string]*adapter.Subscription),
+		subs:                adapter.NewInMemorySubscriptionStore(),
 		pollingStates:       make(map[string]*SubscriptionState),
 	}
 
@@ -85,7 +85,7 @@ func (a *Adapter) ExportDeploymentManagerID() string { return a.deploymentManage
 func (a *Adapter) ExportRegion() string { return a.region }
 
 // ExportSubscriptions exposes the subscriptions map for tests.
-func (a *Adapter) ExportSubscriptions() map[string]*adapter.Subscription { return a.subscriptions }
+func (a *Adapter) ExportSubscriptions() map[string]*adapter.Subscription { return a.subs.RawMap() }
 
 // ExportPollingStates exposes the pollingStates map for tests.
 func (a *Adapter) ExportPollingStates() map[string]*SubscriptionState { return a.pollingStates }
@@ -97,7 +97,7 @@ func NewTestAdapter(logger *zap.Logger) *Adapter {
 	}
 	return &Adapter{
 		logger:        logger,
-		subscriptions: make(map[string]*adapter.Subscription),
+		subs:          adapter.NewInMemorySubscriptionStore(),
 		pollingStates: make(map[string]*SubscriptionState),
 	}
 }
@@ -127,7 +127,7 @@ func NewTestAdapterFull(
 		oCloudID:            oCloudID,
 		deploymentManagerID: deploymentManagerID,
 		region:              region,
-		subscriptions:       make(map[string]*adapter.Subscription),
+		subs:                adapter.NewInMemorySubscriptionStore(),
 		pollingStates:       make(map[string]*SubscriptionState),
 	}
 }

--- a/internal/adapters/openstack/subscriptions.go
+++ b/internal/adapters/openstack/subscriptions.go
@@ -105,7 +105,7 @@ func (a *Adapter) CreateSubscription(
 			zap.String("subscription_id", subscriptionID),
 			zap.Error(err))
 		// Roll back the subscription on polling-start failure.
-		if deleteErr := a.subs.Delete(context.Background(), subscriptionID); deleteErr != nil {
+		if deleteErr := a.subs.Delete(context.WithoutCancel(ctx), subscriptionID); deleteErr != nil {
 			a.logger.Warn("failed to roll back subscription after polling start failure",
 				zap.String("subscription_id", subscriptionID),
 				zap.Error(deleteErr))
@@ -184,7 +184,7 @@ func (a *Adapter) UpdateSubscription(
 			zap.Error(err))
 
 		// Rollback to existing subscription on failure.
-		if rollbackErr := a.subs.Update(context.Background(), id, existing); rollbackErr != nil {
+		if rollbackErr := a.subs.Update(context.WithoutCancel(ctx), id, existing); rollbackErr != nil {
 			a.logger.Error("failed to rollback subscription record",
 				zap.String("subscription_id", id),
 				zap.Error(rollbackErr))

--- a/internal/adapters/openstack/subscriptions.go
+++ b/internal/adapters/openstack/subscriptions.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -44,9 +45,9 @@ type SubscriptionState struct {
 	wg               sync.WaitGroup
 }
 
-// subscriptionStore is a thread-safe in-memory store for subscriptions.
+// Global state for polling machinery. Subscription CRUD is handled by the
+// shared adapter.InMemorySubscriptionStore on a.subs.
 var (
-	subscriptionMu      sync.RWMutex
 	pollingStateMu      sync.RWMutex
 	webhookClientMu     sync.Mutex
 	sharedWebhookClient *http.Client
@@ -83,13 +84,11 @@ func (a *Adapter) CreateSubscription(
 		return nil, fmt.Errorf("callback URL is required")
 	}
 
-	// Generate subscription ID if not provided
 	subscriptionID := sub.SubscriptionID
 	if subscriptionID == "" {
 		subscriptionID = fmt.Sprintf("openstack-sub-%s", uuid.New().String())
 	}
 
-	// Create subscription object
 	subscription := &adapter.Subscription{
 		SubscriptionID:         subscriptionID,
 		Callback:               sub.Callback,
@@ -97,20 +96,20 @@ func (a *Adapter) CreateSubscription(
 		Filter:                 sub.Filter,
 	}
 
-	// Store subscription in memory
-	subscriptionMu.Lock()
-	a.subscriptions[subscriptionID] = subscription
-	subscriptionMu.Unlock()
+	if err := a.subs.Create(ctx, subscription); err != nil {
+		return nil, err
+	}
 
-	// Start polling for this subscription
 	if err := a.startPolling(ctx, subscription); err != nil {
 		a.logger.Error("failed to start polling",
 			zap.String("subscription_id", subscriptionID),
 			zap.Error(err))
-		// Clean up subscription on failure
-		subscriptionMu.Lock()
-		delete(a.subscriptions, subscriptionID)
-		subscriptionMu.Unlock()
+		// Roll back the subscription on polling-start failure.
+		if deleteErr := a.subs.Delete(context.Background(), subscriptionID); deleteErr != nil {
+			a.logger.Warn("failed to roll back subscription after polling start failure",
+				zap.String("subscription_id", subscriptionID),
+				zap.Error(deleteErr))
+		}
 		return nil, fmt.Errorf("failed to start polling: %w", err)
 	}
 
@@ -122,22 +121,16 @@ func (a *Adapter) CreateSubscription(
 }
 
 // GetSubscription retrieves a specific subscription by ID.
-func (a *Adapter) GetSubscription(_ context.Context, id string) (*adapter.Subscription, error) {
-	a.logger.Debug("GetSubscription called",
-		zap.String("id", id))
+func (a *Adapter) GetSubscription(ctx context.Context, id string) (*adapter.Subscription, error) {
+	a.logger.Debug("GetSubscription called", zap.String("id", id))
 
-	// Retrieve subscription from memory
-	subscriptionMu.RLock()
-	subscription, exists := a.subscriptions[id]
-	subscriptionMu.RUnlock()
-
-	if !exists {
-		return nil, fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	subscription, err := a.subs.Get(ctx, id)
+	if err != nil {
+		return nil, err
 	}
 
 	a.logger.Debug("retrieved subscription",
 		zap.String("subscription_id", subscription.SubscriptionID))
-
 	return subscription, nil
 }
 
@@ -156,22 +149,16 @@ func (a *Adapter) UpdateSubscription(
 		zap.String("id", id),
 		zap.String("callback", urlredact.Redact(sub.Callback)))
 
-	// Validate callback URL (defense-in-depth: server validates HTTP input, adapter validates programmatic calls)
 	if sub.Callback == "" {
 		err = fmt.Errorf("callback URL is required")
 		return nil, err
 	}
 
-	// Check if subscription exists and get existing config
-	subscriptionMu.Lock()
-	existing, exists := a.subscriptions[id]
-	if !exists {
-		subscriptionMu.Unlock()
-		err = fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	existing, err := a.subs.Get(ctx, id)
+	if err != nil {
 		return nil, err
 	}
 
-	// Create updated subscription preserving the ID
 	updated := &adapter.Subscription{
 		SubscriptionID:         id,
 		Callback:               sub.Callback,
@@ -179,31 +166,30 @@ func (a *Adapter) UpdateSubscription(
 		Filter:                 sub.Filter,
 	}
 
-	// Stop old polling goroutine before updating (prevents race with polling reads)
-	subscriptionMu.Unlock()
+	// Stop old polling goroutine before updating (prevents races with polling reads).
 	if stopErr := a.stopPolling(id); stopErr != nil {
 		a.logger.Warn("failed to stop old polling",
 			zap.String("subscription_id", id),
 			zap.Error(stopErr))
 	}
 
-	// Hold lock from here until polling successfully starts to prevent races
-	subscriptionMu.Lock()
-	defer subscriptionMu.Unlock()
+	if err = a.subs.Update(ctx, id, updated); err != nil {
+		return nil, err
+	}
 
-	// Update in memory
-	a.subscriptions[id] = updated
-
-	// Start new polling with updated configuration
+	// Start new polling with updated configuration.
 	if err = a.startPolling(ctx, updated); err != nil {
 		a.logger.Error("failed to restart polling",
 			zap.String("subscription_id", id),
 			zap.Error(err))
 
-		// Rollback to existing subscription on failure
-		a.subscriptions[id] = existing
-
-		// Best-effort attempt to restart old polling
+		// Rollback to existing subscription on failure.
+		if rollbackErr := a.subs.Update(context.Background(), id, existing); rollbackErr != nil {
+			a.logger.Error("failed to rollback subscription record",
+				zap.String("subscription_id", id),
+				zap.Error(rollbackErr))
+		}
+		// Best-effort attempt to restart old polling.
 		if restartErr := a.startPolling(ctx, existing); restartErr != nil {
 			a.logger.Error("failed to rollback to old subscription",
 				zap.String("subscription_id", id),
@@ -222,47 +208,37 @@ func (a *Adapter) UpdateSubscription(
 }
 
 // DeleteSubscription deletes a subscription by ID and stops its polling goroutine.
-func (a *Adapter) DeleteSubscription(_ context.Context, id string) error {
-	a.logger.Debug("DeleteSubscription called",
-		zap.String("id", id))
+func (a *Adapter) DeleteSubscription(ctx context.Context, id string) error {
+	a.logger.Debug("DeleteSubscription called", zap.String("id", id))
 
-	// Remove subscription from memory
-	subscriptionMu.Lock()
-	_, exists := a.subscriptions[id]
-	if !exists {
-		subscriptionMu.Unlock()
-		return fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	if err := a.subs.Delete(ctx, id); err != nil {
+		return err
 	}
-	delete(a.subscriptions, id)
-	subscriptionMu.Unlock()
 
-	// Stop polling for this subscription
 	if err := a.stopPolling(id); err != nil {
 		a.logger.Warn("failed to stop polling",
 			zap.String("subscription_id", id),
 			zap.Error(err))
 	}
 
-	a.logger.Info("deleted subscription",
-		zap.String("subscription_id", id))
-
+	a.logger.Info("deleted subscription", zap.String("subscription_id", id))
 	return nil
 }
 
 // ListSubscriptions retrieves all active subscriptions.
-func (a *Adapter) ListSubscriptions(_ context.Context) ([]*adapter.Subscription, error) {
+func (a *Adapter) ListSubscriptions(ctx context.Context) ([]*adapter.Subscription, error) {
 	a.logger.Debug("ListSubscriptions called")
 
-	subscriptionMu.RLock()
-	subscriptions := make([]*adapter.Subscription, 0, len(a.subscriptions))
-	for _, sub := range a.subscriptions {
-		subscriptions = append(subscriptions, sub)
+	subscriptions, err := a.subs.List(ctx, nil)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		a.logger.Warn("listing subscriptions returned unexpected error", zap.Error(err))
+		return nil, err
 	}
-	subscriptionMu.RUnlock()
 
-	a.logger.Debug("listed subscriptions",
-		zap.Int("count", len(subscriptions)))
-
+	a.logger.Debug("listed subscriptions", zap.Int("count", len(subscriptions)))
 	return subscriptions, nil
 }
 

--- a/internal/adapters/vmware/adapter.go
+++ b/internal/adapters/vmware/adapter.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"sync"
 	"time"
 
 	"github.com/piwi3910/netweave/internal/adapter"
@@ -63,13 +62,10 @@ type Adapter struct {
 	// datacenterName is the vSphere datacenter name.
 	datacenterName string
 
-	// subscriptions holds active O2-IMS subscriptions (polling-based fallback).
-	// Note: Subscriptions are stored in-memory and will be lost on adapter restart.
-	// For production use, consider implementing persistent storage via Redis.
-	subscriptions map[string]*adapter.Subscription
-
-	// subscriptionsMu protects the subscriptions map.
-	subscriptionsMu sync.RWMutex
+	// subs holds active O2-IMS subscriptions (polling-based fallback).
+	// Note: The default store is in-memory and will be lost on adapter restart.
+	// For durable storage, wire in a StorageBackedSubscriptionStore.
+	subs *adapter.InMemorySubscriptionStore
 
 	// poolMode determines how resource pools are mapped.
 	// "cluster" maps to Clusters, "pool" maps to Resource Pools.
@@ -170,7 +166,7 @@ func New(cfg *Config) (*Adapter, error) {
 		deploymentManagerID: deploymentManagerID,
 		vcenterURL:          cfg.VCenterURL,
 		datacenterName:      cfg.Datacenter,
-		subscriptions:       make(map[string]*adapter.Subscription),
+		subs:                adapter.NewInMemorySubscriptionStore(),
 		poolMode:            poolMode,
 	}, nil
 }
@@ -358,9 +354,7 @@ func (a *Adapter) Close() error {
 	a.logger.Info("closing VMware adapter")
 
 	// Clear subscriptions
-	a.subscriptionsMu.Lock()
-	a.subscriptions = make(map[string]*adapter.Subscription)
-	a.subscriptionsMu.Unlock()
+	a.subs.Reset()
 
 	// Logout from vCenter
 	if a.client != nil {

--- a/internal/adapters/vmware/export_test.go
+++ b/internal/adapters/vmware/export_test.go
@@ -43,7 +43,7 @@ func ExportNewSimulatorAdapter(ctx context.Context, c *vim25.Client, datacenterN
 		deploymentManagerID: "test-dm-vmware",
 		vcenterURL:          "https://vcenter.test/sdk",
 		datacenterName:      datacenterName,
-		subscriptions:       make(map[string]*adapter.Subscription),
+		subs:                adapter.NewInMemorySubscriptionStore(),
 		poolMode:            poolMode,
 	}, nil
 }
@@ -51,15 +51,15 @@ func ExportNewSimulatorAdapter(ctx context.Context, c *vim25.Client, datacenterN
 // NewTestAdapter creates a VMware Adapter for testing with a no-op logger.
 func NewTestAdapter() *Adapter {
 	return &Adapter{
-		logger:        zap.NewNop(),
-		subscriptions: make(map[string]*adapter.Subscription),
+		logger: zap.NewNop(),
+		subs:   adapter.NewInMemorySubscriptionStore(),
 	}
 }
 
-// ExportSubscriptions exposes the subscriptions map for tests.
+// ExportSubscriptions exposes the underlying subscriptions map for tests.
 // Callers must not access it concurrently with adapter operations.
 func (a *Adapter) ExportSubscriptions() map[string]*adapter.Subscription {
-	return a.subscriptions
+	return a.subs.RawMap()
 }
 
 // ExportFinder returns the adapter's finder for testing.

--- a/internal/adapters/vmware/subscriptions.go
+++ b/internal/adapters/vmware/subscriptions.go
@@ -2,42 +2,44 @@ package vmware
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
+
 	"github.com/piwi3910/netweave/internal/adapter"
 	"github.com/piwi3910/netweave/internal/security/urlredact"
-	"go.uber.org/zap"
 )
+
+// adapterName is used for metrics labels.
+const adapterName = "vmware"
 
 // CreateSubscription creates a new event subscription.
 // VMware adapter uses polling-based subscriptions since vSphere Event
 // integration would require additional configuration.
 func (a *Adapter) CreateSubscription(
-	_ context.Context,
+	ctx context.Context,
 	sub *adapter.Subscription,
 ) (*adapter.Subscription, error) {
 	var err error
 	start := time.Now()
-	defer func() { adapter.ObserveOperation("vmware", "CreateSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "CreateSubscription", start, err) }()
 
 	a.logger.Debug("CreateSubscription called",
 		zap.String("callback", urlredact.Redact(sub.Callback)))
 
-	// Validate callback URL
 	if sub.Callback == "" {
 		err = fmt.Errorf("callback URL is required")
 		return nil, err
 	}
 
-	// Generate subscription ID if not provided
 	subscriptionID := sub.SubscriptionID
 	if subscriptionID == "" {
 		subscriptionID = fmt.Sprintf("vmware-sub-%s", uuid.New().String())
 	}
 
-	// Create the subscription
 	newSub := &adapter.Subscription{
 		SubscriptionID:         subscriptionID,
 		Callback:               sub.Callback,
@@ -45,14 +47,11 @@ func (a *Adapter) CreateSubscription(
 		Filter:                 sub.Filter,
 	}
 
-	// Store in memory
-	a.subscriptionsMu.Lock()
-	a.subscriptions[subscriptionID] = newSub
-	count := len(a.subscriptions)
-	a.subscriptionsMu.Unlock()
+	if err = a.subs.Create(ctx, newSub); err != nil {
+		return nil, err
+	}
 
-	// Update subscription count metric
-	adapter.UpdateSubscriptionCount("vmware", count)
+	adapter.UpdateSubscriptionCount(adapterName, a.subs.Len())
 
 	a.logger.Info("created subscription",
 		zap.String("subscriptionId", subscriptionID),
@@ -62,114 +61,90 @@ func (a *Adapter) CreateSubscription(
 }
 
 // GetSubscription retrieves a specific subscription by ID.
-func (a *Adapter) GetSubscription(_ context.Context, id string) (*adapter.Subscription, error) {
+func (a *Adapter) GetSubscription(ctx context.Context, id string) (*adapter.Subscription, error) {
 	start := time.Now()
 	var err error
-	defer func() { adapter.ObserveOperation("vmware", "GetSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "GetSubscription", start, err) }()
 
-	a.logger.Debug("GetSubscription called",
-		zap.String("id", id))
+	a.logger.Debug("GetSubscription called", zap.String("id", id))
 
-	a.subscriptionsMu.RLock()
-	subscription, exists := a.subscriptions[id]
-	a.subscriptionsMu.RUnlock()
-
-	if !exists {
-		err = fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	sub, err := a.subs.Get(ctx, id)
+	if err != nil {
 		return nil, err
 	}
-
-	return subscription, nil
+	return sub, nil
 }
 
 // UpdateSubscription updates an existing subscription.
 func (a *Adapter) UpdateSubscription(
-	_ context.Context,
+	ctx context.Context,
 	id string,
 	sub *adapter.Subscription,
 ) (*adapter.Subscription, error) {
 	var err error
 	start := time.Now()
-	defer func() { adapter.ObserveOperation("vmware", "UpdateSubscription", start, err) }()
+	defer func() { adapter.ObserveOperation(adapterName, "UpdateSubscription", start, err) }()
 
 	a.logger.Debug("UpdateSubscription called",
 		zap.String("id", id),
 		zap.String("callback", urlredact.Redact(sub.Callback)))
 
-	// Validate callback URL
 	if sub.Callback == "" {
 		err = fmt.Errorf("callback URL is required")
 		return nil, err
 	}
 
-	a.subscriptionsMu.Lock()
-	defer a.subscriptionsMu.Unlock()
-
-	// Check if subscription exists
-	existing, exists := a.subscriptions[id]
-	if !exists {
-		err = fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	existing, err := a.subs.Get(ctx, id)
+	if err != nil {
 		return nil, err
 	}
 
-	// Create updated subscription preserving the ID
-	updatedSub := &adapter.Subscription{
+	updated := &adapter.Subscription{
 		SubscriptionID:         id,
 		Callback:               sub.Callback,
 		ConsumerSubscriptionID: sub.ConsumerSubscriptionID,
 		Filter:                 sub.Filter,
 	}
 
-	// Store updated subscription
-	a.subscriptions[id] = updatedSub
+	if err = a.subs.Update(ctx, id, updated); err != nil {
+		return nil, err
+	}
 
 	a.logger.Info("updated subscription",
 		zap.String("subscription_id", id),
 		zap.String("old_callback", existing.Callback),
 		zap.String("new_callback", sub.Callback))
 
-	return updatedSub, nil
+	return updated, nil
 }
 
 // DeleteSubscription deletes a subscription by ID.
-func (a *Adapter) DeleteSubscription(_ context.Context, id string) error {
-	start := time.Now()
+func (a *Adapter) DeleteSubscription(ctx context.Context, id string) error {
 	var err error
-	defer func() { adapter.ObserveOperation("vmware", "DeleteSubscription", start, err) }()
+	start := time.Now()
+	defer func() { adapter.ObserveOperation(adapterName, "DeleteSubscription", start, err) }()
 
-	a.logger.Debug("DeleteSubscription called",
-		zap.String("id", id))
+	a.logger.Debug("DeleteSubscription called", zap.String("id", id))
 
-	a.subscriptionsMu.Lock()
-	if _, exists := a.subscriptions[id]; !exists {
-		a.subscriptionsMu.Unlock()
-		err = fmt.Errorf("%w: %s", adapter.ErrSubscriptionNotFound, id)
+	if err = a.subs.Delete(ctx, id); err != nil {
 		return err
 	}
 
-	delete(a.subscriptions, id)
-	count := len(a.subscriptions)
-	a.subscriptionsMu.Unlock()
+	adapter.UpdateSubscriptionCount(adapterName, a.subs.Len())
 
-	// Update subscription count metric
-	adapter.UpdateSubscriptionCount("vmware", count)
-
-	a.logger.Info("deleted subscription",
-		zap.String("subscription_id", id))
-
+	a.logger.Info("deleted subscription", zap.String("subscription_id", id))
 	return nil
 }
 
 // ListSubscriptions returns all active subscriptions.
 // This is a helper method not part of the Adapter interface.
 func (a *Adapter) ListSubscriptions() []*adapter.Subscription {
-	a.subscriptionsMu.RLock()
-	defer a.subscriptionsMu.RUnlock()
-
-	subs := make([]*adapter.Subscription, 0, len(a.subscriptions))
-	for _, sub := range a.subscriptions {
-		subs = append(subs, sub)
+	subs, err := a.subs.List(context.Background(), nil)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			a.logger.Warn("listing subscriptions returned unexpected error", zap.Error(err))
+		}
+		return nil
 	}
-
 	return subs
 }

--- a/internal/adapters/vmware/subscriptions.go
+++ b/internal/adapters/vmware/subscriptions.go
@@ -2,7 +2,6 @@ package vmware
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -139,12 +138,5 @@ func (a *Adapter) DeleteSubscription(ctx context.Context, id string) error {
 // ListSubscriptions returns all active subscriptions.
 // This is a helper method not part of the Adapter interface.
 func (a *Adapter) ListSubscriptions() []*adapter.Subscription {
-	subs, err := a.subs.List(context.Background(), nil)
-	if err != nil {
-		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			a.logger.Warn("listing subscriptions returned unexpected error", zap.Error(err))
-		}
-		return nil
-	}
-	return subs
+	return a.subs.Snapshot()
 }


### PR DESCRIPTION
## Summary
- Extract duplicated subscription CRUD (~1,500 LOC) from aws/azure/gcp/openstack/vmware/dtias adapters into a single `adapter.InMemorySubscriptionStore` with context cancellation, filter-aware listing, and a `RawMap()` test hook.
- Add sibling `adapter.StorageBackedSubscriptionStore` that delegates to a `storage.Store`-shaped backend via a locally-declared interface (avoids import cycle), so adapters can opt into persistent storage.
- Each adapter now holds `*adapter.InMemorySubscriptionStore` and its subscription methods are thin wrappers preserving public signatures and metric emission. OpenStack keeps its polling/webhook machinery intact on top of the shared CRUD.

## Test plan
- [x] `go test -race ./internal/adapter/...` (new store, incl. concurrent 50-goroutine test)
- [x] `go test -race ./internal/adapters/openstack/...`
- [x] `go test ./internal/adapter/... ./internal/adapters/{aws,azure,dtias,openstack}/...` — all pass
- [x] `go build ./...` clean
- [ ] CI green

Closes #485
Closes #535