### PR TITLE
[Fix] C1: Wire adapter init() registrations so cloud/DMS/SMO adapters are reachable

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -308,6 +308,9 @@ linters:
           - gochecknoinits
         path: internal/backend/adapter_factory\.go
       - linters:
+          - gochecknoinits
+        path: internal/(adapters|dms/adapters|smo/adapters)/[^/]+/register\.go
+      - linters:
           - revive
         path: internal/adapters/
         text: unused-parameter.*ctx

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -51,12 +51,32 @@ import (
 	"github.com/piwi3910/netweave/internal/database"
 	"github.com/piwi3910/netweave/internal/dms/adapters/helm"
 	dmsmock "github.com/piwi3910/netweave/internal/dms/adapters/mock"
+
+	// Blank imports: each adapter package registers itself with the backend
+	// factory in its init() function. Without these imports the factory cannot
+	// resolve adapter_type strings like "aws" at runtime (see issue #464).
+	_ "github.com/piwi3910/netweave/internal/adapters/aws"
+	_ "github.com/piwi3910/netweave/internal/adapters/azure"
+	_ "github.com/piwi3910/netweave/internal/adapters/dtias"
+	_ "github.com/piwi3910/netweave/internal/adapters/gcp"
+	_ "github.com/piwi3910/netweave/internal/adapters/kubernetes"
+	_ "github.com/piwi3910/netweave/internal/adapters/openstack"
+	_ "github.com/piwi3910/netweave/internal/adapters/starlingx"
+	_ "github.com/piwi3910/netweave/internal/adapters/vmware"
+	_ "github.com/piwi3910/netweave/internal/dms/adapters/argocd"
+	_ "github.com/piwi3910/netweave/internal/dms/adapters/crossplane"
+	_ "github.com/piwi3910/netweave/internal/dms/adapters/flux"
+	_ "github.com/piwi3910/netweave/internal/dms/adapters/kustomize"
+	_ "github.com/piwi3910/netweave/internal/dms/adapters/onaplcm"
+	_ "github.com/piwi3910/netweave/internal/dms/adapters/osmlcm"
 	dmsregistry "github.com/piwi3910/netweave/internal/dms/registry"
 	"github.com/piwi3910/netweave/internal/encryption"
 	"github.com/piwi3910/netweave/internal/handlers"
 	"github.com/piwi3910/netweave/internal/keycloak"
 	"github.com/piwi3910/netweave/internal/observability"
 	"github.com/piwi3910/netweave/internal/server"
+	_ "github.com/piwi3910/netweave/internal/smo/adapters/onap"
+	_ "github.com/piwi3910/netweave/internal/smo/adapters/osm"
 	"github.com/piwi3910/netweave/internal/storage"
 	vaultpkg "github.com/piwi3910/netweave/internal/vault"
 )

