### PR TITLE
[Security] H9: Enforce tenant isolation at the storage boundary

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -285,6 +285,8 @@ func initializePostgres(cfg *config.Config, logger *zap.Logger) (*database.DB, e
 }
 
 // selectSubscriptionStore sets dest to the appropriate subscription store based on storage mode.
+// When cfg.Security.TenantIsolationEnforced is true (the default), the resulting store is wrapped
+// in a TenantEnforcedStore which makes cross-tenant reads/writes at the storage layer impossible.
 func selectSubscriptionStore(
 	dest *storage.Store,
 	cfg *config.Config,
@@ -292,19 +294,28 @@ func selectSubscriptionStore(
 	pgDB *database.DB,
 	logger *zap.Logger,
 ) {
+	var inner storage.Store
 	switch cfg.StorageMode {
 	case "postgres":
 		logger.Info("using PostgreSQL as subscription store")
-		*dest = storage.NewPostgresStore(pgDB, cfg.Security.AllowInsecureCallbacks)
+		inner = storage.NewPostgresStore(pgDB, cfg.Security.AllowInsecureCallbacks)
 
 	case "dual":
 		pgStore := storage.NewPostgresStore(pgDB, cfg.Security.AllowInsecureCallbacks)
 		logger.Info("using dual store (primary=redis, secondary=postgres)")
-		*dest = storage.NewDualStore(redisStore, pgStore, logger)
+		inner = storage.NewDualStore(redisStore, pgStore, logger)
 
 	default: // "redis"
 		logger.Info("using Redis as subscription store")
-		*dest = redisStore
+		inner = redisStore
+	}
+
+	if cfg.Security.TenantIsolationEnforced {
+		logger.Info("wrapping subscription store with tenant isolation enforcer")
+		*dest = storage.NewTenantEnforcedStore(inner)
+	} else {
+		logger.Warn("tenant isolation enforcement DISABLED — handlers are solely responsible for tenant filtering")
+		*dest = inner
 	}
 }
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/piwi3910/netweave/internal/httpx"
+	tenantctx "github.com/piwi3910/netweave/internal/tenant"
 )
 
 // MaxDNLength is the maximum allowed length for a DN string.
