### PR TITLE
[Refactor] H10: Split Config god-struct into role-specific interfaces

### DIFF
--- a/internal/config/accessors.go
+++ b/internal/config/accessors.go
@@ -1,0 +1,58 @@
+// Package config - accessor methods used by role-specific consumer interfaces.
+//
+// These accessors exist so that consumer packages can declare narrow
+// role-specific interfaces (interface-segregation pattern, see H10)
+// instead of depending on the full *Config god-struct. Each accessor
+// returns the backing sub-struct value by value; Config itself remains
+// the single source of truth loaded once from viper in cmd/gateway/main.go.
+package config
+
+import "github.com/piwi3910/netweave/internal/database"
+
+// ServerCfg returns the HTTP server settings.
+func (c *Config) ServerCfg() ServerConfig { return c.Server }
+
+// TLSCfg returns the TLS/mTLS settings.
+func (c *Config) TLSCfg() TLSConfig { return c.TLS }
+
+// SecurityCfg returns the security settings (CORS, rate limiting, headers).
+func (c *Config) SecurityCfg() SecurityConfig { return c.Security }
+
+// ObservabilityCfg returns logging, metrics, and tracing settings.
+func (c *Config) ObservabilityCfg() ObservabilityConfig { return c.Observability }
+
+// ValidationCfg returns request validation settings.
+func (c *Config) ValidationCfg() ValidationConfig { return c.Validation }
+
+// MultiTenancyCfg returns multi-tenancy and mTLS-requirement settings.
+func (c *Config) MultiTenancyCfg() MultiTenancyConfig { return c.MultiTenancy }
+
+// FrontendPluginsCfg returns the frontend plugin toggle settings.
+func (c *Config) FrontendPluginsCfg() FrontendPlugins { return c.FrontendPlugins }
+
+// AuthCfg returns the auth settings.
+func (c *Config) AuthCfg() AuthConfig { return c.Auth }
+
+// OAuth2Cfg returns the OAuth2 settings.
+func (c *Config) OAuth2Cfg() OAuth2Config { return c.OAuth2 }
+
+// RedisCfg returns Redis client settings.
+func (c *Config) RedisCfg() RedisConfig { return c.Redis }
+
+// KubernetesCfg returns Kubernetes client settings.
+func (c *Config) KubernetesCfg() KubernetesConfig { return c.Kubernetes }
+
+// PostgresCfg returns Postgres settings.
+func (c *Config) PostgresCfg() database.PostgresConfig { return c.Postgres }
+
+// EventsCfg returns the event-pipeline settings.
+func (c *Config) EventsCfg() EventsConfig { return c.Events }
+
+// CertLifecycleCfg returns the certificate-lifecycle settings.
+func (c *Config) CertLifecycleCfg() CertLifecycleConfig { return c.CertLifecycle }
+
+// StorageModeCfg returns the configured storage mode.
+func (c *Config) StorageModeCfg() string { return c.StorageMode }
+
+// EnvironmentCfg returns the detected environment (dev/staging/prod).
+func (c *Config) EnvironmentCfg() string { return c.Environment }

--- a/internal/config/accessors_test.go
+++ b/internal/config/accessors_test.go
@@ -1,0 +1,74 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/piwi3910/netweave/internal/config"
+	"github.com/piwi3910/netweave/internal/database"
+)
+
+// TestConfigAccessors exercises the role-specific accessor methods added
+// for H10 (interface-segregation). Each accessor simply returns a backing
+// sub-struct; the test verifies the returned value matches the field,
+// guarding against field-name drift or wrong field being returned.
+func TestConfigAccessors(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Host:         "127.0.0.1",
+			Port:         8080,
+			GinMode:      "test",
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 5 * time.Second,
+		},
+		TLS: config.TLSConfig{
+			Enabled:    true,
+			MinVersion: "1.3",
+		},
+		Security: config.SecurityConfig{
+			EnableCORS:       true,
+			RateLimitEnabled: true,
+		},
+		Observability: config.ObservabilityConfig{
+			Metrics: config.MetricsConfig{Enabled: true, Path: "/metrics", Namespace: "ns"},
+		},
+		Validation: config.ValidationConfig{
+			Enabled:     true,
+			MaxBodySize: 1024,
+		},
+		MultiTenancy: config.MultiTenancyConfig{RequireMTLS: true},
+		FrontendPlugins: config.FrontendPlugins{
+			O2IMS: config.FrontendPluginConfig{Enabled: true},
+		},
+		Auth:          config.AuthConfig{},
+		OAuth2:        config.OAuth2Config{},
+		Redis:         config.RedisConfig{},
+		Kubernetes:    config.KubernetesConfig{},
+		Postgres:      database.PostgresConfig{},
+		Events:        config.EventsConfig{Enabled: true, WebhookWorkers: 7},
+		CertLifecycle: config.CertLifecycleConfig{Enabled: true, MaxRenewalRetries: 3},
+		StorageMode:   "postgres",
+		Environment:   config.EnvProduction,
+	}
+
+	assert.Equal(t, cfg.Server, cfg.ServerCfg())
+	assert.Equal(t, cfg.TLS, cfg.TLSCfg())
+	assert.Equal(t, cfg.Security, cfg.SecurityCfg())
+	assert.Equal(t, cfg.Observability, cfg.ObservabilityCfg())
+	assert.Equal(t, cfg.Validation, cfg.ValidationCfg())
+	assert.Equal(t, cfg.MultiTenancy, cfg.MultiTenancyCfg())
+	assert.Equal(t, cfg.FrontendPlugins, cfg.FrontendPluginsCfg())
+	assert.Equal(t, cfg.Auth, cfg.AuthCfg())
+	assert.Equal(t, cfg.OAuth2, cfg.OAuth2Cfg())
+	assert.Equal(t, cfg.Redis, cfg.RedisCfg())
+	assert.Equal(t, cfg.Kubernetes, cfg.KubernetesCfg())
+	assert.Equal(t, cfg.Postgres, cfg.PostgresCfg())
+	assert.Equal(t, cfg.Events, cfg.EventsCfg())
+	assert.Equal(t, cfg.CertLifecycle, cfg.CertLifecycleCfg())
+	assert.Equal(t, "postgres", cfg.StorageModeCfg())
+	assert.Equal(t, config.EnvProduction, cfg.EnvironmentCfg())
+}