--- a/internal/adapters/aws/register.go
+++ b/internal/adapters/aws/register.go
@@ -1,0 +1,27 @@
+package aws
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/adapter"
+	"github.com/piwi3910/netweave/internal/backend"
+)
+
+// init registers the AWS IMS adapter constructor with the backend factory.
+// The constructor JSON-decodes backend.Instance.Config into aws.Config and
+// falls back to the instance ID for the OCloudID when unspecified.
+func init() {
+	backend.RegisterIMSAdapter("aws", func(inst *backend.Instance) (adapter.Adapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("aws adapter config: %w", err)
+			}
+		}
+		if cfg.OCloudID == "" {
+			cfg.OCloudID = inst.ID
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/adapters/azure/register.go
+++ b/internal/adapters/azure/register.go
@@ -1,0 +1,27 @@
+package azure
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/adapter"
+	"github.com/piwi3910/netweave/internal/backend"
+)
+
+// init registers the Azure IMS adapter constructor with the backend factory.
+// The constructor JSON-decodes backend.Instance.Config into azure.Config and
+// falls back to the instance ID for the OCloudID when unspecified.
+func init() {
+	backend.RegisterIMSAdapter("azure", func(inst *backend.Instance) (adapter.Adapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("azure adapter config: %w", err)
+			}
+		}
+		if cfg.OCloudID == "" {
+			cfg.OCloudID = inst.ID
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/adapters/dtias/register.go
+++ b/internal/adapters/dtias/register.go
@@ -1,0 +1,27 @@
+package dtias
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/adapter"
+	"github.com/piwi3910/netweave/internal/backend"
+)
+
+// init registers the DTIAS IMS adapter constructor with the backend factory.
+// The constructor JSON-decodes backend.Instance.Config into dtias.Config and
+// falls back to the instance ID for the OCloudID when unspecified.
+func init() {
+	backend.RegisterIMSAdapter("dtias", func(inst *backend.Instance) (adapter.Adapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("dtias adapter config: %w", err)
+			}
+		}
+		if cfg.OCloudID == "" {
+			cfg.OCloudID = inst.ID
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/adapters/gcp/register.go
+++ b/internal/adapters/gcp/register.go
@@ -1,0 +1,27 @@
+package gcp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/adapter"
+	"github.com/piwi3910/netweave/internal/backend"
+)
+
+// init registers the GCP IMS adapter constructor with the backend factory.
+// The constructor JSON-decodes backend.Instance.Config into gcp.Config and
+// falls back to the instance ID for the OCloudID when unspecified.
+func init() {
+	backend.RegisterIMSAdapter("gcp", func(inst *backend.Instance) (adapter.Adapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("gcp adapter config: %w", err)
+			}
+		}
+		if cfg.OCloudID == "" {
+			cfg.OCloudID = inst.ID
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/adapters/kubernetes/register.go
+++ b/internal/adapters/kubernetes/register.go
@@ -1,0 +1,32 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/adapter"
+	"github.com/piwi3910/netweave/internal/backend"
+)
+
+// init registers the Kubernetes IMS adapter constructor with the backend factory.
+// The constructor JSON-decodes backend.Instance.Config into kubernetes.Config and
+// falls back to the instance ID for the OCloudID when unspecified. The Store
+// field cannot be carried in Instance.Config JSON; callers that need subscriptions
+// must inject it post-construction.
+func init() {
+	backend.RegisterIMSAdapter("kubernetes", func(inst *backend.Instance) (adapter.Adapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("kubernetes adapter config: %w", err)
+			}
+		}
+		if cfg.OCloudID == "" {
+			cfg.OCloudID = inst.ID
+		}
+		if cfg.DeploymentManagerID == "" {
+			cfg.DeploymentManagerID = inst.ID
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/adapters/openstack/register.go
+++ b/internal/adapters/openstack/register.go
@@ -1,0 +1,27 @@
+package openstack
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/adapter"
+	"github.com/piwi3910/netweave/internal/backend"
+)
+
+// init registers the OpenStack IMS adapter constructor with the backend factory.
+// The constructor JSON-decodes backend.Instance.Config into openstack.Config and
+// falls back to the instance ID for the OCloudID when unspecified.
+func init() {
+	backend.RegisterIMSAdapter("openstack", func(inst *backend.Instance) (adapter.Adapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("openstack adapter config: %w", err)
+			}
+		}
+		if cfg.OCloudID == "" {
+			cfg.OCloudID = inst.ID
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/adapters/starlingx/register.go
+++ b/internal/adapters/starlingx/register.go
@@ -1,0 +1,32 @@
+package starlingx
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/adapter"
+	"github.com/piwi3910/netweave/internal/backend"
+)
+
+// init registers the StarlingX IMS adapter constructor with the backend factory.
+// The constructor JSON-decodes backend.Instance.Config into starlingx.Config and
+// falls back to the instance ID for the OCloudID when unspecified. The
+// subscription Store cannot be carried in the Instance.Config JSON and must be
+// injected post-construction if subscription features are desired.
+func init() {
+	backend.RegisterIMSAdapter("starlingx", func(inst *backend.Instance) (adapter.Adapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("starlingx adapter config: %w", err)
+			}
+		}
+		if cfg.OCloudID == "" {
+			cfg.OCloudID = inst.ID
+		}
+		if cfg.DeploymentManagerID == "" {
+			cfg.DeploymentManagerID = inst.ID
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/adapters/vmware/register.go
+++ b/internal/adapters/vmware/register.go
@@ -1,0 +1,27 @@
+package vmware
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/adapter"
+	"github.com/piwi3910/netweave/internal/backend"
+)
+
+// init registers the VMware IMS adapter constructor with the backend factory.
+// The constructor JSON-decodes backend.Instance.Config into vmware.Config and
+// falls back to the instance ID for the OCloudID when unspecified.
+func init() {
+	backend.RegisterIMSAdapter("vmware", func(inst *backend.Instance) (adapter.Adapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("vmware adapter config: %w", err)
+			}
+		}
+		if cfg.OCloudID == "" {
+			cfg.OCloudID = inst.ID
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/backend/factory_registration_test.go
+++ b/internal/backend/factory_registration_test.go
@@ -1,0 +1,105 @@
+package backend_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/piwi3910/netweave/internal/backend"
+
+	// Blank imports: mirror the set pulled in by cmd/gateway/main.go so that
+	// each adapter package's init() runs and registers itself with the
+	// backend factory. This test asserts that wiring is in place.
+	_ "github.com/piwi3910/netweave/internal/adapters/aws"
+	_ "github.com/piwi3910/netweave/internal/adapters/azure"
+	_ "github.com/piwi3910/netweave/internal/adapters/dtias"
+	_ "github.com/piwi3910/netweave/internal/adapters/gcp"
+	_ "github.com/piwi3910/netweave/internal/adapters/kubernetes"
+	_ "github.com/piwi3910/netweave/internal/adapters/openstack"
+	_ "github.com/piwi3910/netweave/internal/adapters/starlingx"
+	_ "github.com/piwi3910/netweave/internal/adapters/vmware"
+	_ "github.com/piwi3910/netweave/internal/dms/adapters/argocd"
+	_ "github.com/piwi3910/netweave/internal/dms/adapters/crossplane"
+	_ "github.com/piwi3910/netweave/internal/dms/adapters/flux"
+	_ "github.com/piwi3910/netweave/internal/dms/adapters/kustomize"
+	_ "github.com/piwi3910/netweave/internal/dms/adapters/onaplcm"
+	_ "github.com/piwi3910/netweave/internal/dms/adapters/osmlcm"
+	_ "github.com/piwi3910/netweave/internal/smo/adapters/onap"
+	_ "github.com/piwi3910/netweave/internal/smo/adapters/osm"
+)
+
+// TestIMSAdapterTypesResolveConstructors ensures every expected IMS adapter
+// type string is registered with the backend factory via init().
+func TestIMSAdapterTypesResolveConstructors(t *testing.T) {
+	factory := backend.NewAdapterFactory()
+	types := []string{"aws", "azure", "gcp", "dtias", "openstack", "vmware", "starlingx", "kubernetes", "mock"}
+
+	for _, adapterType := range types {
+		t.Run(adapterType, func(t *testing.T) {
+			inst := &backend.Instance{
+				ID:          "backend-" + adapterType,
+				Name:        adapterType + "-test",
+				AdapterType: adapterType,
+				Category:    "ims",
+			}
+
+			// We only verify the type string resolves to a registered
+			// constructor — not that construction itself succeeds with
+			// zero-valued config. ErrUnsupportedAdapterType would indicate
+			// missing registration.
+			_, err := factory.CreateAdapter(inst)
+			if err != nil {
+				require.NotErrorIs(t, err, backend.ErrUnsupportedAdapterType,
+					"IMS adapter type %q is not registered", adapterType)
+			}
+		})
+	}
+}
+
+// TestDMSAdapterTypesResolveConstructors ensures every expected DMS adapter
+// type string is registered with the backend factory via init().
+func TestDMSAdapterTypesResolveConstructors(t *testing.T) {
+	factory := backend.NewAdapterFactory()
+	types := []string{"argocd", "crossplane", "flux", "kustomize", "onaplcm", "osmlcm", "mock-dms"}
+
+	for _, adapterType := range types {
+		t.Run(adapterType, func(t *testing.T) {
+			inst := &backend.Instance{
+				ID:          "backend-" + adapterType,
+				Name:        adapterType + "-test",
+				AdapterType: adapterType,
+				Category:    "dms",
+			}
+
+			_, err := factory.CreateDMSAdapter(inst)
+			if err != nil {
+				require.NotErrorIs(t, err, backend.ErrUnsupportedAdapterType,
+					"DMS adapter type %q is not registered", adapterType)
+			}
+		})
+	}
+}
+
+// TestSMOAdapterTypesResolveConstructors ensures every expected SMO plugin
+// type string is registered with the backend factory via init().
+func TestSMOAdapterTypesResolveConstructors(t *testing.T) {
+	factory := backend.NewAdapterFactory()
+	types := []string{"onap", "osm", "mock-smo"}
+
+	for _, adapterType := range types {
+		t.Run(adapterType, func(t *testing.T) {
+			inst := &backend.Instance{
+				ID:          "backend-" + adapterType,
+				Name:        adapterType + "-test",
+				AdapterType: adapterType,
+				Category:    "smo",
+			}
+
+			_, err := factory.CreateSMOAdapter(inst)
+			if err != nil {
+				require.NotErrorIs(t, err, backend.ErrUnsupportedAdapterType,
+					"SMO adapter type %q is not registered", adapterType)
+			}
+		})
+	}
+}

--- a/internal/dms/adapters/argocd/register.go
+++ b/internal/dms/adapters/argocd/register.go
@@ -1,0 +1,22 @@
+package argocd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/backend"
+	dmsadapter "github.com/piwi3910/netweave/internal/dms/adapter"
+)
+
+// init registers the ArgoCD DMS adapter constructor with the backend factory.
+func init() {
+	backend.RegisterDMSAdapter("argocd", func(inst *backend.Instance) (dmsadapter.DMSAdapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("argocd adapter config: %w", err)
+			}
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/dms/adapters/crossplane/register.go
+++ b/internal/dms/adapters/crossplane/register.go
@@ -1,0 +1,22 @@
+package crossplane
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/backend"
+	dmsadapter "github.com/piwi3910/netweave/internal/dms/adapter"
+)
+
+// init registers the Crossplane DMS adapter constructor with the backend factory.
+func init() {
+	backend.RegisterDMSAdapter("crossplane", func(inst *backend.Instance) (dmsadapter.DMSAdapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("crossplane adapter config: %w", err)
+			}
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/dms/adapters/flux/register.go
+++ b/internal/dms/adapters/flux/register.go
@@ -1,0 +1,22 @@
+package flux
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/backend"
+	dmsadapter "github.com/piwi3910/netweave/internal/dms/adapter"
+)
+
+// init registers the Flux DMS adapter constructor with the backend factory.
+func init() {
+	backend.RegisterDMSAdapter("flux", func(inst *backend.Instance) (dmsadapter.DMSAdapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("flux adapter config: %w", err)
+			}
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/dms/adapters/kustomize/register.go
+++ b/internal/dms/adapters/kustomize/register.go
@@ -1,0 +1,22 @@
+package kustomize
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/backend"
+	dmsadapter "github.com/piwi3910/netweave/internal/dms/adapter"
+)
+
+// init registers the Kustomize DMS adapter constructor with the backend factory.
+func init() {
+	backend.RegisterDMSAdapter("kustomize", func(inst *backend.Instance) (dmsadapter.DMSAdapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("kustomize adapter config: %w", err)
+			}
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/dms/adapters/onaplcm/register.go
+++ b/internal/dms/adapters/onaplcm/register.go
@@ -1,0 +1,22 @@
+package onaplcm
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/backend"
+	dmsadapter "github.com/piwi3910/netweave/internal/dms/adapter"
+)
+
+// init registers the ONAP-LCM DMS adapter constructor with the backend factory.
+func init() {
+	backend.RegisterDMSAdapter("onaplcm", func(inst *backend.Instance) (dmsadapter.DMSAdapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("onaplcm adapter config: %w", err)
+			}
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/dms/adapters/osmlcm/register.go
+++ b/internal/dms/adapters/osmlcm/register.go
@@ -1,0 +1,22 @@
+package osmlcm
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/backend"
+	dmsadapter "github.com/piwi3910/netweave/internal/dms/adapter"
+)
+
+// init registers the OSM-LCM DMS adapter constructor with the backend factory.
+func init() {
+	backend.RegisterDMSAdapter("osmlcm", func(inst *backend.Instance) (dmsadapter.DMSAdapter, error) {
+		var cfg Config
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, &cfg); err != nil {
+				return nil, fmt.Errorf("osmlcm adapter config: %w", err)
+			}
+		}
+		return New(&cfg)
+	})
+}

--- a/internal/smo/adapters/onap/register.go
+++ b/internal/smo/adapters/onap/register.go
@@ -1,0 +1,22 @@
+package onap
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/backend"
+	"github.com/piwi3910/netweave/internal/smo"
+)
+
+// init registers the ONAP SMO plugin constructor with the backend factory.
+func init() {
+	backend.RegisterSMOAdapter("onap", func(inst *backend.Instance) (smo.Plugin, error) {
+		cfg := DefaultConfig()
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, cfg); err != nil {
+				return nil, fmt.Errorf("onap plugin config: %w", err)
+			}
+		}
+		return New(cfg)
+	})
+}

--- a/internal/smo/adapters/osm/register.go
+++ b/internal/smo/adapters/osm/register.go
@@ -1,0 +1,26 @@
+package osm
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/piwi3910/netweave/internal/backend"
+	"github.com/piwi3910/netweave/internal/smo"
+)
+
+// init registers the OSM SMO plugin constructor with the backend factory.
+func init() {
+	backend.RegisterSMOAdapter("osm", func(inst *backend.Instance) (smo.Plugin, error) {
+		cfg := DefaultConfig()
+		if len(inst.Config) > 0 {
+			if err := json.Unmarshal(inst.Config, cfg); err != nil {
+				return nil, fmt.Errorf("osm plugin config: %w", err)
+			}
+		}
+		plugin, err := New(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return NewSMOPluginAdapter(plugin), nil
+	})
+}


### PR DESCRIPTION
## Summary

Wires every cloud/DMS/SMO adapter package to self-register with the backend factory at init time. Before this change, the registry added in PR #555 only had constructors for the mock adapters, so any backend instance with `adapter_type=aws` (or azure, gcp, dtias, openstack, vmware, starlingx, kubernetes, argocd, crossplane, flux, kustomize, onaplcm, osmlcm, onap, osm) failed with `unsupported adapter type`.

- Added a `register.go` to each adapter package whose `init()` calls the appropriate `backend.Register*Adapter(type, ctor)`.
- Each constructor JSON-decodes `Instance.Config` into the adapter's `Config` struct and falls back to `Instance.ID` for `OCloudID` / `DeploymentManagerID` when unspecified.
- Added blank imports to `cmd/gateway/main.go` so the init() functions run.
- Added `.golangci.yml` exclusion for `gochecknoinits` on the new `register.go` files, mirroring the existing exclusion for `internal/backend/adapter_factory.go`.
- Added `internal/backend/factory_registration_test.go` asserting every expected type string resolves to a registered constructor.

Closes #464

## Test plan

- [x] `go test ./internal/backend/... -run TestIMSAdapterTypesResolveConstructors`
- [x] `go test ./internal/backend/... -run TestDMSAdapterTypesResolveConstructors`
- [x] `go test ./internal/backend/... -run TestSMOAdapterTypesResolveConstructors`
- [x] `go build ./cmd/gateway/` produces a working binary
- [x] No new `golangci-lint` warnings on the new files