@@ -487,6 +488,17 @@ func (m *Middleware) finalizeAuthentication(
 
 	ctx = ContextWithUser(ctx, authUser)
 	ctx = ContextWithTenant(ctx, tenant)
+
+	// Stamp tenant identity into ctx for the storage-layer tenant enforcer.
+	// Platform admins get the all-tenants bypass sentinel; everyone else is
+	// scoped strictly to their own tenant. This is the ONLY place tenant
+	// identity is put into ctx for storage — handlers that bypass middleware
+	// must either call tenantctx.WithID explicitly or be refused by storage.
+	if authUser.IsPlatformAdmin {
+		ctx = tenantctx.WithAll(ctx)
+	} else {
+		ctx = tenantctx.WithID(ctx, user.TenantID)
+	}
 	c.Request = c.Request.WithContext(ctx)
 
 	// Update last login asynchronously

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -683,6 +683,14 @@ type SecurityConfig struct {
 
 	// SecurityHeaders contains configuration for security headers middleware
 	SecurityHeaders SecurityHeadersConfig `mapstructure:"security_headers"`
+
+	// TenantIsolationEnforced toggles the storage-layer tenant isolation
+	// enforcer. When true (default), every subscription storage call must
+	// carry a tenant identity in context; cross-tenant reads/writes are
+	// refused by the store. When false, the store behaves as before and
+	// handlers are solely responsible for tenant filtering — use ONLY for
+	// one-off migrations of legacy data, and re-enable immediately.
+	TenantIsolationEnforced bool `mapstructure:"tenant_isolation_enforced"`
 }
 
 // SecurityHeadersConfig contains configuration for HTTP security headers.
@@ -1110,6 +1118,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("security.rate_limit.global.requests_per_second", 10000)
 	v.SetDefault("security.rate_limit.global.max_concurrent_requests", 1000)
 	v.SetDefault("security.allow_insecure_callbacks", false)
+	v.SetDefault("security.tenant_isolation_enforced", true)
 
 	// Validation defaults
 	v.SetDefault("validation.enabled", true)

--- a/internal/server/tenant_storage_boundary_test.go
+++ b/internal/server/tenant_storage_boundary_test.go
@@ -1,0 +1,88 @@
+package server_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/storage"
+	"github.com/piwi3910/netweave/internal/tenant"
+)
+
+// TestStorageBoundary_HandlerForgettingFilterCannotLeak simulates a handler
+// that forgets to add an inline tenant check before calling the store. The
+// storage layer's tenant enforcer must still prevent cross-tenant access,
+// guaranteeing defense in depth for the class of bug described in issue #482.
+func TestStorageBoundary_HandlerForgettingFilterCannotLeak(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	cfg := storage.DefaultRedisConfig()
+	cfg.Addr = mr.Addr()
+	cfg.AllowInsecureCallbacks = true
+	inner := storage.NewRedisStore(cfg)
+	t.Cleanup(func() { _ = inner.Close() })
+	enforcer := storage.NewTenantEnforcedStore(inner)
+
+	// Seed two tenants' subscriptions using an admin context.
+	admin := tenant.WithAll(context.Background())
+	require.NoError(t, enforcer.Create(admin, &storage.Subscription{
+		ID:       "sub-alice",
+		TenantID: "alice",
+		Callback: "http://example.com/alice",
+	}))
+	require.NoError(t, enforcer.Create(admin, &storage.Subscription{
+		ID:       "sub-bob",
+		TenantID: "bob",
+		Callback: "http://example.com/bob",
+	}))
+
+	// Case 1: a handler stamps tenant correctly via middleware; storage
+	// returns only alice's subscriptions.
+	aliceCtx := tenant.WithID(context.Background(), "alice")
+	got, err := enforcer.List(aliceCtx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "alice", got[0].TenantID)
+
+	// Case 2: a handler "forgets" to filter and calls Get with bob's id from
+	// alice's context. Storage returns ErrSubscriptionNotFound — not the
+	// subscription — even though the handler didn't add any inline check.
+	sub, err := enforcer.Get(aliceCtx, "sub-bob")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, storage.ErrSubscriptionNotFound))
+	assert.Nil(t, sub)
+
+	// Case 3: a handler's ctx has no tenant stamped at all (middleware bug
+	// or test wiring oversight). Storage refuses every operation with
+	// tenant.ErrMissingTenant instead of silently returning data.
+	bareCtx := context.Background()
+	_, err = enforcer.List(bareCtx)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, tenant.ErrMissingTenant))
+
+	_, err = enforcer.Get(bareCtx, "sub-alice")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, tenant.ErrMissingTenant))
+
+	err = enforcer.Delete(bareCtx, "sub-alice")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, tenant.ErrMissingTenant))
+
+	// Case 4: a handler's ctx specifies the wrong tenant. Delete reports
+	// not-found (identical shape to a genuine missing row) so the caller
+	// cannot use response variance to enumerate sibling tenants' ids.
+	wrongCtx := tenant.WithID(context.Background(), "alice")
+	err = enforcer.Delete(wrongCtx, "sub-bob")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, storage.ErrSubscriptionNotFound))
+
+	// Confirm bob's subscription is still intact.
+	bobSub, err := enforcer.Get(admin, "sub-bob")
+	require.NoError(t, err)
+	assert.Equal(t, "bob", bobSub.TenantID)
+}