--- a/internal/server/callback_validation.go
+++ b/internal/server/callback_validation.go
@@ -49,7 +49,7 @@ func (s *Server) ValidateCallback(ctx context.Context, sub *adapter.Subscription
 
 	// SSRF Protection: Block localhost and private IP ranges
 	// Skip SSRF protection if disabled in config (for testing only)
-	if !s.config.Security.DisableSSRFProtection {
+	if !s.config.SecurityCfg().DisableSSRFProtection {
 		if err := ValidateCallbackHost(ctx, parsedURL.Hostname()); err != nil {
 			return err
 		}

--- a/internal/server/config_contract.go
+++ b/internal/server/config_contract.go
@@ -1,0 +1,22 @@
+package server
+
+import "github.com/piwi3910/netweave/internal/config"
+
+// ServerConfigProvider is the role-specific configuration contract the
+// server package requires from its caller. It exposes only the sections
+// of configuration that server code actually reads, making the
+// package's configuration surface explicit and letting tests pass a
+// narrow stub instead of constructing a full *config.Config (H10).
+//
+// *config.Config satisfies this interface via the accessor methods in
+// internal/config/accessors.go. Tests may supply any type that
+// implements the same methods.
+type ServerConfigProvider interface {
+	ServerCfg() config.ServerConfig
+	TLSCfg() config.TLSConfig
+	SecurityCfg() config.SecurityConfig
+	ObservabilityCfg() config.ObservabilityConfig
+	ValidationCfg() config.ValidationConfig
+	MultiTenancyCfg() config.MultiTenancyConfig
+	FrontendPluginsCfg() config.FrontendPlugins
+}

--- a/internal/server/config_contract_test.go
+++ b/internal/server/config_contract_test.go
@@ -1,0 +1,60 @@
+package server_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/piwi3910/netweave/internal/config"
+	"github.com/piwi3910/netweave/internal/server"
+)
+
+// stubConfigProvider is a minimal stand-in for *config.Config that
+// demonstrates the H10 interface-segregation payoff: a test can satisfy
+// server.ServerConfigProvider with only the sub-structs it cares about,
+// without constructing the full god-struct.
+type stubConfigProvider struct {
+	server        config.ServerConfig
+	tls           config.TLSConfig
+	security      config.SecurityConfig
+	observability config.ObservabilityConfig
+	validation    config.ValidationConfig
+	multiTenancy  config.MultiTenancyConfig
+	frontend      config.FrontendPlugins
+}
+
+func (s stubConfigProvider) ServerCfg() config.ServerConfig               { return s.server }
+func (s stubConfigProvider) TLSCfg() config.TLSConfig                     { return s.tls }
+func (s stubConfigProvider) SecurityCfg() config.SecurityConfig           { return s.security }
+func (s stubConfigProvider) ObservabilityCfg() config.ObservabilityConfig { return s.observability }
+func (s stubConfigProvider) ValidationCfg() config.ValidationConfig       { return s.validation }
+func (s stubConfigProvider) MultiTenancyCfg() config.MultiTenancyConfig   { return s.multiTenancy }
+func (s stubConfigProvider) FrontendPluginsCfg() config.FrontendPlugins   { return s.frontend }
+
+// TestServerConfigProvider_SatisfiedByConfig ensures that *config.Config
+// continues to satisfy server.ServerConfigProvider. This is a compile-time
+// guarantee, but an explicit test gives a clearer failure if someone
+// removes an accessor method.
+func TestServerConfigProvider_SatisfiedByConfig(t *testing.T) {
+	t.Parallel()
+
+	var _ server.ServerConfigProvider = (*config.Config)(nil)
+	var _ server.ServerConfigProvider = stubConfigProvider{}
+}
+
+// TestServerConfigProvider_StubHonoursValues ensures a narrow stub is
+// usable in place of the full *config.Config for tests that only need a
+// few sub-structs.
+func TestServerConfigProvider_StubHonoursValues(t *testing.T) {
+	t.Parallel()
+
+	stub := stubConfigProvider{
+		server: config.ServerConfig{Host: "127.0.0.1", Port: 9090},
+		tls:    config.TLSConfig{Enabled: true, MinVersion: "1.3"},
+	}
+
+	var provider server.ServerConfigProvider = stub
+	assert.Equal(t, "127.0.0.1", provider.ServerCfg().Host)
+	assert.Equal(t, 9090, provider.ServerCfg().Port)
+	assert.True(t, provider.TLSCfg().Enabled)
+}

--- a/internal/server/graphql_routes.go
+++ b/internal/server/graphql_routes.go
@@ -55,7 +55,7 @@ func (s *Server) setupGraphQLRoutes() {
 		wsAuth = concrete.OAuth2Authenticator()
 	}
 	gqlSrv := gqlserver.NewServer(resolver, gqlserver.ServerOptions{
-		GinMode:                s.config.Server.GinMode,
+		GinMode:                s.config.ServerCfg().GinMode,
 		WebSocketAuthenticator: wsAuth,
 		WebSocketRequireAuth:   wsAuth != nil,
 	})
@@ -70,7 +70,7 @@ func (s *Server) setupGraphQLRoutes() {
 	// GraphQL playground UI (GET /graphql).
 	// Only enabled in development mode for security.
 	// Provides interactive IDE for exploring the GraphQL schema.
-	if s.config.Server.GinMode != "release" {
+	if s.config.ServerCfg().GinMode != "release" {
 		s.graphqlRouter.GET("/graphql", gqlGuard, gqlserver.PlaygroundHandler("/graphql"))
 		s.logger.Info("GraphQL playground enabled at /graphql")
 	}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -251,8 +251,8 @@ func (s *Server) setupRoutes() {
 	s.adminRouter.GET("/ready", s.handleReadiness)
 	s.adminRouter.GET("/readyz", s.handleReadiness)
 
-	if s.config.Observability.Metrics.Enabled {
-		s.adminRouter.GET(s.config.Observability.Metrics.Path, s.handleMetrics)
+	if s.config.ObservabilityCfg().Metrics.Enabled {
+		s.adminRouter.GET(s.config.ObservabilityCfg().Metrics.Path, s.handleMetrics)
 	}
 
 	// /o2ims serves API metadata. It was previously opened up via a

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -66,7 +66,10 @@ var o2imsOpenAPISpec []byte
 //	    log.Fatal(err)
 //	}
 type Server struct {
-	config *config.Config
+	// config exposes only the sections server actually reads, via the
+	// narrow ServerConfigProvider contract (H10, interface-segregation).
+	// *config.Config satisfies this interface; tests may supply a stub.
+	config ServerConfigProvider
 	logger *zap.Logger
 
 	// Multi-port routers: each port gets its own Gin engine with appropriate auth.
@@ -507,25 +510,25 @@ func (s *Server) setupMiddleware() {
 		// OpenAPI spec still have a hard body limit (issue #494).
 		r.Use(bodyLimitMw)
 
-		if s.config.Observability.Metrics.Enabled {
+		if s.config.ObservabilityCfg().Metrics.Enabled {
 			r.Use(s.MetricsMiddleware())
 		}
 
-		if s.config.Security.EnableCORS {
+		if s.config.SecurityCfg().EnableCORS {
 			r.Use(s.corsMiddleware())
 		}
 
-		if s.config.Security.RateLimitEnabled {
+		if s.config.SecurityCfg().RateLimitEnabled {
 			r.Use(s.rateLimitMiddleware())
 		}
 
-		if s.config.Security.RateLimit.PerResource.Enabled {
+		if s.config.SecurityCfg().RateLimit.PerResource.Enabled {
 			r.Use(s.resourceRateLimitMiddleware())
 		}
 	}
 
 	// OpenAPI validation only on admin and O2 routers (O2-IMS spec applies there)
-	if s.openAPIValidator != nil && s.config.Validation.Enabled {
+	if s.openAPIValidator != nil && s.config.ValidationCfg().Enabled {
 		s.adminRouter.Use(s.openAPIValidator.Middleware())
 		s.o2Router.Use(s.openAPIValidator.Middleware())
 		s.logger.Info("OpenAPI request validation enabled")
@@ -550,14 +553,14 @@ func (s *Server) setupMiddleware() {
 // securityHeadersMiddleware returns the security headers middleware.
 func (s *Server) securityHeadersMiddleware() gin.HandlerFunc {
 	config := &middleware.SecurityHeadersConfig{
-		Enabled:               s.config.Security.SecurityHeaders.Enabled,
-		HSTSMaxAge:            s.config.Security.SecurityHeaders.HSTSMaxAge,
-		HSTSIncludeSubDomains: s.config.Security.SecurityHeaders.HSTSIncludeSubDomains,
-		HSTSPreload:           s.config.Security.SecurityHeaders.HSTSPreload,
-		ContentSecurityPolicy: s.config.Security.SecurityHeaders.ContentSecurityPolicy,
-		FrameOptions:          s.config.Security.SecurityHeaders.FrameOptions,
-		ReferrerPolicy:        s.config.Security.SecurityHeaders.ReferrerPolicy,
-		TLSEnabled:            s.config.TLS.Enabled,
+		Enabled:               s.config.SecurityCfg().SecurityHeaders.Enabled,
+		HSTSMaxAge:            s.config.SecurityCfg().SecurityHeaders.HSTSMaxAge,
+		HSTSIncludeSubDomains: s.config.SecurityCfg().SecurityHeaders.HSTSIncludeSubDomains,
+		HSTSPreload:           s.config.SecurityCfg().SecurityHeaders.HSTSPreload,
+		ContentSecurityPolicy: s.config.SecurityCfg().SecurityHeaders.ContentSecurityPolicy,
+		FrameOptions:          s.config.SecurityCfg().SecurityHeaders.FrameOptions,
+		ReferrerPolicy:        s.config.SecurityCfg().SecurityHeaders.ReferrerPolicy,
+		TLSEnabled:            s.config.TLSCfg().Enabled,
 	}
 
 	// Apply defaults if not configured
@@ -584,7 +587,7 @@ func (s *Server) securityHeadersMiddleware() gin.HandlerFunc {
 // when this function is extended in the future.
 func (s *Server) bodyLimitMiddleware() gin.HandlerFunc {
 	cfg := middleware.BodyLimitConfig{
-		Default: s.config.Validation.MaxBodySize,
+		Default: s.config.ValidationCfg().MaxBodySize,
 		Logger:  s.logger,
 	}
 	if cfg.Default <= 0 {
@@ -605,11 +608,11 @@ func (s *Server) bodyLimitMiddleware() gin.HandlerFunc {
 //	    log.Fatalf("Server failed: %v", err)
 //	}
 func (s *Server) Start() error {
-	host := s.config.Server.Host
+	host := s.config.ServerCfg().Host
 
 	// Build TLS configs if TLS is enabled
 	var standardTLS, o2TLS *tls.Config
-	if s.config.TLS.Enabled {
+	if s.config.TLSCfg().Enabled {
 		var err error
 		standardTLS, err = s.buildStandardTLSConfig()
 		if err != nil {
@@ -622,19 +625,19 @@ func (s *Server) Start() error {
 	}
 
 	// Create admin server (port 8080)
-	adminAddr := fmt.Sprintf("%s:%d", host, s.config.Server.Port)
+	adminAddr := fmt.Sprintf("%s:%d", host, s.config.ServerCfg().Port)
 	s.httpServer = s.newHTTPServer(adminAddr, s.adminRouter, standardTLS)
 
 	// Create O2 mTLS server (port 8443)
-	o2Addr := fmt.Sprintf("%s:%d", host, s.config.Server.O2Port)
+	o2Addr := fmt.Sprintf("%s:%d", host, s.config.ServerCfg().O2Port)
 	s.o2Server = s.newHTTPServer(o2Addr, s.o2Router, o2TLS)
 
 	// Create TMForum server (port 8444)
-	tmfAddr := fmt.Sprintf("%s:%d", host, s.config.Server.TMFPort)
+	tmfAddr := fmt.Sprintf("%s:%d", host, s.config.ServerCfg().TMFPort)
 	s.tmfServer = s.newHTTPServer(tmfAddr, s.tmfRouter, standardTLS)
 
 	// Create GraphQL server (port 8445)
-	gqlAddr := fmt.Sprintf("%s:%d", host, s.config.Server.GraphQLPort)
+	gqlAddr := fmt.Sprintf("%s:%d", host, s.config.ServerCfg().GraphQLPort)
 	s.graphqlServer = s.newHTTPServer(gqlAddr, s.graphqlRouter, standardTLS)
 
 	// Channel to listen for errors from any server
@@ -677,10 +680,10 @@ func (s *Server) newHTTPServer(addr string, handler http.Handler, tlsCfg *tls.Co
 	srv := &http.Server{
 		Addr:           addr,
 		Handler:        handler,
-		ReadTimeout:    s.config.Server.ReadTimeout,
-		WriteTimeout:   s.config.Server.WriteTimeout,
-		IdleTimeout:    s.config.Server.IdleTimeout,
-		MaxHeaderBytes: s.config.Server.MaxHeaderBytes,
+		ReadTimeout:    s.config.ServerCfg().ReadTimeout,
+		WriteTimeout:   s.config.ServerCfg().WriteTimeout,
+		IdleTimeout:    s.config.ServerCfg().IdleTimeout,
+		MaxHeaderBytes: s.config.ServerCfg().MaxHeaderBytes,
 	}
 	if tlsCfg != nil {
 		srv.TLSConfig = tlsCfg
@@ -708,10 +711,10 @@ func (s *Server) bindAllListeners(host string) (*boundListeners, error) {
 		name string
 		port int
 	}{
-		{"admin", s.config.Server.Port},
-		{"o2", s.config.Server.O2Port},
-		{"tmf", s.config.Server.TMFPort},
-		{"graphql", s.config.Server.GraphQLPort},
+		{"admin", s.config.ServerCfg().Port},
+		{"o2", s.config.ServerCfg().O2Port},
+		{"tmf", s.config.ServerCfg().TMFPort},
+		{"graphql", s.config.ServerCfg().GraphQLPort},
 	}
 
 	opened := make([]net.Listener, 0, len(targets))
@@ -755,8 +758,8 @@ func (s *Server) startListener(name string, srv *http.Server, ln net.Listener, e
 		)
 
 		var err error
-		if s.config.TLS.Enabled {
-			err = srv.ServeTLS(ln, s.config.TLS.CertFile, s.config.TLS.KeyFile)
+		if s.config.TLSCfg().Enabled {
+			err = srv.ServeTLS(ln, s.config.TLSCfg().CertFile, s.config.TLSCfg().KeyFile)
 		} else {
 			err = srv.Serve(ln)
 		}
@@ -776,15 +779,15 @@ func (s *Server) buildBaseTLSConfig() (*tls.Config, error) {
 		MinVersion: tls.VersionTLS13,
 	}
 
-	switch s.config.TLS.MinVersion {
+	switch s.config.TLSCfg().MinVersion {
 	case "1.2":
 		tlsCfg.MinVersion = tls.VersionTLS12
 	case "1.3", "":
 		tlsCfg.MinVersion = tls.VersionTLS13
 	}
 
-	if len(s.config.TLS.CipherSuites) > 0 {
-		suites, err := resolveCipherSuites(s.config.TLS.CipherSuites)
+	if len(s.config.TLSCfg().CipherSuites) > 0 {
+		suites, err := resolveCipherSuites(s.config.TLSCfg().CipherSuites)
 		if err != nil {
 			return nil, err
 		}
@@ -792,7 +795,7 @@ func (s *Server) buildBaseTLSConfig() (*tls.Config, error) {
 		// for TLS 1.3 so the operator is not misled.
 		if tlsCfg.MinVersion == tls.VersionTLS13 {
 			s.logger.Warn("cipher_suites configured but MinVersion is TLS 1.3; Go ignores cipher_suites for TLS 1.3",
-				zap.Strings("cipher_suites", s.config.TLS.CipherSuites),
+				zap.Strings("cipher_suites", s.config.TLSCfg().CipherSuites),
 			)
 		}
 		tlsCfg.CipherSuites = suites
@@ -824,19 +827,19 @@ func resolveCipherSuites(names []string) ([]uint16, error) {
 
 // loadClientCAs loads the CA certificate pool for client verification.
 func (s *Server) loadClientCAs() (*x509.CertPool, error) {
-	if s.config.TLS.CAFile == "" {
+	if s.config.TLSCfg().CAFile == "" {
 		return nil, nil
 	}
 
-	caCert, err := os.ReadFile(s.config.TLS.CAFile)
+	caCert, err := os.ReadFile(s.config.TLSCfg().CAFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read CA certificate %s: %w", s.config.TLS.CAFile, err)
+		return nil, fmt.Errorf("failed to read CA certificate %s: %w", s.config.TLSCfg().CAFile, err)
 	}
 	caCertPool := x509.NewCertPool()
 	if !caCertPool.AppendCertsFromPEM(caCert) {
-		return nil, fmt.Errorf("failed to parse CA certificate from %s", s.config.TLS.CAFile)
+		return nil, fmt.Errorf("failed to parse CA certificate from %s", s.config.TLSCfg().CAFile)
 	}
-	s.logger.Info("client CA certificate loaded", zap.String("ca_file", s.config.TLS.CAFile))
+	s.logger.Info("client CA certificate loaded", zap.String("ca_file", s.config.TLSCfg().CAFile))
 	return caCertPool, nil
 }
 
@@ -850,7 +853,7 @@ func (s *Server) buildStandardTLSConfig() (*tls.Config, error) {
 	tlsCfg.ClientAuth = tls.NoClientCert
 
 	s.logger.Info("standard TLS configuration built (no client auth)",
-		zap.String("min_version", s.config.TLS.MinVersion),
+		zap.String("min_version", s.config.TLSCfg().MinVersion),
 	)
 
 	return tlsCfg, nil
@@ -865,7 +868,7 @@ func (s *Server) buildO2TLSConfig() (*tls.Config, error) {
 	}
 
 	// Configure client certificate authentication from config
-	switch s.config.TLS.ClientAuth {
+	switch s.config.TLSCfg().ClientAuth {
 	case "require-and-verify":
 		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
 	case "require":
@@ -881,8 +884,8 @@ func (s *Server) buildO2TLSConfig() (*tls.Config, error) {
 	// Validate that CA file is provided when client verification is required
 	if tlsCfg.ClientAuth == tls.RequireAndVerifyClientCert ||
 		tlsCfg.ClientAuth == tls.VerifyClientCertIfGiven {
-		if s.config.TLS.CAFile == "" {
-			return nil, fmt.Errorf("CA certificate file required when client_auth is %q", s.config.TLS.ClientAuth)
+		if s.config.TLSCfg().CAFile == "" {
+			return nil, fmt.Errorf("CA certificate file required when client_auth is %q", s.config.TLSCfg().ClientAuth)
 		}
 	}
 
@@ -904,8 +907,8 @@ func (s *Server) buildO2TLSConfig() (*tls.Config, error) {
 	}
 
 	s.logger.Info("O2 mTLS configuration built",
-		zap.String("min_version", s.config.TLS.MinVersion),
-		zap.String("client_auth", s.config.TLS.ClientAuth),
+		zap.String("min_version", s.config.TLSCfg().MinVersion),
+		zap.String("client_auth", s.config.TLSCfg().ClientAuth),
 		zap.Bool("crl_enabled", s.crlVerifier != nil),
 	)
 
@@ -943,7 +946,7 @@ func (s *Server) Shutdown() error {
 	// Create shutdown context with timeout
 	ctx, cancel := context.WithTimeout(
 		context.Background(),
-		s.config.Server.ShutdownTimeout,
+		s.config.ServerCfg().ShutdownTimeout,
 	)
 	defer cancel()
 
@@ -957,7 +960,7 @@ func (s *Server) shutdownWithContext(ctx context.Context) error {
 
 	s.shutdownOnce.Do(func() {
 		s.logger.Info("initiating graceful shutdown",
-			zap.Duration("timeout", s.config.Server.ShutdownTimeout),
+			zap.Duration("timeout", s.config.ServerCfg().ShutdownTimeout),
 		)
 
 		// Stop SMO health checks and close registry
@@ -1291,7 +1294,7 @@ func (s *Server) MetricsMiddleware() gin.HandlerFunc {
 func (s *Server) corsMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		origin := c.Request.Header.Get("Origin")
-		allowedOrigins := s.config.Security.AllowedOrigins
+		allowedOrigins := s.config.SecurityCfg().AllowedOrigins
 
 		// Empty list: deny-all. Do not emit any CORS headers, but still
 		// shortcut preflight so downstream handlers don't see the OPTIONS.
@@ -1324,16 +1327,16 @@ func (s *Server) corsMiddleware() gin.HandlerFunc {
 			c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 			c.Writer.Header().Set("Vary", "Origin")
 			c.Writer.Header().Set("Access-Control-Allow-Headers",
-				JoinStrings(s.config.Security.AllowedHeaders, ", "))
+				JoinStrings(s.config.SecurityCfg().AllowedHeaders, ", "))
 			c.Writer.Header().Set("Access-Control-Allow-Methods",
-				JoinStrings(s.config.Security.AllowedMethods, ", "))
+				JoinStrings(s.config.SecurityCfg().AllowedMethods, ", "))
 		case wildcard:
 			// Wildcard: never reflect the request origin with credentials=true.
 			c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
 			c.Writer.Header().Set("Access-Control-Allow-Headers",
-				JoinStrings(s.config.Security.AllowedHeaders, ", "))
+				JoinStrings(s.config.SecurityCfg().AllowedHeaders, ", "))
 			c.Writer.Header().Set("Access-Control-Allow-Methods",
-				JoinStrings(s.config.Security.AllowedMethods, ", "))
+				JoinStrings(s.config.SecurityCfg().AllowedMethods, ", "))
 		default:
 			// Origin not allow-listed: emit no CORS headers at all.
 		}
@@ -1361,21 +1364,21 @@ func (s *Server) rateLimitMiddleware() gin.HandlerFunc {
 
 	// Convert config types to middleware types
 	rateLimitConfig := &middleware.RateLimitConfig{
-		Enabled:     s.config.Security.RateLimitEnabled,
+		Enabled:     s.config.SecurityCfg().RateLimitEnabled,
 		RedisClient: redisStore.Client,
 		PerTenant: middleware.TenantLimitConfig{
-			RequestsPerSecond: s.config.Security.RateLimit.PerTenant.RequestsPerSecond,
-			BurstSize:         s.config.Security.RateLimit.PerTenant.BurstSize,
+			RequestsPerSecond: s.config.SecurityCfg().RateLimit.PerTenant.RequestsPerSecond,
+			BurstSize:         s.config.SecurityCfg().RateLimit.PerTenant.BurstSize,
 		},
 		Global: middleware.GlobalLimitConfig{
-			RequestsPerSecond:     s.config.Security.RateLimit.Global.RequestsPerSecond,
-			MaxConcurrentRequests: s.config.Security.RateLimit.Global.MaxConcurrentRequests,
+			RequestsPerSecond:     s.config.SecurityCfg().RateLimit.Global.RequestsPerSecond,
+			MaxConcurrentRequests: s.config.SecurityCfg().RateLimit.Global.MaxConcurrentRequests,
 		},
-		DefaultFailMode: middleware.FailMode(s.config.Security.RateLimit.FailMode),
+		DefaultFailMode: middleware.FailMode(s.config.SecurityCfg().RateLimit.FailMode),
 	}
 
 	// Convert endpoint configs
-	for _, ep := range s.config.Security.RateLimit.PerEndpoint {
+	for _, ep := range s.config.SecurityCfg().RateLimit.PerEndpoint {
 		rateLimitConfig.PerEndpoint = append(rateLimitConfig.PerEndpoint, middleware.EndpointLimitConfig{
 			Path:              ep.Path,
 			Method:            ep.Method,
@@ -1413,32 +1416,32 @@ func (s *Server) resourceRateLimitMiddleware() gin.HandlerFunc {
 
 	// Convert config types to middleware types
 	resourceConfig := &middleware.ResourceRateLimitConfig{
-		Enabled:     s.config.Security.RateLimit.PerResource.Enabled,
+		Enabled:     s.config.SecurityCfg().RateLimit.PerResource.Enabled,
 		RedisClient: redisStore.Client,
 		DeploymentManagers: middleware.ResourceTypeLimits{
-			ReadsPerMinute:  s.config.Security.RateLimit.PerResource.DeploymentManagers.ReadsPerMinute,
-			WritesPerMinute: s.config.Security.RateLimit.PerResource.DeploymentManagers.WritesPerMinute,
-			ListPageSizeMax: s.config.Security.RateLimit.PerResource.DeploymentManagers.ListPageSizeMax,
+			ReadsPerMinute:  s.config.SecurityCfg().RateLimit.PerResource.DeploymentManagers.ReadsPerMinute,
+			WritesPerMinute: s.config.SecurityCfg().RateLimit.PerResource.DeploymentManagers.WritesPerMinute,
+			ListPageSizeMax: s.config.SecurityCfg().RateLimit.PerResource.DeploymentManagers.ListPageSizeMax,
 		},
 		ResourcePools: middleware.ResourceTypeLimits{
-			ReadsPerMinute:  s.config.Security.RateLimit.PerResource.ResourcePools.ReadsPerMinute,
-			WritesPerMinute: s.config.Security.RateLimit.PerResource.ResourcePools.WritesPerMinute,
-			ListPageSizeMax: s.config.Security.RateLimit.PerResource.ResourcePools.ListPageSizeMax,
+			ReadsPerMinute:  s.config.SecurityCfg().RateLimit.PerResource.ResourcePools.ReadsPerMinute,
+			WritesPerMinute: s.config.SecurityCfg().RateLimit.PerResource.ResourcePools.WritesPerMinute,
+			ListPageSizeMax: s.config.SecurityCfg().RateLimit.PerResource.ResourcePools.ListPageSizeMax,
 		},
 		Resources: middleware.ResourceTypeLimits{
-			ReadsPerMinute:  s.config.Security.RateLimit.PerResource.Resources.ReadsPerMinute,
-			WritesPerMinute: s.config.Security.RateLimit.PerResource.Resources.WritesPerMinute,
-			ListPageSizeMax: s.config.Security.RateLimit.PerResource.Resources.ListPageSizeMax,
+			ReadsPerMinute:  s.config.SecurityCfg().RateLimit.PerResource.Resources.ReadsPerMinute,
+			WritesPerMinute: s.config.SecurityCfg().RateLimit.PerResource.Resources.WritesPerMinute,
+			ListPageSizeMax: s.config.SecurityCfg().RateLimit.PerResource.Resources.ListPageSizeMax,
 		},
 		ResourceTypes: middleware.ResourceTypeLimits{
-			ReadsPerMinute:  s.config.Security.RateLimit.PerResource.ResourceTypes.ReadsPerMinute,
-			WritesPerMinute: s.config.Security.RateLimit.PerResource.ResourceTypes.WritesPerMinute,
-			ListPageSizeMax: s.config.Security.RateLimit.PerResource.ResourceTypes.ListPageSizeMax,
+			ReadsPerMinute:  s.config.SecurityCfg().RateLimit.PerResource.ResourceTypes.ReadsPerMinute,
+			WritesPerMinute: s.config.SecurityCfg().RateLimit.PerResource.ResourceTypes.WritesPerMinute,
+			ListPageSizeMax: s.config.SecurityCfg().RateLimit.PerResource.ResourceTypes.ListPageSizeMax,
 		},
 		Subscriptions: middleware.SubscriptionLimits{
-			CreatesPerHour: s.config.Security.RateLimit.PerResource.Subscriptions.CreatesPerHour,
-			MaxActive:      s.config.Security.RateLimit.PerResource.Subscriptions.MaxActive,
-			ReadsPerMinute: s.config.Security.RateLimit.PerResource.Subscriptions.ReadsPerMinute,
+			CreatesPerHour: s.config.SecurityCfg().RateLimit.PerResource.Subscriptions.CreatesPerHour,
+			MaxActive:      s.config.SecurityCfg().RateLimit.PerResource.Subscriptions.MaxActive,
+			ReadsPerMinute: s.config.SecurityCfg().RateLimit.PerResource.Subscriptions.ReadsPerMinute,
 		},
 	}
 

--- a/internal/server/test_helpers.go
+++ b/internal/server/test_helpers.go
@@ -133,9 +133,18 @@ func NewTestServerWithAuth(
 // Getter methods for testing - these expose internal fields for test assertions.
 // These should only be used in tests.
 
-// Config returns the server configuration for testing.
+// Config returns the concrete server configuration for testing.
+// Production code reads config through the narrow ServerConfigProvider
+// interface (see Server.config), but tests need to mutate fields like
+// Security.DisableSSRFProtection directly, so this helper unwraps the
+// interface to the concrete *config.Config. Panics if a non-*config.Config
+// provider was installed (tests should always use a real Config).
 func (s *Server) Config() *config.Config {
-	return s.config
+	cfg, ok := s.config.(*config.Config)
+	if !ok {
+		panic("server.Config(): underlying provider is not *config.Config; tests must supply a real config")
+	}
+	return cfg
 }
 
 // Logger returns the server logger for testing.


### PR DESCRIPTION
## Summary

Applies the interface-segregation pattern to the ~1680 LOC `config.Config`
god-struct so each consumer declares the narrow slice of configuration it
actually reads, rather than inferring it from field accesses into a
15-section shared struct.

- New accessor methods on `*config.Config` (`ServerCfg`, `TLSCfg`,
  `SecurityCfg`, `ObservabilityCfg`, `ValidationCfg`, `MultiTenancyCfg`,
  `FrontendPluginsCfg`, and more) returning the existing backing
  sub-structs by value. `*Config` remains the single source of truth
  loaded once from viper in `cmd/gateway/main.go`; viper semantics, YAML
  keys, and env-var bindings are unchanged.
- New `server.ServerConfigProvider` interface listing the seven
  sub-structs the server package actually reads. `Server.config` is now
  this narrow interface. `*config.Config` satisfies it; tests can now
  supply a stub (`config_contract_test.go` demonstrates both paths).
- Rewrote 80+ `s.config.<Section>.X` reads across `server.go`,
  `routes.go`, `graphql_routes.go`, and `callback_validation.go` to
  `s.config.<Section>Cfg().X`. No behavioural change.

## Scope note

Only the `server` package holds `*config.Config` as a field and
accesses dozens of sub-sections. The remaining consumers
(`cmd/gateway/main.go`, `internal/cli/cmd/setup/vault.go`,
`cmd/gateway/events.go`) either are the composition root or already
take narrow sub-struct parameters, so they derive no benefit from
further interface narrowing. Accessors for the other sections are
included so follow-up work (`AuthConfigProvider`,
`EventsConfigProvider`, `StorageConfigProvider`, etc.) can layer on
incrementally without touching `config.Config` again.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages green)
- [x] `go test -cover ./internal/config/...` -> 91.7% (was 88.0%)
- [x] `go test -cover ./internal/server/...` -> 75.6% (unchanged baseline)
- [x] `golangci-lint run --new-from-rev=origin/main` -> 0 new issues
- [x] No `//nolint` directives added
- [x] New `config_contract_test.go` demonstrates the testability win
      via a stub that satisfies `ServerConfigProvider` without
      constructing a full `*config.Config`

Closes #483