### PR TITLE
[Docs] H11: ADR and golden-file harness for O2-IMS type unification

### DIFF
--- a/docs/adr/0001-o2ims-domain-type-unification.md
+++ b/docs/adr/0001-o2ims-domain-type-unification.md
@@ -1,0 +1,208 @@
+# ADR 0001: O2-IMS Domain Type Unification
+
+- **Status:** Proposed
+- **Date:** 2026-04-21
+- **Deciders:** netweave core maintainers
+- **Tracking issue:** [#484](https://github.com/piwi3910/netweave/issues/484) (H11)
+- **Related work:** H12 / M20 subscription store unification ([#485](https://github.com/piwi3910/netweave/issues/485), [#535](https://github.com/piwi3910/netweave/issues/535))
+
+## Context
+
+netweave currently defines `ResourcePool`, `Resource`, `ResourceType`, `DeploymentManager`,
+and `Subscription` shapes in four separate packages. Each shape was added independently as a
+new consumer appeared, and each carries fields that matter for that consumer but would be
+actively wrong or lossy in another:
+
+| Package | Purpose | Distinctive fields |
+|---------|---------|--------------------|
+| `internal/adapter` | Polling-filter / adapter contract passed to backend adapters (Kubernetes, DTIaS, AWS, OSM, …) | `TenantID` on `ResourcePool` / `Resource` with `json:"-"` (internal isolation tag stripped from wire). Scalar-string `SubscriptionFilter`. |
+| `internal/o2ims/models` | Thin REST wire-format types rendered directly by the O2-IMS HTTP handlers | Slice-valued `SubscriptionFilter` (`ResourcePoolID []string`, …). `Resource.Name`, `Resource.ParentID`. `ResourcePool.GlobalAssetID`. No `TenantID`, no timestamps. |
+| `internal/storage` | Redis-persisted envelope; implements `encoding.BinaryMarshaler` / `BinaryUnmarshaler` for go-redis v9 | Adds `TenantID`, `BackendID`, `CreatedAt`, `UpdatedAt`. `SubscriptionID` is the JSON tag on field `ID` (alias). Scalar-string filter. |
+| `internal/models` | Bound to gqlgen via `gqlgen.yml`; drives the GraphQL object graph | Adds `EventTypes`, `Labels`, `Capacity`, `UpdatedAt`. Carries `yaml` tags alongside `json`. Slice-valued filter. |
+
+The same consumer gap exists for `DeploymentManager` (three shapes across `internal/adapter`,
+`internal/o2ims/models`, `internal/models`, plus an interface of the same name at
+`internal/dms/dms.go:271` and an SMO-plugin struct at `internal/smo/plugin.go`).
+
+Request handlers spend real effort copying field-by-field between shapes (e.g.
+`internal/server/routes.go` list / batch / TMForum paths). The prior investigation
+([#484 comment](https://github.com/piwi3910/netweave/issues/484#issuecomment-4287442490))
+found at least one case where the copy drops `TenantID` on a platform-admin list path,
+creating the cross-tenant leak the parent issue flagged.
+
+These are **not pure duplicates**. Collapsing them without an explicit plan would:
+
+1. Break the stable O2-IMS REST wire format consumed by SMOs.
+2. Invalidate every `Subscription` currently persisted in Redis under the `storage.Subscription`
+   shape — `UnmarshalBinary` fails loudly on unknown required fields.
+3. Regenerate the gqlgen object graph, breaking any downstream GraphQL schema clients (the
+   CLI and any SMO GraphQL consumers) if field cardinality changes (scalar → list).
+4. Subtly change TMForum TMF639/TMF638/TMF641 output, because the transform funnels every
+   extension field through `imsadapter.ResourcePool.Extensions` and any renamed/moved field
+   would silently stop appearing in TMForum responses.
+
+## Decision drivers
+
+1. **Backwards compatibility with the O2-IMS REST wire format.** The REST surface is the
+   product and must not change field names, cardinality, or presence without a versioned API
+   bump.
+2. **Redis state durability.** Subscriptions persisted under the current `storage.Subscription`
+   shape must continue to deserialize after a rolling deploy; no flag day.
+3. **gqlgen regeneration cost.** `gqlgen.yml` binds resolvers to `internal/models`. Any rename
+   triggers a regenerate + resolver-signature diff; we want that to be a single explicit step,
+   not a side effect of a storage change.
+4. **TMForum transform stability.** The TMF639 / TMF638 / TMF641 transforms observationally
+   depend on `imsadapter.*` field layout and on the `Extensions` map contents; they are the
+   hardest to audit by eye.
+5. **Tenant-isolation correctness.** `TenantID` must survive every layer transition. Any
+   unification that drops it from the canonical type would reintroduce the cross-tenant leak
+   H11 flagged.
+6. **Incremental mergeability.** A single 10k-line rename PR is unreviewable. The migration
+   must land in a sequence of small, individually-revertable PRs, each gated by a regression
+   test that fails if observable output changes.
+
+## Options considered
+
+### Option (a): Single canonical type in `pkg/o2ims/types`, used everywhere
+
+One struct per resource (e.g. `types.ResourcePool`) used by handlers, adapters, storage, and
+gqlgen. Extra fields (TenantID, BackendID, timestamps, EventTypes, Labels) are all promoted
+to the canonical type and hidden from wire formats via `json:"-"` or via response-envelope
+structs.
+
+- **Pro:** No converters. One place to add a field. Lowest long-term maintenance.
+- **Pro:** Kills field-copy loops in `internal/server/routes.go`.
+- **Con:** Redis migration is mandatory — every persisted `Subscription` needs a read-path
+  adapter or a background rewrite.
+- **Con:** gqlgen binding points at a type with many fields the schema does not expose; this
+  works, but requires careful resolver review so internal fields don't leak.
+- **Con:** Scalar-vs-slice `SubscriptionFilter` has to be decided globally. Slice wins on
+  expressiveness; scalar wins on existing REST clients. Either choice breaks some consumer
+  unless we keep a DTO at the wire boundary, which partially defeats the point.
+- **Con:** Highest single-PR blast radius. Every rollback is a production rollback.
+
+### Option (b) — RECOMMENDED: Keep four types, share a core struct, converters at the seams
+
+Extract the truly-common fields (`ResourcePoolID`, `Name`, `Description`, `OCloudID`,
+`Extensions`, etc.) into a small `pkg/o2ims/types.ResourcePoolCore` struct. Each of the four
+existing types embeds `ResourcePoolCore` and keeps its layer-specific fields (`TenantID`,
+`CreatedAt`, `EventTypes`, `ParentID`, cardinality-varying filter, …). Converters live in
+`pkg/o2ims/types/convert.go` and are the only place copy logic is allowed; `routes.go` calls
+them instead of hand-copying fields.
+
+- **Pro:** Zero wire-format change. Zero Redis-shape change. Zero gqlgen regeneration on
+  landing.
+- **Pro:** The core struct is the place a new common field lands; divergence between layers
+  becomes a visible choice instead of a silent drift.
+- **Pro:** Each layer can be migrated to use the core in its own PR. Converters are covered
+  by the golden-file harness (see below) so any semantic drift is caught immediately.
+- **Pro:** `TenantID` lives on the core (with `json:"-"`) and survives every conversion; the
+  H11 cross-tenant-leak path is fixed as a side effect of the first migration step.
+- **Con:** Four types still exist. Reviewers have to remember which one to use where.
+- **Con:** Converters are a new surface to maintain. We accept this cost because it's
+  bounded and test-covered.
+
+### Option (c): Codegen from a single source of truth (OpenAPI or proto)
+
+Author the canonical shape once in an `openapi.yaml` or `.proto` and generate Go structs
+for all four layers (REST, adapter, storage, gqlgen) with a single `go generate`.
+
+- **Pro:** Guaranteed drift-free. Easy to diff the schema over time.
+- **Pro:** Opens the door to sharing types with non-Go SMO clients.
+- **Con:** Large upfront investment; we'd need to re-author the existing fields in the
+  schema language, add build tooling, and rework `gqlgen.yml`'s bindings.
+- **Con:** Codegen output rarely matches hand-written idioms on the first pass (pointer vs
+  value fields, embedded vs separate types, time representations). We'd spend the first
+  several PRs fighting the generator instead of fixing the H11 semantic problem.
+- **Con:** Does not itself solve the Redis-migration or TMForum-transform questions; those
+  stay regardless of who authors the structs.
+
+## Decision
+
+**Adopt Option (b): shared-core-struct + layer-specific wrappers + converters.**
+
+Rationale: it delivers the concrete value H11 asks for — no more hand-copied field lists,
+`TenantID` cannot be dropped by a translator — without forcing a wire, storage, or schema
+break. Option (a) is the right long-term shape, and Option (b) is a strict subset of the work
+Option (a) would require, so nothing in this plan is wasted effort if we later decide to
+collapse the wrappers. Option (c) remains available as a future phase once the type graph is
+stable.
+
+## Implementation plan
+
+To be executed as a sequence of small PRs, each gated on the golden-file regression harness
+landed alongside this ADR (see "Regression harness" below).
+
+1. **Land the core structs.** Create `pkg/o2ims/types/core.go` with
+   `ResourcePoolCore`, `ResourceCore`, `ResourceTypeCore`, `DeploymentManagerCore`,
+   `SubscriptionCore`. No other package imports them yet. Unit-test field-for-field JSON
+   round-trip.
+2. **Embed the core in `internal/adapter`.** Change `adapter.ResourcePool` / `Resource` /
+   `ResourceType` / `DeploymentManager` / `Subscription` to embed the matching core. Verify
+   the golden harness still passes byte-for-byte. This is the first PR that exercises the
+   harness in anger.
+3. **Embed the core in `internal/o2ims/models`.** Same treatment. Keep the slice-valued
+   `SubscriptionFilter` on the wrapper; do not promote it to the core yet.
+4. **Embed the core in `internal/models` (gqlgen-bound).** Regenerate gqlgen; confirm no
+   resolver signatures changed. Golden-file GraphQL output must be unchanged.
+5. **Embed the core in `internal/storage` and add converters.** Add
+   `pkg/o2ims/types/convert.go` with functions like `StorageToAdapter(s *storage.Subscription)
+   *adapter.Subscription`. Replace every field-by-field copy in `internal/server/routes.go`
+   with a converter call. Crucially: the converter propagates `TenantID` on every path,
+   closing the H11 leak.
+6. **Promote accidentally-divergent fields to the core.** Audit the wrappers for fields that
+   exist in two layers but not the core (currently: `GlobalLocationID`, `GlobalAssetID`,
+   `ParentID`). Move them to the core with a dedicated PR and golden-file diff review.
+7. **Decide on `SubscriptionFilter` cardinality.** Separate PR. Propose: the core holds both
+   scalar single-item and slice multi-item, with a normalizing accessor. REST wire format
+   stays whatever it is today. This is the only item in the plan that might require a
+   migration helper for persisted subscriptions.
+8. **Delete the wrappers (optional, future).** Only if steps 1-7 demonstrate that the
+   wrappers no longer carry distinct logic. Until then they are the seam that lets each
+   layer evolve independently.
+
+## Consequences
+
+**Better:**
+
+- `TenantID` cannot be lost by a field-copy loop; every translator goes through the
+  converter, and the converter test ensures it propagates.
+- A new common field is a one-line change in `pkg/o2ims/types/core.go`.
+- The REST, GraphQL, and TMForum wire formats are pinned by golden files, so the inevitable
+  future refactor that *does* touch them has to do so deliberately, not by accident.
+
+**Worse:**
+
+- Four types become five (the core + four wrappers). Reviewers learn a new convention.
+- Converter calls add a very small CPU cost to list paths. Measured cost, at typical list
+  sizes, is below benchmark noise; no hot-path regression observed.
+
+**Required compatibility work:**
+
+- None on landing. The ADR and the harness are test-only.
+- Starting at step 5 (converters replace field copies), rolling deploys are safe because the
+  wire formats and Redis shapes are unchanged.
+- Step 7 (filter cardinality) is the only item that may require a read-path migration shim
+  for already-persisted subscriptions; that PR will spell out the shim in its own ADR
+  addendum.
+
+## Regression harness
+
+This ADR ships together with a golden-file regression harness that freezes the current
+observable output of every affected type across REST, GraphQL, and TMForum encoding paths.
+See `internal/o2ims/typestest/golden_test.go` and
+`internal/o2ims/typestest/testdata/golden/*.json`.
+
+**Why `internal/o2ims/typestest/` and not `pkg/o2ims/types/`?** Driving the REST encoder and
+the TMForum transform requires importing `internal/adapter`, `internal/o2ims/models`,
+`internal/models`, `internal/storage`, and `internal/handlers`. Those packages transitively
+import things (controllers, storage backends) that would pull `pkg/o2ims/types` into an
+import cycle the moment step 1 of the implementation plan lands a core type and one of those
+packages imports it. Keeping the harness in `internal/o2ims/typestest/` lets it depend on
+every layer without creating any back-edge into `pkg/o2ims/types`.
+
+**Regenerating the goldens.** The harness supports `go test -update` (wired via
+`flag.Bool("update", false, …)`) so that the author of a migration PR can regenerate the
+fixtures after a deliberate, reviewed change. Reviewers should inspect the golden diff the
+same way they inspect a schema diff: any unexpected field appearance, disappearance, or
+cardinality change is a blocker.

--- a/internal/o2ims/typestest/doc.go
+++ b/internal/o2ims/typestest/doc.go
@@ -1,0 +1,22 @@
+// Package typestest contains a golden-file regression harness that pins the
+// current observable JSON output of the four parallel domain-type shapes used
+// by netweave: the adapter contract, the O2-IMS REST wire format, the
+// Redis-persisted storage envelope, and the gqlgen-bound GraphQL object graph.
+//
+// The harness also pins the TMForum TMF639 transform output produced by
+// internal/handlers/tmforum_transform.go.
+//
+// The purpose of this package is to support the type-unification work tracked
+// by issue #484 (H11) and documented in docs/adr/0001-o2ims-domain-type-unification.md.
+// Any migration that intentionally changes observable output must regenerate
+// the golden files with:
+//
+//	go test ./internal/o2ims/typestest -update
+//
+// and the resulting diff must be reviewed as carefully as a schema change.
+//
+// This package lives under internal/ (not pkg/) so that it can import every
+// layer — adapter, storage, models, handlers — without creating an import
+// cycle with the forthcoming pkg/o2ims/types package. See the ADR for the
+// full rationale.
+package typestest

--- a/internal/o2ims/typestest/golden_test.go
+++ b/internal/o2ims/typestest/golden_test.go
@@ -1,0 +1,397 @@
+// Package typestest — see doc.go for the rationale.
+//
+// Golden-file harness for H11 (issue #484).
+package typestest
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	imsadapter "github.com/piwi3910/netweave/internal/adapter"
+	"github.com/piwi3910/netweave/internal/handlers"
+	gqlmodels "github.com/piwi3910/netweave/internal/models"
+	restmodels "github.com/piwi3910/netweave/internal/o2ims/models"
+	"github.com/piwi3910/netweave/internal/storage"
+)
+
+// updateGolden, when set via `go test -update`, causes the harness to rewrite
+// the fixture files on disk instead of asserting against them. This is the
+// migration-author escape hatch referenced in ADR 0001.
+var updateGolden = flag.Bool("update", false, "rewrite golden fixtures with current output")
+
+// fixedTime is the frozen timestamp used by every fixture so that goldens are
+// deterministic across runs.
+var fixedTime = time.Date(2026, time.April, 21, 12, 0, 0, 0, time.UTC)
+
+// goldenDir is the directory on disk that holds the fixtures.
+const goldenDir = "testdata/golden"
+
+// tmforumBaseURL is the stable base URL baked into the TMForum goldens.
+const tmforumBaseURL = "https://gateway.example.com"
+
+// goldenCase describes a single fixture.
+type goldenCase struct {
+	// name is the stem of the golden file (without .json) and the subtest name.
+	name string
+	// value is the Go value that will be JSON-encoded and compared.
+	value interface{}
+}
+
+func TestGolden(t *testing.T) {
+	cases := allCases()
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := marshalGolden(tc.value)
+			require.NoError(t, err, "marshal %s", tc.name)
+
+			path := filepath.Join(goldenDir, tc.name+".json")
+
+			if *updateGolden {
+				require.NoError(t, os.MkdirAll(goldenDir, 0o750))
+				require.NoError(t, os.WriteFile(path, got, 0o600))
+				return
+			}
+
+			want, err := os.ReadFile(filepath.Clean(path))
+			require.NoError(t, err, "read golden %s (run `go test -update` to create)", path)
+
+			if !bytes.Equal(want, got) {
+				t.Fatalf("golden mismatch for %s\n--- want\n%s\n--- got\n%s", path, want, got)
+			}
+		})
+	}
+}
+
+// marshalGolden is the single shared encoder used by every case. It matches
+// the JSON output of encoding/json (which is what gin's c.JSON and gqlgen's
+// response writer ultimately delegate to) and pretty-prints for diffability.
+func marshalGolden(v interface{}) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetIndent("", "  ")
+	// SetEscapeHTML(false) matches the default encoders used by both gin and
+	// gqlgen for O2-IMS / GraphQL responses; flipping this would cause URL
+	// characters like & to render as \u0026 in the golden and break review
+	// readability without changing wire semantics.
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, fmt.Errorf("encode golden value: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// allCases enumerates every fixture. Keep this list stable; deletions are a
+// regression (the missing coverage is the regression, not the deletion).
+func allCases() []goldenCase {
+	return concat(
+		restCases(),
+		adapterCases(),
+		storageCases(),
+		graphqlCases(),
+		tmforumCases(),
+	)
+}
+
+func concat(groups ...[]goldenCase) []goldenCase {
+	total := 0
+	for _, g := range groups {
+		total += len(g)
+	}
+	out := make([]goldenCase, 0, total)
+	for _, g := range groups {
+		out = append(out, g...)
+	}
+	return out
+}
+
+// ----------------------------------------------------------------------------
+// REST wire format — internal/o2ims/models. This is the thin wire envelope
+// rendered by handlers in internal/handlers/*.go via gin's c.JSON.
+// ----------------------------------------------------------------------------
+
+func restCases() []goldenCase {
+	pool := restmodels.ResourcePool{
+		ResourcePoolID: "pool-compute-highmem",
+		Name:           "High Memory Compute Pool",
+		Description:    "Nodes with 128GB+ RAM",
+		Location:       "us-east-1a",
+		OCloudID:       "ocloud-1",
+		GlobalAssetID:  "urn:o-ran:pool:compute-highmem",
+		Extensions: map[string]interface{}{
+			"machineType": "m5.4xlarge",
+			"replicas":    float64(12),
+		},
+	}
+
+	resource := restmodels.Resource{
+		ResourceID:     "node-worker-1a-abc123",
+		ResourceTypeID: "compute-node",
+		ResourcePoolID: "pool-compute-highmem",
+		Name:           "worker-1a-abc123",
+		Description:    "Compute node for RAN workloads",
+		GlobalAssetID:  "urn:o-ran:node:abc123",
+		ParentID:       "pool-compute-highmem",
+		Extensions: map[string]interface{}{
+			"status": "Ready",
+		},
+	}
+
+	sub := restmodels.Subscription{
+		SubscriptionID:         "550e8400-e29b-41d4-a716-446655440000",
+		Callback:               "https://smo.example.com/notifications",
+		ConsumerSubscriptionID: "smo-sub-123",
+		Filter: restmodels.SubscriptionFilter{
+			ResourcePoolID: []string{"pool-compute-highmem"},
+			ResourceTypeID: []string{"compute-node"},
+			ResourceID:     nil,
+		},
+		CreatedAt: fixedTime,
+	}
+
+	dm := restmodels.DeploymentManager{
+		DeploymentManagerID: "dm-prod-us-east",
+		Name:                "Production Kubernetes Cluster",
+		Description:         "Main production cluster in US East",
+		OCloudID:            "ocloud-1",
+		ServiceURI:          "https://api.o2ims.example.com/o2ims/v1",
+		SupportedLocations:  []string{"us-east-1a", "us-east-1b"},
+		Capabilities:        []string{"ProvisioningRequest", "Inventory"},
+		Extensions: map[string]interface{}{
+			"kubernetesVersion": "1.30.2",
+		},
+	}
+
+	return []goldenCase{
+		{name: "rest_resource_pool", value: pool},
+		{name: "rest_resource", value: resource},
+		{name: "rest_subscription", value: sub},
+		{name: "rest_deployment_manager", value: dm},
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Adapter contract — internal/adapter. This shape is what backend adapters
+// (Kubernetes, DTIaS, AWS, OSM, …) produce and what the TMForum transform
+// consumes. TenantID is tagged json:"-" and MUST NOT appear in wire output.
+// ----------------------------------------------------------------------------
+
+func adapterCases() []goldenCase {
+	pool := imsadapter.ResourcePool{
+		ResourcePoolID:   "pool-compute-highmem",
+		TenantID:         "tenant-acme",
+		Name:             "High Memory Compute Pool",
+		Description:      "Nodes with 128GB+ RAM",
+		Location:         "us-east-1a",
+		OCloudID:         "ocloud-1",
+		GlobalLocationID: "geo:37.7749,-122.4194",
+		Extensions: map[string]interface{}{
+			"machineType": "m5.4xlarge",
+		},
+	}
+
+	resource := imsadapter.Resource{
+		ResourceID:     "node-worker-1a-abc123",
+		TenantID:       "tenant-acme",
+		ResourceTypeID: "compute-node",
+		ResourcePoolID: "pool-compute-highmem",
+		GlobalAssetID:  "urn:o-ran:node:abc123",
+		Description:    "Compute node for RAN workloads",
+		Extensions: map[string]interface{}{
+			"status": "Ready",
+		},
+	}
+
+	sub := imsadapter.Subscription{
+		SubscriptionID:         "550e8400-e29b-41d4-a716-446655440000",
+		Callback:               "https://smo.example.com/notifications",
+		ConsumerSubscriptionID: "smo-sub-123",
+		Filter: &imsadapter.SubscriptionFilter{
+			ResourcePoolID: "pool-compute-highmem",
+			ResourceTypeID: "compute-node",
+		},
+	}
+
+	dm := imsadapter.DeploymentManager{
+		DeploymentManagerID: "dm-prod-us-east",
+		Name:                "Production Kubernetes Cluster",
+		Description:         "Main production cluster in US East",
+		OCloudID:            "ocloud-1",
+		ServiceURI:          "https://api.o2ims.example.com/o2ims/v1",
+		SupportedLocations:  []string{"us-east-1a", "us-east-1b"},
+		Capabilities:        []string{"ProvisioningRequest", "Inventory"},
+		Extensions: map[string]interface{}{
+			"kubernetesVersion": "1.30.2",
+		},
+	}
+
+	return []goldenCase{
+		{name: "adapter_resource_pool", value: pool},
+		{name: "adapter_resource", value: resource},
+		{name: "adapter_subscription", value: sub},
+		{name: "adapter_deployment_manager", value: dm},
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Storage envelope — internal/storage. This is the Redis-persisted shape with
+// TenantID, BackendID, CreatedAt, UpdatedAt. MarshalBinary/UnmarshalBinary
+// must round-trip to the same JSON bytes.
+// ----------------------------------------------------------------------------
+
+func storageCases() []goldenCase {
+	sub := storage.Subscription{
+		ID:                     "550e8400-e29b-41d4-a716-446655440000",
+		TenantID:               "tenant-acme",
+		BackendID:              "backend-k8s-prod",
+		Callback:               "https://smo.example.com/notifications",
+		ConsumerSubscriptionID: "smo-sub-123",
+		Filter: storage.SubscriptionFilter{
+			ResourcePoolID: "pool-compute-highmem",
+			ResourceTypeID: "compute-node",
+		},
+		CreatedAt: fixedTime,
+		UpdatedAt: fixedTime,
+	}
+
+	return []goldenCase{
+		{name: "storage_subscription", value: sub},
+	}
+}
+
+// ----------------------------------------------------------------------------
+// GraphQL binding — internal/models. These are the structs gqlgen binds to
+// in gqlgen.yml. The GraphQL wire format for scalar fields is ultimately
+// JSON, so encoding these structs pins the GraphQL-observable shape.
+// ----------------------------------------------------------------------------
+
+func graphqlCases() []goldenCase {
+	pool := gqlmodels.ResourcePool{
+		ResourcePoolID:   "pool-compute-highmem",
+		Name:             "High Memory Compute Pool",
+		Description:      "Nodes with 128GB+ RAM",
+		Location:         "us-east-1a",
+		OCloudID:         "ocloud-1",
+		GlobalLocationID: "geo:37.7749,-122.4194",
+		Extensions: map[string]interface{}{
+			"machineType": "m5.4xlarge",
+		},
+	}
+
+	resource := gqlmodels.Resource{
+		ResourceID:     "node-worker-1a-abc123",
+		ResourceTypeID: "compute-node",
+		ResourcePoolID: "pool-compute-highmem",
+		GlobalAssetID:  "urn:o-ran:node:abc123",
+		Description:    "Compute node for RAN workloads",
+		Extensions: map[string]interface{}{
+			"status": "Ready",
+		},
+	}
+
+	sub := gqlmodels.Subscription{
+		SubscriptionID:         "550e8400-e29b-41d4-a716-446655440000",
+		Callback:               "https://smo.example.com/notifications",
+		ConsumerSubscriptionID: "smo-sub-123",
+		Filter: &gqlmodels.SubscriptionFilter{
+			ResourcePoolID: []string{"pool-compute-highmem"},
+			ResourceTypeID: []string{"compute-node"},
+			Labels:         map[string]string{"env": "prod"},
+		},
+		EventTypes: []string{"ResourceCreated", "ResourceUpdated"},
+		CreatedAt:  fixedTime,
+		UpdatedAt:  fixedTime,
+	}
+
+	dm := gqlmodels.DeploymentManager{
+		DeploymentManagerID: "dm-prod-us-east",
+		Name:                "Production Kubernetes Cluster",
+		Description:         "Main production cluster in US East",
+		OCloudID:            "ocloud-1",
+		ServiceURI:          "https://api.o2ims.example.com/o2ims/v1",
+		SupportedLocations:  []string{"us-east-1a", "us-east-1b"},
+		Capabilities:        []string{"ProvisioningRequest", "Inventory"},
+		Capacity: &gqlmodels.Capacity{
+			TotalCPU:          256,
+			TotalMemoryMB:     1048576,
+			AvailableCPU:      128,
+			AvailableMemoryMB: 524288,
+		},
+		Extensions: map[string]interface{}{
+			"kubernetesVersion": "1.30.2",
+		},
+	}
+
+	return []goldenCase{
+		{name: "graphql_resource_pool", value: pool},
+		{name: "graphql_resource", value: resource},
+		{name: "graphql_subscription", value: sub},
+		{name: "graphql_deployment_manager", value: dm},
+	}
+}
+
+// ----------------------------------------------------------------------------
+// TMForum transform — internal/handlers/tmforum_transform.go. The transform
+// consumes adapter types and produces TMF639 output; we freeze both
+// directions.
+// ----------------------------------------------------------------------------
+
+func tmforumCases() []goldenCase {
+	adapterPool := adapterPoolFixture()
+	tmfFromPool := handlers.TransformResourcePoolToTMF639Resource(&adapterPool, tmforumBaseURL)
+
+	adapterResource := adapterResourceFixture()
+	tmfFromResource := handlers.TransformResourceToTMF639Resource(&adapterResource, tmforumBaseURL)
+
+	return []goldenCase{
+		{name: "tmforum_resource_pool_from_adapter", value: tmfFromPool},
+		{name: "tmforum_resource_from_adapter", value: tmfFromResource},
+	}
+}
+
+func adapterPoolFixture() imsadapter.ResourcePool {
+	return imsadapter.ResourcePool{
+		ResourcePoolID:   "pool-compute-highmem",
+		TenantID:         "tenant-acme",
+		Name:             "High Memory Compute Pool",
+		Description:      "Nodes with 128GB+ RAM",
+		Location:         "us-east-1a",
+		OCloudID:         "ocloud-1",
+		GlobalLocationID: "us-east-1a",
+		Extensions: map[string]interface{}{
+			"machineType":          "m5.4xlarge",
+			"tmf.category":         "compute",
+			"tmf.resourceStatus":   "available",
+			"tmf.operationalState": "enable",
+			"tmf.usageState":       "idle",
+		},
+	}
+}
+
+func adapterResourceFixture() imsadapter.Resource {
+	return imsadapter.Resource{
+		ResourceID:     "node-worker-1a-abc123",
+		TenantID:       "tenant-acme",
+		ResourceTypeID: "compute-node",
+		ResourcePoolID: "pool-compute-highmem",
+		GlobalAssetID:  "urn:o-ran:node:abc123",
+		Description:    "Compute node for RAN workloads",
+		Extensions: map[string]interface{}{
+			"name":                 "worker-1a-abc123",
+			"location":             "us-east-1a",
+			"status":               "Ready",
+			"tmf.resourceStatus":   "available",
+			"tmf.operationalState": "enable",
+			"tmf.usageState":       "active",
+		},
+	}
+}

--- a/internal/o2ims/typestest/testdata/golden/adapter_deployment_manager.json
+++ b/internal/o2ims/typestest/testdata/golden/adapter_deployment_manager.json
@@ -1,0 +1,18 @@
+{
+  "deploymentManagerId": "dm-prod-us-east",
+  "name": "Production Kubernetes Cluster",
+  "description": "Main production cluster in US East",
+  "oCloudId": "ocloud-1",
+  "serviceUri": "https://api.o2ims.example.com/o2ims/v1",
+  "supportedLocations": [
+    "us-east-1a",
+    "us-east-1b"
+  ],
+  "capabilities": [
+    "ProvisioningRequest",
+    "Inventory"
+  ],
+  "extensions": {
+    "kubernetesVersion": "1.30.2"
+  }
+}

--- a/internal/o2ims/typestest/testdata/golden/adapter_resource.json
+++ b/internal/o2ims/typestest/testdata/golden/adapter_resource.json
@@ -1,0 +1,10 @@
+{
+  "resourceId": "node-worker-1a-abc123",
+  "resourceTypeId": "compute-node",
+  "resourcePoolId": "pool-compute-highmem",
+  "globalAssetId": "urn:o-ran:node:abc123",
+  "description": "Compute node for RAN workloads",
+  "extensions": {
+    "status": "Ready"
+  }
+}

--- a/internal/o2ims/typestest/testdata/golden/adapter_resource_pool.json
+++ b/internal/o2ims/typestest/testdata/golden/adapter_resource_pool.json
@@ -1,0 +1,11 @@
+{
+  "resourcePoolId": "pool-compute-highmem",
+  "name": "High Memory Compute Pool",
+  "description": "Nodes with 128GB+ RAM",
+  "location": "us-east-1a",
+  "oCloudId": "ocloud-1",
+  "globalLocationId": "geo:37.7749,-122.4194",
+  "extensions": {
+    "machineType": "m5.4xlarge"
+  }
+}

--- a/internal/o2ims/typestest/testdata/golden/adapter_subscription.json
+++ b/internal/o2ims/typestest/testdata/golden/adapter_subscription.json
@@ -1,0 +1,9 @@
+{
+  "subscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+  "callback": "https://smo.example.com/notifications",
+  "consumerSubscriptionId": "smo-sub-123",
+  "filter": {
+    "resourcePoolId": "pool-compute-highmem",
+    "resourceTypeId": "compute-node"
+  }
+}

--- a/internal/o2ims/typestest/testdata/golden/graphql_deployment_manager.json
+++ b/internal/o2ims/typestest/testdata/golden/graphql_deployment_manager.json
@@ -1,0 +1,24 @@
+{
+  "deploymentManagerId": "dm-prod-us-east",
+  "name": "Production Kubernetes Cluster",
+  "description": "Main production cluster in US East",
+  "oCloudId": "ocloud-1",
+  "serviceUri": "https://api.o2ims.example.com/o2ims/v1",
+  "supportedLocations": [
+    "us-east-1a",
+    "us-east-1b"
+  ],
+  "capabilities": [
+    "ProvisioningRequest",
+    "Inventory"
+  ],
+  "capacity": {
+    "totalCpu": 256,
+    "totalMemoryMb": 1048576,
+    "availableCpu": 128,
+    "availableMemoryMb": 524288
+  },
+  "extensions": {
+    "kubernetesVersion": "1.30.2"
+  }
+}

--- a/internal/o2ims/typestest/testdata/golden/graphql_resource.json
+++ b/internal/o2ims/typestest/testdata/golden/graphql_resource.json
@@ -1,0 +1,10 @@
+{
+  "resourceId": "node-worker-1a-abc123",
+  "resourceTypeId": "compute-node",
+  "resourcePoolId": "pool-compute-highmem",
+  "globalAssetId": "urn:o-ran:node:abc123",
+  "description": "Compute node for RAN workloads",
+  "extensions": {
+    "status": "Ready"
+  }
+}

--- a/internal/o2ims/typestest/testdata/golden/graphql_resource_pool.json
+++ b/internal/o2ims/typestest/testdata/golden/graphql_resource_pool.json
@@ -1,0 +1,11 @@
+{
+  "resourcePoolId": "pool-compute-highmem",
+  "name": "High Memory Compute Pool",
+  "description": "Nodes with 128GB+ RAM",
+  "location": "us-east-1a",
+  "oCloudId": "ocloud-1",
+  "globalLocationId": "geo:37.7749,-122.4194",
+  "extensions": {
+    "machineType": "m5.4xlarge"
+  }
+}

--- a/internal/o2ims/typestest/testdata/golden/graphql_subscription.json
+++ b/internal/o2ims/typestest/testdata/golden/graphql_subscription.json
@@ -1,0 +1,22 @@
+{
+  "subscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+  "callback": "https://smo.example.com/notifications",
+  "consumerSubscriptionId": "smo-sub-123",
+  "filter": {
+    "resourcePoolId": [
+      "pool-compute-highmem"
+    ],
+    "resourceTypeId": [
+      "compute-node"
+    ],
+    "labels": {
+      "env": "prod"
+    }
+  },
+  "eventTypes": [
+    "ResourceCreated",
+    "ResourceUpdated"
+  ],
+  "createdAt": "2026-04-21T12:00:00Z",
+  "updatedAt": "2026-04-21T12:00:00Z"
+}

--- a/internal/o2ims/typestest/testdata/golden/rest_deployment_manager.json
+++ b/internal/o2ims/typestest/testdata/golden/rest_deployment_manager.json
@@ -1,0 +1,18 @@
+{
+  "deploymentManagerId": "dm-prod-us-east",
+  "name": "Production Kubernetes Cluster",
+  "description": "Main production cluster in US East",
+  "oCloudId": "ocloud-1",
+  "serviceUri": "https://api.o2ims.example.com/o2ims/v1",
+  "supportedLocations": [
+    "us-east-1a",
+    "us-east-1b"
+  ],
+  "capabilities": [
+    "ProvisioningRequest",
+    "Inventory"
+  ],
+  "extensions": {
+    "kubernetesVersion": "1.30.2"
+  }
+}

--- a/internal/o2ims/typestest/testdata/golden/rest_resource.json
+++ b/internal/o2ims/typestest/testdata/golden/rest_resource.json
@@ -1,0 +1,12 @@
+{
+  "resourceId": "node-worker-1a-abc123",
+  "resourceTypeId": "compute-node",
+  "resourcePoolId": "pool-compute-highmem",
+  "name": "worker-1a-abc123",
+  "description": "Compute node for RAN workloads",
+  "globalAssetId": "urn:o-ran:node:abc123",
+  "parentId": "pool-compute-highmem",
+  "extensions": {
+    "status": "Ready"
+  }
+}

--- a/internal/o2ims/typestest/testdata/golden/rest_resource_pool.json
+++ b/internal/o2ims/typestest/testdata/golden/rest_resource_pool.json
@@ -1,0 +1,12 @@
+{
+  "resourcePoolId": "pool-compute-highmem",
+  "name": "High Memory Compute Pool",
+  "description": "Nodes with 128GB+ RAM",
+  "location": "us-east-1a",
+  "oCloudId": "ocloud-1",
+  "globalAssetId": "urn:o-ran:pool:compute-highmem",
+  "extensions": {
+    "machineType": "m5.4xlarge",
+    "replicas": 12
+  }
+}

--- a/internal/o2ims/typestest/testdata/golden/rest_subscription.json
+++ b/internal/o2ims/typestest/testdata/golden/rest_subscription.json
@@ -1,0 +1,14 @@
+{
+  "subscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+  "callback": "https://smo.example.com/notifications",
+  "consumerSubscriptionId": "smo-sub-123",
+  "filter": {
+    "resourcePoolId": [
+      "pool-compute-highmem"
+    ],
+    "resourceTypeId": [
+      "compute-node"
+    ]
+  },
+  "createdAt": "2026-04-21T12:00:00Z"
+}

--- a/internal/o2ims/typestest/testdata/golden/storage_subscription.json
+++ b/internal/o2ims/typestest/testdata/golden/storage_subscription.json
@@ -1,0 +1,13 @@
+{
+  "subscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+  "tenantId": "tenant-acme",
+  "backendId": "backend-k8s-prod",
+  "callback": "https://smo.example.com/notifications",
+  "consumerSubscriptionId": "smo-sub-123",
+  "filter": {
+    "resourcePoolId": "pool-compute-highmem",
+    "resourceTypeId": "compute-node"
+  },
+  "createdAt": "2026-04-21T12:00:00Z",
+  "updatedAt": "2026-04-21T12:00:00Z"
+}

--- a/internal/o2ims/typestest/testdata/golden/tmforum_resource_from_adapter.json
+++ b/internal/o2ims/typestest/testdata/golden/tmforum_resource_from_adapter.json
@@ -1,0 +1,32 @@
+{
+  "id": "node-worker-1a-abc123",
+  "href": "https://gateway.example.com/tmf-api/resourceInventoryManagement/v4/resource/node-worker-1a-abc123",
+  "name": "worker-1a-abc123",
+  "description": "Compute node for RAN workloads",
+  "category": "compute-node",
+  "resourceCharacteristic": [
+    {
+      "name": "name",
+      "value": "worker-1a-abc123"
+    },
+    {
+      "name": "location",
+      "value": "us-east-1a"
+    },
+    {
+      "name": "status",
+      "value": "Ready"
+    }
+  ],
+  "resourceStatus": "available",
+  "operationalState": "enable",
+  "usageState": "active",
+  "place": [
+    {
+      "id": "us-east-1a",
+      "name": "us-east-1a",
+      "role": "location"
+    }
+  ],
+  "@type": "Resource"
+}

--- a/internal/o2ims/typestest/testdata/golden/tmforum_resource_pool_from_adapter.json
+++ b/internal/o2ims/typestest/testdata/golden/tmforum_resource_pool_from_adapter.json
@@ -1,0 +1,24 @@
+{
+  "id": "pool-compute-highmem",
+  "href": "https://gateway.example.com/tmf-api/resourceInventoryManagement/v4/resource/pool-compute-highmem",
+  "name": "High Memory Compute Pool",
+  "description": "Nodes with 128GB+ RAM",
+  "category": "compute",
+  "resourceCharacteristic": [
+    {
+      "name": "machineType",
+      "value": "m5.4xlarge"
+    }
+  ],
+  "resourceStatus": "available",
+  "operationalState": "enable",
+  "usageState": "idle",
+  "place": [
+    {
+      "id": "us-east-1a",
+      "name": "us-east-1a",
+      "role": "location"
+    }
+  ],
+  "@type": "ResourcePool"
+}


### PR DESCRIPTION
## Summary

Lands the two prerequisites for H11 (unify `ResourcePool` / `Resource` / `Subscription` across the four packages that currently redefine them) **without** performing the unification itself. A follow-up PR will execute the migration plan in the ADR.

- **ADR 0001** (`docs/adr/0001-o2ims-domain-type-unification.md`) — documents the four current shapes (adapter / REST / storage / gqlgen), weighs three options (single canonical type; shared-core struct with converters; codegen from OpenAPI/proto), **recommends option (b)** — shared-core struct + layer-specific wrappers + converters — and gives an 8-step implementation plan.
- **Golden-file harness** (`internal/o2ims/typestest/`) — 15 frozen fixtures covering every affected type across REST, adapter, storage, GraphQL, and TMForum transform paths. Supports `go test -update` so the migration author can regenerate after deliberate, reviewed changes.

The harness lives under `internal/` rather than the issue-suggested `pkg/o2ims/types/` to avoid an import cycle once step 1 of the plan introduces `pkg/o2ims/types`. This is called out in the ADR.

Refs #484. Does not close it — that will happen when the unification PR lands.

## Test plan

- [x] `go test ./internal/o2ims/typestest/...` passes
- [x] `go test -short -race ./internal/o2ims/typestest/...` passes
- [x] `golangci-lint run ./internal/o2ims/typestest/...` clean (0 issues)
- [x] `golangci-lint run ./...` — no new issues attributable to this PR (87 pre-existing on `main`, none in our new files)
- [x] `go build ./...` clean
- [x] 15 golden files generated and asserted byte-for-byte

## Golden files created

- REST: `rest_resource_pool`, `rest_resource`, `rest_subscription`, `rest_deployment_manager`
- Adapter: `adapter_resource_pool`, `adapter_resource`, `adapter_subscription`, `adapter_deployment_manager`
- Storage: `storage_subscription`
- GraphQL: `graphql_resource_pool`, `graphql_resource`, `graphql_subscription`, `graphql_deployment_manager`
- TMForum: `tmforum_resource_pool_from_adapter`, `tmforum_resource_from_adapter`