--- a/internal/storage/tenant_enforced.go
+++ b/internal/storage/tenant_enforced.go
@@ -1,0 +1,216 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/tenant"
+)
+
+// TenantEnforcedStore wraps a Store and enforces tenant isolation at every
+// read/write. The wrapper extracts the tenant identity from ctx (using the
+// internal/tenant package) and:
+//
+//   - rejects Create/Update/Delete with tenant.ErrMissingTenant when ctx
+//     carries no tenant;
+//   - filters Get/List/ListByResourcePool/ListByResourceType by tenant,
+//     returning ErrSubscriptionNotFound for cross-tenant reads so the
+//     caller cannot use response variance as a cross-tenant oracle;
+//   - honors tenant.TenantAll as a platform-admin bypass that skips
+//     tenant filtering (the ONLY supported bypass mechanism).
+//
+// This decorator is a defense-in-depth layer: handlers should still put
+// tenant into ctx via middleware, but if a handler author forgets to add
+// an inline tenant check, the storage layer makes cross-tenant reads
+// physically impossible.
+//
+// TenantEnforcedStore is safe for concurrent use when the underlying
+// Store is safe for concurrent use.
+type TenantEnforcedStore struct {
+	inner Store
+}
+
+// NewTenantEnforcedStore wraps an inner Store so that every operation
+// requires a tenant identity in ctx (or tenant.TenantAll for admin bypass).
+func NewTenantEnforcedStore(inner Store) *TenantEnforcedStore {
+	return &TenantEnforcedStore{inner: inner}
+}
+
+// Inner returns the wrapped Store. Intended for tests and migration code
+// that must bypass enforcement with an explicit platform-admin context.
+func (s *TenantEnforcedStore) Inner() Store {
+	return s.inner
+}
+
+// Create creates a subscription after verifying that the subscription's
+// TenantID is consistent with the tenant in ctx. When ctx carries
+// tenant.TenantAll, the subscription's TenantID is used as-is.
+func (s *TenantEnforcedStore) Create(ctx context.Context, sub *Subscription) error {
+	tid, err := tenant.FromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("storage.Create: %w", err)
+	}
+	if sub == nil {
+		return ErrInvalidID
+	}
+	if !tenant.IsAll(tid) {
+		// Stamp or verify tenant id. Never trust the caller's sub.TenantID
+		// to be correct; overwrite it with the ctx tenant.
+		sub.TenantID = tid
+	} else if sub.TenantID == "" {
+		// Platform-admin create must still carry a tenant id because
+		// subscriptions belong to a tenant at rest.
+		return fmt.Errorf("storage.Create with all-tenants ctx requires explicit TenantID: %w", tenant.ErrMissingTenant)
+	}
+	return s.inner.Create(ctx, sub)
+}
+
+// Get retrieves a subscription only if it belongs to the tenant in ctx
+// (or ctx carries tenant.TenantAll). Cross-tenant reads return
+// ErrSubscriptionNotFound.
+func (s *TenantEnforcedStore) Get(ctx context.Context, id string) (*Subscription, error) {
+	tid, err := tenant.FromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("storage.Get: %w", err)
+	}
+	sub, err := s.inner.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !tenant.IsAll(tid) && sub.TenantID != tid {
+		return nil, ErrSubscriptionNotFound
+	}
+	return sub, nil
+}
+
+// Update updates a subscription only if it belongs to the tenant in ctx
+// (or ctx carries tenant.TenantAll). The caller-supplied sub.TenantID is
+// overwritten with the ctx tenant to prevent a malicious caller from
+// re-homing a subscription into another tenant.
+func (s *TenantEnforcedStore) Update(ctx context.Context, sub *Subscription) error {
+	tid, err := tenant.FromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("storage.Update: %w", err)
+	}
+	if sub == nil {
+		return ErrInvalidID
+	}
+	// Load existing to check ownership.
+	existing, err := s.inner.Get(ctx, sub.ID)
+	if err != nil {
+		return err
+	}
+	if !tenant.IsAll(tid) {
+		if existing.TenantID != tid {
+			return ErrSubscriptionNotFound
+		}
+		sub.TenantID = tid
+	}
+	return s.inner.Update(ctx, sub)
+}
+
+// Delete deletes a subscription only if it belongs to the tenant in ctx
+// (or ctx carries tenant.TenantAll). Cross-tenant deletes return
+// ErrSubscriptionNotFound.
+func (s *TenantEnforcedStore) Delete(ctx context.Context, id string) error {
+	tid, err := tenant.FromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("storage.Delete: %w", err)
+	}
+	if !tenant.IsAll(tid) {
+		existing, gerr := s.inner.Get(ctx, id)
+		if gerr != nil {
+			return gerr
+		}
+		if existing.TenantID != tid {
+			return ErrSubscriptionNotFound
+		}
+	}
+	return s.inner.Delete(ctx, id)
+}
+
+// List returns all subscriptions visible to the tenant in ctx.
+// For a normal tenant it is equivalent to ListByTenant(ctx, tenantID).
+// For tenant.TenantAll it returns everything.
+func (s *TenantEnforcedStore) List(ctx context.Context) ([]*Subscription, error) {
+	tid, err := tenant.FromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("storage.List: %w", err)
+	}
+	if tenant.IsAll(tid) {
+		return s.inner.List(ctx)
+	}
+	return s.inner.ListByTenant(ctx, tid)
+}
+
+// ListByResourcePool returns subscriptions filtered by resource pool and
+// further constrained to the tenant in ctx (or all tenants for
+// tenant.TenantAll).
+func (s *TenantEnforcedStore) ListByResourcePool(ctx context.Context, resourcePoolID string) ([]*Subscription, error) {
+	tid, err := tenant.FromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("storage.ListByResourcePool: %w", err)
+	}
+	subs, err := s.inner.ListByResourcePool(ctx, resourcePoolID)
+	if err != nil {
+		return nil, err
+	}
+	return filterByTenant(subs, tid), nil
+}
+
+// ListByResourceType returns subscriptions filtered by resource type and
+// further constrained to the tenant in ctx (or all tenants for
+// tenant.TenantAll).
+func (s *TenantEnforcedStore) ListByResourceType(ctx context.Context, resourceTypeID string) ([]*Subscription, error) {
+	tid, err := tenant.FromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("storage.ListByResourceType: %w", err)
+	}
+	subs, err := s.inner.ListByResourceType(ctx, resourceTypeID)
+	if err != nil {
+		return nil, err
+	}
+	return filterByTenant(subs, tid), nil
+}
+
+// ListByTenant validates that the ctx tenant matches the requested tenant
+// (or that ctx carries tenant.TenantAll) before delegating.
+func (s *TenantEnforcedStore) ListByTenant(ctx context.Context, tenantID string) ([]*Subscription, error) {
+	tid, err := tenant.FromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("storage.ListByTenant: %w", err)
+	}
+	if !tenant.IsAll(tid) && tid != tenantID {
+		// Refuse cross-tenant listing.
+		return nil, ErrSubscriptionNotFound
+	}
+	return s.inner.ListByTenant(ctx, tenantID)
+}
+
+// Close closes the underlying store.
+func (s *TenantEnforcedStore) Close() error {
+	return s.inner.Close()
+}
+
+// Ping probes the underlying store.
+func (s *TenantEnforcedStore) Ping(ctx context.Context) error {
+	return s.inner.Ping(ctx)
+}
+
+// filterByTenant returns the subset of subs whose TenantID matches tid.
+// When tid is tenant.TenantAll the input is returned unchanged.
+func filterByTenant(subs []*Subscription, tid string) []*Subscription {
+	if tenant.IsAll(tid) {
+		return subs
+	}
+	out := make([]*Subscription, 0, len(subs))
+	for _, sub := range subs {
+		if sub != nil && sub.TenantID == tid {
+			out = append(out, sub)
+		}
+	}
+	return out
+}
+
+// Compile-time check that TenantEnforcedStore satisfies Store.
+var _ Store = (*TenantEnforcedStore)(nil)

--- a/internal/storage/tenant_enforced_test.go
+++ b/internal/storage/tenant_enforced_test.go
@@ -1,0 +1,301 @@
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/storage"
+	"github.com/piwi3910/netweave/internal/tenant"
+)
+
+// newTestEnforcedRedis returns a TenantEnforcedStore backed by miniredis.
+func newTestEnforcedRedis(t *testing.T) *storage.TenantEnforcedStore {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	cfg := storage.DefaultRedisConfig()
+	cfg.Addr = mr.Addr()
+	cfg.AllowInsecureCallbacks = true
+	inner := storage.NewRedisStore(cfg)
+	t.Cleanup(func() { _ = inner.Close() })
+	return storage.NewTenantEnforcedStore(inner)
+}
+
+func seedSub(t *testing.T, store *storage.TenantEnforcedStore, id, tenantID string) {
+	t.Helper()
+	ctx := tenant.WithAll(context.Background())
+	err := store.Create(ctx, &storage.Subscription{
+		ID:       id,
+		TenantID: tenantID,
+		Callback: "http://example.com/cb",
+	})
+	require.NoError(t, err)
+}
+
+func TestTenantEnforcedStore_RejectsMissingTenant(t *testing.T) {
+	t.Parallel()
+
+	store := newTestEnforcedRedis(t)
+	bare := context.Background()
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{"Create", func() error {
+			return store.Create(bare, &storage.Subscription{ID: "x", Callback: "http://e.com/c"})
+		}},
+		{"Get", func() error {
+			_, err := store.Get(bare, "x")
+			return err
+		}},
+		{"Update", func() error {
+			return store.Update(bare, &storage.Subscription{ID: "x", Callback: "http://e.com/c"})
+		}},
+		{"Delete", func() error { return store.Delete(bare, "x") }},
+		{"List", func() error {
+			_, err := store.List(bare)
+			return err
+		}},
+		{"ListByResourcePool", func() error {
+			_, err := store.ListByResourcePool(bare, "p")
+			return err
+		}},
+		{"ListByResourceType", func() error {
+			_, err := store.ListByResourceType(bare, "t")
+			return err
+		}},
+		{"ListByTenant", func() error {
+			_, err := store.ListByTenant(bare, "t1")
+			return err
+		}},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.call()
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, tenant.ErrMissingTenant),
+				"method %s: expected ErrMissingTenant, got %v", tc.name, err)
+		})
+	}
+}
+
+func TestTenantEnforcedStore_GetCrossTenantReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := newTestEnforcedRedis(t)
+	seedSub(t, store, "sub-a", "tenant-a")
+
+	// tenant-b must not see tenant-a's subscription.
+	ctxB := tenant.WithID(context.Background(), "tenant-b")
+	got, err := store.Get(ctxB, "sub-a")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, storage.ErrSubscriptionNotFound))
+	assert.Nil(t, got)
+
+	// Same tenant can read it.
+	ctxA := tenant.WithID(context.Background(), "tenant-a")
+	got, err = store.Get(ctxA, "sub-a")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a", got.TenantID)
+
+	// Platform admin can read it.
+	ctxAll := tenant.WithAll(context.Background())
+	got, err = store.Get(ctxAll, "sub-a")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a", got.TenantID)
+}
+
+func TestTenantEnforcedStore_UpdateCrossTenantReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := newTestEnforcedRedis(t)
+	seedSub(t, store, "sub-a", "tenant-a")
+
+	// tenant-b tries to update tenant-a's subscription.
+	ctxB := tenant.WithID(context.Background(), "tenant-b")
+	err := store.Update(ctxB, &storage.Subscription{
+		ID:       "sub-a",
+		Callback: "http://evil.example.com/pwn",
+		TenantID: "tenant-b", // caller-supplied; must be ignored
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, storage.ErrSubscriptionNotFound))
+
+	// Verify tenant-a's sub was not mutated.
+	ctxAll := tenant.WithAll(context.Background())
+	got, err := store.Get(ctxAll, "sub-a")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a", got.TenantID)
+	assert.Equal(t, "http://example.com/cb", got.Callback)
+}
+
+func TestTenantEnforcedStore_UpdateOverwritesCallerTenantID(t *testing.T) {
+	t.Parallel()
+
+	store := newTestEnforcedRedis(t)
+	seedSub(t, store, "sub-a", "tenant-a")
+
+	// Legit update from tenant-a, but the caller tried to set TenantID to
+	// something else. The decorator must overwrite TenantID with the ctx
+	// tenant so the subscription cannot be re-homed.
+	ctxA := tenant.WithID(context.Background(), "tenant-a")
+	err := store.Update(ctxA, &storage.Subscription{
+		ID:       "sub-a",
+		Callback: "http://example.com/new",
+		TenantID: "tenant-b", // malicious override attempt
+	})
+	require.NoError(t, err)
+
+	ctxAll := tenant.WithAll(context.Background())
+	got, err := store.Get(ctxAll, "sub-a")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a", got.TenantID, "TenantID must not be re-homed")
+	assert.Equal(t, "http://example.com/new", got.Callback)
+}
+
+func TestTenantEnforcedStore_DeleteCrossTenantReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := newTestEnforcedRedis(t)
+	seedSub(t, store, "sub-a", "tenant-a")
+
+	ctxB := tenant.WithID(context.Background(), "tenant-b")
+	err := store.Delete(ctxB, "sub-a")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, storage.ErrSubscriptionNotFound))
+
+	// Sub still exists.
+	ctxAll := tenant.WithAll(context.Background())
+	_, err = store.Get(ctxAll, "sub-a")
+	require.NoError(t, err)
+
+	// tenant-a can delete it.
+	ctxA := tenant.WithID(context.Background(), "tenant-a")
+	err = store.Delete(ctxA, "sub-a")
+	require.NoError(t, err)
+
+	_, err = store.Get(ctxAll, "sub-a")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, storage.ErrSubscriptionNotFound))
+}
+
+func TestTenantEnforcedStore_ListFiltersByTenant(t *testing.T) {
+	t.Parallel()
+
+	store := newTestEnforcedRedis(t)
+	seedSub(t, store, "sub-a1", "tenant-a")
+	seedSub(t, store, "sub-a2", "tenant-a")
+	seedSub(t, store, "sub-b1", "tenant-b")
+
+	ctxA := tenant.WithID(context.Background(), "tenant-a")
+	gotA, err := store.List(ctxA)
+	require.NoError(t, err)
+	assert.Len(t, gotA, 2)
+	for _, s := range gotA {
+		assert.Equal(t, "tenant-a", s.TenantID)
+	}
+
+	ctxB := tenant.WithID(context.Background(), "tenant-b")
+	gotB, err := store.List(ctxB)
+	require.NoError(t, err)
+	assert.Len(t, gotB, 1)
+	assert.Equal(t, "tenant-b", gotB[0].TenantID)
+
+	// Platform admin sees everything.
+	ctxAll := tenant.WithAll(context.Background())
+	gotAll, err := store.List(ctxAll)
+	require.NoError(t, err)
+	assert.Len(t, gotAll, 3)
+}
+
+func TestTenantEnforcedStore_ListByTenantRefusesCrossTenant(t *testing.T) {
+	t.Parallel()
+
+	store := newTestEnforcedRedis(t)
+	seedSub(t, store, "sub-a1", "tenant-a")
+
+	// tenant-b asking for tenant-a's subs is refused, not silently filtered.
+	ctxB := tenant.WithID(context.Background(), "tenant-b")
+	_, err := store.ListByTenant(ctxB, "tenant-a")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, storage.ErrSubscriptionNotFound))
+
+	// Platform admin can ask for any specific tenant.
+	ctxAll := tenant.WithAll(context.Background())
+	got, err := store.ListByTenant(ctxAll, "tenant-a")
+	require.NoError(t, err)
+	assert.Len(t, got, 1)
+}
+
+func TestTenantEnforcedStore_CreateStampsTenant(t *testing.T) {
+	t.Parallel()
+
+	store := newTestEnforcedRedis(t)
+
+	// Caller supplies no TenantID (or wrong one); the decorator stamps it
+	// from ctx.
+	ctxA := tenant.WithID(context.Background(), "tenant-a")
+	err := store.Create(ctxA, &storage.Subscription{
+		ID:       "sub-new",
+		Callback: "http://example.com/cb",
+		TenantID: "tenant-b", // attempted override
+	})
+	require.NoError(t, err)
+
+	ctxAll := tenant.WithAll(context.Background())
+	got, err := store.Get(ctxAll, "sub-new")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a", got.TenantID, "ctx tenant must win over body")
+}
+
+func TestTenantEnforcedStore_CreateAllCtxRequiresExplicitTenant(t *testing.T) {
+	t.Parallel()
+
+	store := newTestEnforcedRedis(t)
+
+	// Platform admin ctx without a TenantID on the subscription is refused:
+	// subscriptions belong to SOME tenant at rest.
+	ctxAll := tenant.WithAll(context.Background())
+	err := store.Create(ctxAll, &storage.Subscription{
+		ID:       "sub-orphan",
+		Callback: "http://example.com/cb",
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, tenant.ErrMissingTenant))
+}
+
+func TestTenantEnforcedStore_ListByResourcePoolFilters(t *testing.T) {
+	t.Parallel()
+
+	store := newTestEnforcedRedis(t)
+	ctxAll := tenant.WithAll(context.Background())
+
+	err := store.Create(ctxAll, &storage.Subscription{
+		ID:       "s1",
+		TenantID: "tenant-a",
+		Callback: "http://example.com/a",
+		Filter:   storage.SubscriptionFilter{ResourcePoolID: "pool-1"},
+	})
+	require.NoError(t, err)
+	err = store.Create(ctxAll, &storage.Subscription{
+		ID:       "s2",
+		TenantID: "tenant-b",
+		Callback: "http://example.com/b",
+		Filter:   storage.SubscriptionFilter{ResourcePoolID: "pool-1"},
+	})
+	require.NoError(t, err)
+
+	ctxA := tenant.WithID(context.Background(), "tenant-a")
+	got, err := store.ListByResourcePool(ctxA, "pool-1")
+	require.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "tenant-a", got[0].TenantID)
+}

--- a/internal/tenant/tenant.go
+++ b/internal/tenant/tenant.go
@@ -1,0 +1,78 @@
+// Package tenant provides context propagation of tenant identity across
+// the request/handler/storage stack.
+//
+// Tenant isolation is a cross-cutting concern: every storage read/write must
+// be scoped to exactly one tenant, or explicitly declared to span all
+// tenants (a platform-admin operation). Handlers that "forget" to filter by
+// tenant are a class of bug that this package and the storage layer's
+// enforcement are designed to make impossible.
+//
+// Usage:
+//
+//	// In middleware after authenticating the caller:
+//	ctx = tenant.WithID(ctx, user.TenantID)
+//	// or, for a platform-admin caller:
+//	ctx = tenant.WithAll(ctx)
+//
+//	// In storage:
+//	tid, err := tenant.FromContext(ctx)
+//	if err != nil {
+//	    return fmt.Errorf("storage: %w", err) // ErrMissingTenant
+//	}
+//	if tenant.IsAll(tid) {
+//	    // platform-admin: skip filter
+//	} else {
+//	    // filter by tid
+//	}
+package tenant
+
+import (
+	"context"
+	"errors"
+)
+
+// TenantAll is the sentinel tenant ID for platform-admin operations that
+// must span every tenant (for example, global audit or cross-tenant listing).
+//
+// It is intentionally not a UUID or empty string so that no real tenant
+// record can ever collide with it, and so that reviewers spot bypass sites
+// when reading code.
+const TenantAll = "*"
+
+// ErrMissingTenant is returned when a storage operation is invoked without
+// a tenant identity in context. This is a programmer error and must be
+// treated as a 500-level failure by callers: it means middleware did not
+// stamp tenant identity before the call reached storage.
+var ErrMissingTenant = errors.New("tenant id required in context")
+
+type ctxKey struct{}
+
+// WithID returns a derived context carrying the given tenant ID.
+// An empty id is rejected by FromContext with ErrMissingTenant.
+func WithID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, ctxKey{}, id)
+}
+
+// WithAll returns a derived context flagged as spanning all tenants.
+// Callers that pass this context to storage bypass tenant filtering.
+// Use ONLY for platform-admin-authenticated requests.
+func WithAll(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKey{}, TenantAll)
+}
+
+// FromContext extracts the tenant ID from ctx. Returns ErrMissingTenant if
+// no tenant has been stamped into the context.
+func FromContext(ctx context.Context) (string, error) {
+	v, ok := ctx.Value(ctxKey{}).(string)
+	if !ok || v == "" {
+		return "", ErrMissingTenant
+	}
+	return v, nil
+}
+
+// IsAll reports whether the given tenant id is the platform-admin bypass
+// sentinel. Storage implementations MUST honor this by skipping tenant
+// filtering.
+func IsAll(id string) bool {
+	return id == TenantAll
+}

--- a/internal/tenant/tenant_test.go
+++ b/internal/tenant/tenant_test.go
@@ -1,0 +1,66 @@
+package tenant_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/tenant"
+)
+
+func TestFromContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ctx     context.Context //nolint:containedctx // test table
+		wantID  string
+		wantErr error
+	}{
+		{
+			name:    "bare context returns ErrMissingTenant",
+			ctx:     context.Background(),
+			wantErr: tenant.ErrMissingTenant,
+		},
+		{
+			name:    "empty tenant id returns ErrMissingTenant",
+			ctx:     tenant.WithID(context.Background(), ""),
+			wantErr: tenant.ErrMissingTenant,
+		},
+		{
+			name:   "WithID carries the tenant id",
+			ctx:    tenant.WithID(context.Background(), "tenant-1"),
+			wantID: "tenant-1",
+		},
+		{
+			name:   "WithAll carries the bypass sentinel",
+			ctx:    tenant.WithAll(context.Background()),
+			wantID: tenant.TenantAll,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tenant.FromContext(tt.ctx)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tt.wantErr))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantID, got)
+		})
+	}
+}
+
+func TestIsAll(t *testing.T) {
+	t.Parallel()
+	assert.True(t, tenant.IsAll(tenant.TenantAll))
+	assert.False(t, tenant.IsAll(""))
+	assert.False(t, tenant.IsAll("tenant-1"))
+}


### PR DESCRIPTION
## Summary

Moves tenant-isolation enforcement from handler convention to the storage boundary. Handlers that forget an inline `if sub.TenantID != tenantID` check can no longer leak cross-tenant data: every `storage.Store` call now requires a tenant identity in `context.Context`, filters reads by that tenant, and refuses cross-tenant writes.

Closes #482.

## Design

- **`internal/tenant`** (new package)
  - `WithID(ctx, id)` / `WithAll(ctx)` stamp tenant identity into `context.Context`.
  - `FromContext(ctx)` returns `ErrMissingTenant` when nothing is stamped.
  - `TenantAll = "*"` is the **only** bypass sentinel — loud name so reviewers spot it.

- **`storage.TenantEnforcedStore`** (new decorator around `storage.Store`)
  - Refuses any call without a tenant in ctx (`ErrMissingTenant`).
  - `Get` / `Delete` / `Update` load the row and return `ErrSubscriptionNotFound` on a tenant mismatch — identical shape to a genuine miss, so response variance cannot be used as a cross-tenant ID oracle.
  - `Create` / `Update` **overwrite** any caller-supplied `Subscription.TenantID` with the ctx tenant, preventing a malicious caller from re-homing a subscription.
  - `List` routes to `ListByTenant` (uses the native index) for regular tenants, and to `List` for platform admins.
  - `ListByResourcePool` / `ListByResourceType` post-filter by tenant.
  - `TenantAll` skips filtering — the single supported platform-admin bypass.

- **`internal/auth/middleware`**
  - Authentication now stamps `tenant.WithID` or `tenant.WithAll` into ctx immediately after verifying the caller. Platform admins get `WithAll`; everyone else is scoped to their own tenant. This is the single stamping site.

- **`cmd/gateway/main.go` + `internal/config.SecurityConfig`**
  - New flag `security.tenant_isolation_enforced` (default **true**). Wraps the selected subscription store (`redis` / `postgres` / `dual`) with `TenantEnforcedStore`.
  - When disabled, the gateway logs a loud `WARN` line. Intended solely for one-off legacy-data migrations.

## Store methods now tenant-enforced

Every method on `storage.Store`:

- `Create(ctx, sub)`
- `Get(ctx, id)`
- `Update(ctx, sub)`
- `Delete(ctx, id)`
- `List(ctx)`
- `ListByResourcePool(ctx, poolID)`
- `ListByResourceType(ctx, typeID)`
- `ListByTenant(ctx, tenantID)`

All four concrete implementations (`RedisStore`, `PostgresStore`, `DualStore`, and any future `Store`) get enforcement automatically because the decorator wraps the interface, not a specific impl.

## Feature flag / migration note

- Redis keys were **not** re-shaped to embed tenant. Doing so would have required either silently dropping existing keys or shipping an ops-level migration tool. Enforcement is achieved via the decorator reading `sub.TenantID` and the existing `subscriptions:tenant:<id>` index.
- For legacy deployments with subscriptions created before tenant-aware code landed (empty `TenantID`), operators can temporarily set `security.tenant_isolation_enforced=false` while backfilling, then re-enable. The warning log makes the risk explicit.
- Postgres already has the `idx_subscriptions_tenant_id` index; no new migration is required.

## Tests

- `internal/tenant/tenant_test.go` — context plumbing, sentinel behavior.
- `internal/storage/tenant_enforced_test.go` — table-driven: every `Store` method, allow-path and deny-path (missing tenant, cross-tenant read/update/delete/list, caller-side `TenantID` override attempt, platform-admin bypass).
- `internal/server/tenant_storage_boundary_test.go` — architectural test: simulates a handler that "forgets" to filter and asserts the storage layer returns `ErrSubscriptionNotFound` / `ErrMissingTenant` rather than leaking data.

## Test plan

- [x] `go test -race ./internal/tenant/ ./internal/storage/ ./internal/server/ ./internal/config/`
- [x] `go build ./...`
- [x] `golangci-lint run ./internal/tenant/ ./internal/storage/ ./internal/server/ ./internal/auth/ ./internal/config/ ./cmd/gateway/` — no new warnings attributable to this change
- [ ] CI pipeline green